### PR TITLE
step 1: reddit client + research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/tider
+/cmd/tider/tider
+*.out
+.DS_Store

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "tider",
+	Short: "Reddit drafting co-pilot (read-only)",
+	Long: `tider drafts Reddit posts and reply suggestions, grounded in each
+subreddit's rules and what's worked there. The bot reads Reddit; you
+post manually. No auth, no posting, no commenting — by design.`,
+}
+
+func main() {
+	rootCmd.AddCommand(researchCmd)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/tider/research.go
+++ b/cmd/tider/research.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/reddit"
+	"github.com/viggy28/tider/research"
+)
+
+var (
+	researchRefresh   bool
+	researchNotesPath string
+	researchCacheRoot string
+)
+
+var researchCmd = &cobra.Command{
+	Use:   "research <sub>",
+	Short: "Fetch and assemble a research bundle for a subreddit",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sub := args[0]
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		cacheRoot := researchCacheRoot
+		if cacheRoot == "" {
+			cacheRoot = filepath.Join(home, ".tider", "cache")
+		}
+		notesPath := researchNotesPath
+		if notesPath == "" {
+			notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
+		}
+
+		notes, err := research.LoadNotes(notesPath)
+		if err != nil {
+			return err
+		}
+
+		client := reddit.NewClient(reddit.NewCache(cacheRoot))
+		bundle, err := research.For(context.Background(), client, notes, sub, researchRefresh)
+		if err != nil {
+			return err
+		}
+		out, err := json.MarshalIndent(bundle, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+func init() {
+	researchCmd.Flags().BoolVar(&researchRefresh, "refresh", false, "force fresh fetch, bypass cache")
+	researchCmd.Flags().StringVar(&researchNotesPath, "notes", "", "path to subreddits.yaml (default ~/.tider/subreddits.yaml)")
+	researchCmd.Flags().StringVar(&researchCacheRoot, "cache", "", "cache root dir (default ~/.tider/cache)")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/viggy28/tider
+
+go 1.26.1
+
+require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/reddit/cache.go
+++ b/internal/reddit/cache.go
@@ -1,0 +1,109 @@
+package reddit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Cache stores per-sub Reddit responses on disk under Root/subs/{name}/,
+// with TTLs tracked in a sibling _meta.json.
+type Cache struct {
+	Root string
+	mu   sync.Mutex
+}
+
+type cacheMeta struct {
+	FetchedAt map[string]time.Time `json:"fetched_at"`
+	TTLNanos  map[string]int64     `json:"ttl_nanos"`
+}
+
+func NewCache(root string) *Cache { return &Cache{Root: root} }
+
+func (c *Cache) subDir(sub string) string  { return filepath.Join(c.Root, "subs", sub) }
+func (c *Cache) metaPath(sub string) string { return filepath.Join(c.subDir(sub), "_meta.json") }
+
+func (c *Cache) loadMeta(sub string) (*cacheMeta, error) {
+	data, err := os.ReadFile(c.metaPath(sub))
+	if errors.Is(err, os.ErrNotExist) {
+		return &cacheMeta{
+			FetchedAt: map[string]time.Time{},
+			TTLNanos:  map[string]int64{},
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read cache meta: %w", err)
+	}
+	var m cacheMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse cache meta: %w", err)
+	}
+	if m.FetchedAt == nil {
+		m.FetchedAt = map[string]time.Time{}
+	}
+	if m.TTLNanos == nil {
+		m.TTLNanos = map[string]int64{}
+	}
+	return &m, nil
+}
+
+func (c *Cache) saveMeta(sub string, m *cacheMeta) error {
+	if err := os.MkdirAll(c.subDir(sub), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cache meta: %w", err)
+	}
+	return os.WriteFile(c.metaPath(sub), data, 0o644)
+}
+
+// Get returns cached bytes for (sub, file). fresh==false means caller should
+// fetch — either the entry is missing or its TTL has expired.
+func (c *Cache) Get(sub, file string) (data []byte, fresh bool, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m, err := c.loadMeta(sub)
+	if err != nil {
+		return nil, false, err
+	}
+	fetchedAt, ok := m.FetchedAt[file]
+	if !ok {
+		return nil, false, nil
+	}
+	ttl := time.Duration(m.TTLNanos[file])
+	if ttl > 0 && time.Since(fetchedAt) > ttl {
+		return nil, false, nil
+	}
+	body, err := os.ReadFile(filepath.Join(c.subDir(sub), file))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read cached file: %w", err)
+	}
+	return body, true, nil
+}
+
+// Put stores bytes for (sub, file) with the given TTL.
+func (c *Cache) Put(sub, file string, data []byte, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := os.MkdirAll(c.subDir(sub), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(c.subDir(sub), file), data, 0o644); err != nil {
+		return fmt.Errorf("write cache file: %w", err)
+	}
+	m, err := c.loadMeta(sub)
+	if err != nil {
+		return err
+	}
+	m.FetchedAt[file] = time.Now().UTC()
+	m.TTLNanos[file] = int64(ttl)
+	return c.saveMeta(sub, m)
+}

--- a/internal/reddit/cache_test.go
+++ b/internal/reddit/cache_test.go
@@ -1,0 +1,64 @@
+package reddit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCachePutGetFresh(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "about.json", []byte(`{"x":1}`), time.Hour); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	data, fresh, err := c.Get("golang", "about.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !fresh {
+		t.Fatal("expected fresh entry")
+	}
+	if string(data) != `{"x":1}` {
+		t.Fatalf("data = %q", data)
+	}
+}
+
+func TestCacheExpired(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "hot.json", []byte(`x`), time.Millisecond); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	_, fresh, err := c.Get("golang", "hot.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh {
+		t.Fatal("expected stale entry")
+	}
+}
+
+func TestCacheMissing(t *testing.T) {
+	c := NewCache(t.TempDir())
+	_, fresh, err := c.Get("nonexistent", "file.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh {
+		t.Fatal("expected miss")
+	}
+}
+
+func TestCacheMultipleFiles(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "about.json", []byte(`a`), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put("golang", "rules.json", []byte(`r`), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	a, _, _ := c.Get("golang", "about.json")
+	r, _, _ := c.Get("golang", "rules.json")
+	if string(a) != "a" || string(r) != "r" {
+		t.Fatalf("crosstalk: a=%q r=%q", a, r)
+	}
+}

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -1,0 +1,203 @@
+// Package reddit is the only package that talks to Reddit. It exposes a
+// cached HTTP client with a polite User-Agent and exponential backoff.
+package reddit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+const (
+	DefaultUserAgent = "tider/0.1 (by /u/tider28)"
+	DefaultBaseURL   = "https://www.reddit.com"
+)
+
+// Tiered TTLs as specified in the project plan.
+const (
+	TTLAbout  = 7 * 24 * time.Hour
+	TTLRules  = 7 * 24 * time.Hour
+	TTLWiki   = 7 * 24 * time.Hour
+	TTLFlairs = 7 * 24 * time.Hour
+	TTLTop    = 24 * time.Hour
+	TTLHot    = 6 * time.Hour
+)
+
+type Client struct {
+	HTTP      *http.Client
+	BaseURL   string
+	UserAgent string
+	Cache     *Cache
+	MaxRetry  int
+	BaseDelay time.Duration
+}
+
+func NewClient(cache *Cache) *Client {
+	return &Client{
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+		BaseURL:   DefaultBaseURL,
+		UserAgent: DefaultUserAgent,
+		Cache:     cache,
+		MaxRetry:  3,
+		BaseDelay: 500 * time.Millisecond,
+	}
+}
+
+// get performs a GET with exponential backoff on 429/5xx/network errors.
+// The status code is returned alongside the body so callers can soft-fail
+// on 403/404 without losing the signal.
+func (c *Client) get(ctx context.Context, path string) ([]byte, int, error) {
+	var lastStatus int
+	var lastErr error
+	for attempt := 0; attempt <= c.MaxRetry; attempt++ {
+		if attempt > 0 {
+			delay := c.BaseDelay << (attempt - 1)
+			select {
+			case <-ctx.Done():
+				return nil, lastStatus, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
+		if err != nil {
+			return nil, 0, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("User-Agent", c.UserAgent)
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			lastStatus = 0
+			lastErr = err
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		lastStatus = resp.StatusCode
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			return body, resp.StatusCode, nil
+		case resp.StatusCode == http.StatusTooManyRequests, resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+			continue
+		default:
+			return body, resp.StatusCode, fmt.Errorf("reddit %s: status %d", path, resp.StatusCode)
+		}
+	}
+	return nil, lastStatus, fmt.Errorf("reddit %s: exhausted retries: %w", path, lastErr)
+}
+
+// fetch returns cached bytes if fresh; otherwise fetches and caches.
+func (c *Client) fetch(ctx context.Context, sub, file, path string, ttl time.Duration, refresh bool) ([]byte, error) {
+	if !refresh {
+		if data, fresh, err := c.Cache.Get(sub, file); err == nil && fresh {
+			return data, nil
+		}
+	}
+	body, _, err := c.get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Cache.Put(sub, file, body, ttl); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// fetchSoft is fetch with 403/404 → (nil, nil) for endpoints that many subs
+// gate or omit (wiki rules, link flairs).
+func (c *Client) fetchSoft(ctx context.Context, sub, file, path string, ttl time.Duration, refresh bool) ([]byte, error) {
+	if !refresh {
+		if data, fresh, err := c.Cache.Get(sub, file); err == nil && fresh {
+			return data, nil
+		}
+	}
+	body, status, err := c.get(ctx, path)
+	if err != nil {
+		if status == http.StatusForbidden || status == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if err := c.Cache.Put(sub, file, body, ttl); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *Client) About(ctx context.Context, sub string, refresh bool) (types.Subreddit, error) {
+	body, err := c.fetch(ctx, sub, "about.json", "/r/"+sub+"/about.json", TTLAbout, refresh)
+	if err != nil {
+		return types.Subreddit{}, err
+	}
+	return parseAbout(body)
+}
+
+func (c *Client) Rules(ctx context.Context, sub string, refresh bool) ([]types.Rule, error) {
+	body, err := c.fetch(ctx, sub, "rules.json", "/r/"+sub+"/about/rules.json", TTLRules, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseRules(body)
+}
+
+func (c *Client) WikiRules(ctx context.Context, sub string, refresh bool) (string, error) {
+	body, err := c.fetchSoft(ctx, sub, "wiki_rules.json", "/r/"+sub+"/wiki/rules.json", TTLWiki, refresh)
+	if err != nil {
+		return "", err
+	}
+	if body == nil {
+		return "", nil
+	}
+	return parseWiki(body)
+}
+
+func (c *Client) Top(ctx context.Context, sub, period string, refresh bool) ([]types.Post, error) {
+	var file string
+	switch period {
+	case "week":
+		file = "top_week.json"
+	case "month":
+		file = "top_month.json"
+	default:
+		return nil, fmt.Errorf("unknown top period: %s", period)
+	}
+	path := "/r/" + sub + "/top.json?t=" + period + "&limit=25"
+	body, err := c.fetch(ctx, sub, file, path, TTLTop, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseListing(body)
+}
+
+func (c *Client) Hot(ctx context.Context, sub string, refresh bool) ([]types.Post, error) {
+	body, err := c.fetch(ctx, sub, "hot.json", "/r/"+sub+"/hot.json?limit=25", TTLHot, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseListing(body)
+}
+
+func (c *Client) Flairs(ctx context.Context, sub string, refresh bool) ([]types.Flair, error) {
+	body, err := c.fetchSoft(ctx, sub, "flairs.json", "/r/"+sub+"/api/link_flair_v2.json", TTLFlairs, refresh)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, nil
+	}
+	return parseFlairs(body)
+}
+
+// Stickies derives stickied posts from the hot listing.
+func Stickies(hot []types.Post) []types.Post {
+	var out []types.Post
+	for _, p := range hot {
+		if p.Stickied {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/reddit/client_test.go
+++ b/internal/reddit/client_test.go
@@ -1,0 +1,229 @@
+package reddit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const aboutJSON = `{"kind":"t5","data":{"display_name":"golang","subscribers":250000,"public_description":"Go community","over18":false,"url":"/r/golang/"}}`
+
+const rulesJSON = `{"rules":[{"short_name":"No spam","description":"do not spam","kind":"link","priority":0}]}`
+
+const wikiJSON = `{"data":{"content_md":"# Detailed rules\n\n* No spam"}}`
+
+const listingJSON = `{"kind":"Listing","data":{"children":[
+  {"kind":"t3","data":{"id":"abc","title":"Hello","author":"alice","score":100,"num_comments":5,"is_self":true,"selftext":"hi","stickied":false,"link_flair_text":"discussion","created_utc":1700000000.0,"permalink":"/r/golang/comments/abc/hello/","url":"https://reddit.com/r/golang/comments/abc/hello/"}},
+  {"kind":"t3","data":{"id":"def","title":"Sticky announcement","stickied":true,"created_utc":1700000100.0}}
+]}}`
+
+const flairsJSON = `[{"id":"f1","text":"discussion","text_editable":false},{"id":"f2","text":"show & tell","text_editable":false}]`
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient(NewCache(t.TempDir()))
+	c.BaseURL = srv.URL
+	c.MaxRetry = 2
+	c.BaseDelay = time.Millisecond
+	return c
+}
+
+func TestClientAboutCachesAndRefreshes(t *testing.T) {
+	var hits int32
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != DefaultUserAgent {
+			t.Errorf("user-agent = %q, want %q", got, DefaultUserAgent)
+		}
+		if r.URL.Path != "/r/golang/about.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(aboutJSON))
+	})
+	c := newTestClient(t, h)
+
+	sub, err := c.About(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("about: %v", err)
+	}
+	if sub.Name != "golang" || sub.Subscribers != 250000 {
+		t.Fatalf("parsed: %+v", sub)
+	}
+	// second call: cache hit, no new HTTP
+	if _, err := c.About(context.Background(), "golang", false); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("hits after cache hit = %d, want 1", got)
+	}
+	// refresh: forces fresh fetch
+	if _, err := c.About(context.Background(), "golang", true); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("hits after refresh = %d, want 2", got)
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var calls int32
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(aboutJSON))
+	})
+	c := newTestClient(t, h)
+	if _, err := c.About(context.Background(), "golang", false); err != nil {
+		t.Fatalf("about: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("calls = %d, want 3", got)
+	}
+}
+
+func TestClientRules(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/about/rules.json") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(rulesJSON))
+	})
+	c := newTestClient(t, h)
+	rules, err := c.Rules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 1 || rules[0].ShortName != "No spam" {
+		t.Fatalf("rules = %+v", rules)
+	}
+}
+
+func TestClientWikiSoftFails404(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	c := newTestClient(t, h)
+	s, err := c.WikiRules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if s != "" {
+		t.Fatalf("expected empty, got %q", s)
+	}
+}
+
+func TestClientWikiSuccess(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(wikiJSON))
+	})
+	c := newTestClient(t, h)
+	s, err := c.WikiRules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "Detailed rules") {
+		t.Fatalf("wiki content = %q", s)
+	}
+}
+
+func TestClientFlairsSoftFails403(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if flairs != nil {
+		t.Fatalf("expected nil, got %+v", flairs)
+	}
+}
+
+func TestClientFlairsAuthEnvelope(t *testing.T) {
+	// Reddit returns 200 with a json-errors envelope when auth is required.
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"json":{"errors":[["USER_REQUIRED","Please log in to do that.",null]]}}`))
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if flairs != nil {
+		t.Fatalf("expected nil, got %+v", flairs)
+	}
+}
+
+func TestClientFlairsSuccess(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(flairsJSON))
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flairs) != 2 || flairs[0].Text != "discussion" {
+		t.Fatalf("flairs = %+v", flairs)
+	}
+}
+
+func TestClientHotAndStickies(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(listingJSON))
+	})
+	c := newTestClient(t, h)
+	hot, err := c.Hot(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hot) != 2 {
+		t.Fatalf("hot len = %d", len(hot))
+	}
+	stickies := Stickies(hot)
+	if len(stickies) != 1 || stickies[0].ID != "def" {
+		t.Fatalf("stickies = %+v", stickies)
+	}
+}
+
+func TestClientTopPeriodInQuery(t *testing.T) {
+	var captured string
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		_, _ = w.Write([]byte(listingJSON))
+	})
+	c := newTestClient(t, h)
+	if _, err := c.Top(context.Background(), "golang", "week", false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(captured, "t=week") {
+		t.Fatalf("query = %q, missing t=week", captured)
+	}
+}
+
+func TestClientTopUnknownPeriod(t *testing.T) {
+	c := newTestClient(t, http.NewServeMux())
+	if _, err := c.Top(context.Background(), "golang", "yearly", false); err == nil {
+		t.Fatal("expected error for unknown period")
+	}
+}
+
+func TestClientPropagatesHardError(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	c := newTestClient(t, h)
+	if _, err := c.About(context.Background(), "doesnotexist", false); err == nil {
+		t.Fatal("expected error on 404 for non-soft endpoint")
+	}
+}

--- a/internal/reddit/parse.go
+++ b/internal/reddit/parse.go
@@ -1,0 +1,101 @@
+package reddit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+type aboutResponse struct {
+	Data struct {
+		DisplayName       string `json:"display_name"`
+		Subscribers       int    `json:"subscribers"`
+		Description       string `json:"description"`
+		PublicDescription string `json:"public_description"`
+		Over18            bool   `json:"over18"`
+		URL               string `json:"url"`
+	} `json:"data"`
+}
+
+func parseAbout(data []byte) (types.Subreddit, error) {
+	var r aboutResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return types.Subreddit{}, fmt.Errorf("parse about: %w", err)
+	}
+	return types.Subreddit{
+		Name:              r.Data.DisplayName,
+		Subscribers:       r.Data.Subscribers,
+		Description:       r.Data.Description,
+		PublicDescription: r.Data.PublicDescription,
+		Over18:            r.Data.Over18,
+		URL:               r.Data.URL,
+	}, nil
+}
+
+type rulesResponse struct {
+	Rules []types.Rule `json:"rules"`
+}
+
+func parseRules(data []byte) ([]types.Rule, error) {
+	var r rulesResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse rules: %w", err)
+	}
+	if r.Rules == nil {
+		return []types.Rule{}, nil
+	}
+	return r.Rules, nil
+}
+
+type wikiResponse struct {
+	Data struct {
+		ContentMD string `json:"content_md"`
+	} `json:"data"`
+}
+
+func parseWiki(data []byte) (string, error) {
+	var r wikiResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return "", fmt.Errorf("parse wiki: %w", err)
+	}
+	return r.Data.ContentMD, nil
+}
+
+type listingResponse struct {
+	Data struct {
+		Children []struct {
+			Data types.Post `json:"data"`
+		} `json:"children"`
+	} `json:"data"`
+}
+
+func parseListing(data []byte) ([]types.Post, error) {
+	var r listingResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse listing: %w", err)
+	}
+	out := make([]types.Post, 0, len(r.Data.Children))
+	for _, c := range r.Data.Children {
+		out = append(out, c.Data)
+	}
+	return out, nil
+}
+
+// parseFlairs accepts the array Reddit returns on success and treats the
+// `{"json":{"errors":[["USER_REQUIRED",...]]}}` envelope (200 with error
+// payload, returned when the endpoint requires auth) as soft-fail → nil.
+func parseFlairs(data []byte) ([]types.Flair, error) {
+	var probe any
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("parse flairs: %w", err)
+	}
+	if _, ok := probe.([]any); !ok {
+		return nil, nil
+	}
+	var r []types.Flair
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse flairs: %w", err)
+	}
+	return r, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,78 @@
+// Package types holds the shared domain types used across tider packages.
+package types
+
+import "time"
+
+type Subreddit struct {
+	Name              string `json:"name"`
+	Subscribers       int    `json:"subscribers"`
+	Description       string `json:"description,omitempty"`
+	PublicDescription string `json:"public_description,omitempty"`
+	Over18            bool   `json:"over_18"`
+	URL               string `json:"url,omitempty"`
+}
+
+type Rule struct {
+	ShortName   string `json:"short_name"`
+	Description string `json:"description"`
+	Kind        string `json:"kind,omitempty"`
+	Priority    int    `json:"priority"`
+}
+
+type Post struct {
+	ID            string  `json:"id"`
+	Title         string  `json:"title"`
+	Author        string  `json:"author,omitempty"`
+	Score         int     `json:"score"`
+	NumComments   int     `json:"num_comments"`
+	URL           string  `json:"url,omitempty"`
+	Permalink     string  `json:"permalink,omitempty"`
+	Selftext      string  `json:"selftext,omitempty"`
+	IsSelf        bool    `json:"is_self"`
+	Stickied      bool    `json:"stickied"`
+	LinkFlairText string  `json:"link_flair_text,omitempty"`
+	CreatedUTC    float64 `json:"created_utc"`
+}
+
+type Flair struct {
+	ID           string `json:"id"`
+	Text         string `json:"text"`
+	TextEditable bool   `json:"text_editable"`
+}
+
+// SubNotes is the curated knowledge layer for a single subreddit, loaded
+// from subreddits.yaml. All fields are optional; free-form Notes is the
+// catch-all for observations that don't fit a structured field.
+type SubNotes struct {
+	Name               string     `yaml:"name" json:"name"`
+	Tone               string     `yaml:"tone,omitempty" json:"tone,omitempty"`
+	SelfPromoTolerance string     `yaml:"self_promo_tolerance,omitempty" json:"self_promo_tolerance,omitempty"`
+	FormatPreferences  []string   `yaml:"format_preferences,omitempty" json:"format_preferences,omitempty"`
+	Flair              FlairNotes `yaml:"flair" json:"flair"`
+	DoNot              []string   `yaml:"do_not,omitempty" json:"do_not,omitempty"`
+	Notes              string     `yaml:"notes,omitempty" json:"notes,omitempty"`
+	ExemplarURLs       []string   `yaml:"exemplar_urls,omitempty" json:"exemplar_urls,omitempty"`
+}
+
+type FlairNotes struct {
+	Required bool     `yaml:"required" json:"required"`
+	Common   []string `yaml:"common,omitempty" json:"common,omitempty"`
+}
+
+type SubsConfig struct {
+	Subs []SubNotes `yaml:"subs"`
+}
+
+// Research is the assembled per-sub bundle: live Reddit data + curated notes.
+type Research struct {
+	Sub       Subreddit `json:"sub"`
+	Notes     *SubNotes `json:"notes,omitempty"`
+	Rules     []Rule    `json:"rules"`
+	WikiRules string    `json:"wiki_rules,omitempty"`
+	TopWeek   []Post    `json:"top_week"`
+	TopMonth  []Post    `json:"top_month"`
+	Hot       []Post    `json:"hot"`
+	Stickies  []Post    `json:"stickies"`
+	Flairs    []Flair   `json:"flairs"`
+	Generated time.Time `json:"generated"`
+}

--- a/research/notes.go
+++ b/research/notes.go
@@ -1,0 +1,42 @@
+package research
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// LoadNotes reads subreddits.yaml from path. A missing file returns (nil, nil)
+// — the curated layer is optional.
+func LoadNotes(path string) (*types.SubsConfig, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read subreddits.yaml: %w", err)
+	}
+	var cfg types.SubsConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse subreddits.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// FindSub returns the curated notes for sub (case-insensitive), or nil.
+func FindSub(cfg *types.SubsConfig, sub string) *types.SubNotes {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.Subs {
+		if strings.EqualFold(cfg.Subs[i].Name, sub) {
+			return &cfg.Subs[i]
+		}
+	}
+	return nil
+}

--- a/research/research.go
+++ b/research/research.go
@@ -1,0 +1,67 @@
+// Package research assembles per-subreddit research bundles by combining
+// curated notes (subreddits.yaml) with live (cached) Reddit data.
+package research
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/viggy28/tider/internal/reddit"
+	"github.com/viggy28/tider/internal/types"
+)
+
+// Fetcher is the subset of reddit.Client that research depends on.
+// Defining it here keeps research/ free of HTTP/cache plumbing in tests.
+type Fetcher interface {
+	About(ctx context.Context, sub string, refresh bool) (types.Subreddit, error)
+	Rules(ctx context.Context, sub string, refresh bool) ([]types.Rule, error)
+	WikiRules(ctx context.Context, sub string, refresh bool) (string, error)
+	Top(ctx context.Context, sub, period string, refresh bool) ([]types.Post, error)
+	Hot(ctx context.Context, sub string, refresh bool) ([]types.Post, error)
+	Flairs(ctx context.Context, sub string, refresh bool) ([]types.Flair, error)
+}
+
+// For assembles a Research bundle for sub.
+func For(ctx context.Context, f Fetcher, notes *types.SubsConfig, sub string, refresh bool) (*types.Research, error) {
+	about, err := f.About(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("about: %w", err)
+	}
+	rules, err := f.Rules(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("rules: %w", err)
+	}
+	wiki, err := f.WikiRules(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("wiki rules: %w", err)
+	}
+	topW, err := f.Top(ctx, sub, "week", refresh)
+	if err != nil {
+		return nil, fmt.Errorf("top week: %w", err)
+	}
+	topM, err := f.Top(ctx, sub, "month", refresh)
+	if err != nil {
+		return nil, fmt.Errorf("top month: %w", err)
+	}
+	hot, err := f.Hot(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("hot: %w", err)
+	}
+	flairs, err := f.Flairs(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("flairs: %w", err)
+	}
+	return &types.Research{
+		Sub:       about,
+		Notes:     FindSub(notes, sub),
+		Rules:     rules,
+		WikiRules: wiki,
+		TopWeek:   topW,
+		TopMonth:  topM,
+		Hot:       hot,
+		Stickies:  reddit.Stickies(hot),
+		Flairs:    flairs,
+		Generated: time.Now().UTC(),
+	}, nil
+}

--- a/research/research_test.go
+++ b/research/research_test.go
@@ -1,0 +1,116 @@
+package research
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+type fakeFetcher struct {
+	about  types.Subreddit
+	rules  []types.Rule
+	wiki   string
+	topW   []types.Post
+	topM   []types.Post
+	hot    []types.Post
+	flairs []types.Flair
+}
+
+func (f *fakeFetcher) About(_ context.Context, _ string, _ bool) (types.Subreddit, error) {
+	return f.about, nil
+}
+func (f *fakeFetcher) Rules(_ context.Context, _ string, _ bool) ([]types.Rule, error) {
+	return f.rules, nil
+}
+func (f *fakeFetcher) WikiRules(_ context.Context, _ string, _ bool) (string, error) {
+	return f.wiki, nil
+}
+func (f *fakeFetcher) Top(_ context.Context, _, period string, _ bool) ([]types.Post, error) {
+	if period == "week" {
+		return f.topW, nil
+	}
+	return f.topM, nil
+}
+func (f *fakeFetcher) Hot(_ context.Context, _ string, _ bool) ([]types.Post, error) {
+	return f.hot, nil
+}
+func (f *fakeFetcher) Flairs(_ context.Context, _ string, _ bool) ([]types.Flair, error) {
+	return f.flairs, nil
+}
+
+func TestForAssemblesBundle(t *testing.T) {
+	f := &fakeFetcher{
+		about:  types.Subreddit{Name: "golang", Subscribers: 250000},
+		rules:  []types.Rule{{ShortName: "No spam"}},
+		wiki:   "Detailed rules",
+		topW:   []types.Post{{ID: "a"}},
+		topM:   []types.Post{{ID: "b"}},
+		hot:    []types.Post{{ID: "c", Stickied: true}, {ID: "d", Stickied: false}},
+		flairs: []types.Flair{{ID: "f1", Text: "discussion"}},
+	}
+	notes := &types.SubsConfig{Subs: []types.SubNotes{{Name: "golang", Tone: "terse"}}}
+
+	r, err := For(context.Background(), f, notes, "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Sub.Name != "golang" {
+		t.Fatalf("sub: %+v", r.Sub)
+	}
+	if r.Notes == nil || r.Notes.Tone != "terse" {
+		t.Fatalf("notes: %+v", r.Notes)
+	}
+	if len(r.Stickies) != 1 || r.Stickies[0].ID != "c" {
+		t.Fatalf("stickies: %+v", r.Stickies)
+	}
+	if r.WikiRules != "Detailed rules" {
+		t.Fatalf("wiki: %q", r.WikiRules)
+	}
+	if r.Generated.IsZero() {
+		t.Fatal("generated not set")
+	}
+}
+
+func TestForNotesAbsent(t *testing.T) {
+	f := &fakeFetcher{about: types.Subreddit{Name: "obscuresub"}}
+	r, err := For(context.Background(), f, nil, "obscuresub", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Notes != nil {
+		t.Fatalf("expected nil notes, got %+v", r.Notes)
+	}
+}
+
+func TestLoadNotesMissing(t *testing.T) {
+	cfg, err := LoadNotes(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil cfg, got %+v", cfg)
+	}
+}
+
+func TestLoadNotesParse(t *testing.T) {
+	cfg, err := LoadNotes("testdata/subreddits.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil || len(cfg.Subs) != 2 {
+		t.Fatalf("cfg: %+v", cfg)
+	}
+	g := FindSub(cfg, "golang")
+	if g == nil || g.Tone == "" || !g.Flair.Required {
+		t.Fatalf("golang notes: %+v", g)
+	}
+	// case-insensitive match
+	if FindSub(cfg, "POSTGRESQL") == nil {
+		t.Fatal("case-insensitive lookup failed")
+	}
+	if FindSub(cfg, "doesnotexist") != nil {
+		t.Fatal("expected nil for unknown sub")
+	}
+}

--- a/research/testdata/subreddits.yaml
+++ b/research/testdata/subreddits.yaml
@@ -1,0 +1,23 @@
+subs:
+  - name: golang
+    tone: "technical, terse, hype-allergic"
+    self_promo_tolerance: low
+    format_preferences:
+      - "self-posts > link posts"
+      - "code blocks expected for technical claims"
+    flair:
+      required: true
+      common: ["discussion", "show & tell"]
+    do_not:
+      - "no 'I built X' show-offs without code"
+    notes: |
+      Mods are active. Showcase posts without substance get removed.
+    exemplar_urls: []
+  - name: PostgreSQL
+    tone: "engineering-focused"
+    self_promo_tolerance: medium
+    flair:
+      required: false
+      common: []
+    notes: |
+      Smaller community. Goes deep on internals.


### PR DESCRIPTION
## Summary
- `internal/reddit/`: cached JSON client with polite User-Agent (`tider/0.1 (by /u/tider28)`), exponential backoff on 429/5xx, and a tiered disk cache under `~/.tider/cache/subs/{name}/` with per-file TTLs in `_meta.json` (about/rules/wiki/flairs 7d, top 24h, hot 6h; stickies derived from hot, always fresh).
- `research/`: `subreddits.yaml` loader (curated knowledge layer; missing file is fine) + orchestrator that assembles a `Research` bundle (live data + notes).
- `cmd/tider research <sub> [--refresh] [--notes] [--cache]`: end-to-end verifiable surface for step 1, dumps the bundle as JSON.

## Notable runtime discovery
The unauthenticated link-flair endpoint returns HTTP 200 with `{"json":{"errors":[["USER_REQUIRED",...]]}}` rather than the 403/404 the plan anticipated. Treated as the same soft-fail (empty flairs) — same intent, different mechanism.

## Test plan
- [x] `go test ./...` — cache (fresh/expired/missing/multi-file), client (UA header, cache + refresh, 429 retry, rules, wiki success + 404 soft fail, flairs success + 403 soft fail + auth-envelope soft fail, hot/stickies, top period query, unknown period error, hard 404 propagation), research (bundle assembly, missing notes, yaml load + case-insensitive lookup).
- [x] `go vet ./...` clean.
- [x] Live smoke test against `r/golang`: 356k subs, 12 rules, 25 top/week, 25 top/month, 25 hot, 2 stickies, curated notes joined, wiki + flairs soft-failed cleanly.

## Out of scope (deferred to later steps)
- LLM provider interface (step 2).
- Brief intake (step 3).
- Draft generation (step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)