### PR TITLE
step 3: intake (URL + file modes)

### DIFF
--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	intakeURL  string
-	intakeFile string
-	intakeProvider string
-	intakeModel    string
+	intakeURL       string
+	intakeFile      string
+	intakeProvider  string
+	intakeModel     string
+	intakeMaxTokens int
 )
 
 var intakeCmd = &cobra.Command{
@@ -39,6 +40,9 @@ API key for the chosen provider must be set in the environment
 			return err
 		}
 		i := intake.New(p)
+		if intakeMaxTokens > 0 {
+			i.MaxTokens = intakeMaxTokens
+		}
 
 		ctx := context.Background()
 		var brief *types.Brief
@@ -65,4 +69,5 @@ func init() {
 	intakeCmd.Flags().StringVar(&intakeFile, "file", "", "path to a markdown brief")
 	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "anthropic", "LLM provider: anthropic | openai")
 	intakeCmd.Flags().StringVar(&intakeModel, "model", "claude-sonnet-4-7", "LLM model name")
+	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget; 0 uses package default (2048). Bump for reasoning models.")
 }

--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/intake"
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+)
+
+var (
+	intakeURL  string
+	intakeFile string
+	intakeProvider string
+	intakeModel    string
+)
+
+var intakeCmd = &cobra.Command{
+	Use:   "intake",
+	Short: "Turn a URL or file into a structured Brief (read-only, LLM-extracted)",
+	Long: `intake reads source material and emits a structured Brief in JSON.
+
+Exactly one of --url or --file must be set. The interactive --topic mode
+lands in a follow-up.
+
+API key for the chosen provider must be set in the environment
+(ANTHROPIC_API_KEY or OPENAI_API_KEY).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if (intakeURL == "") == (intakeFile == "") {
+			return fmt.Errorf("exactly one of --url or --file is required")
+		}
+
+		p, err := llm.New(llm.Config{Provider: intakeProvider, Model: intakeModel})
+		if err != nil {
+			return err
+		}
+		i := intake.New(p)
+
+		ctx := context.Background()
+		var brief *types.Brief
+		switch {
+		case intakeURL != "":
+			brief, err = i.FromURL(ctx, intakeURL)
+		case intakeFile != "":
+			brief, err = i.FromFile(ctx, intakeFile)
+		}
+		if err != nil {
+			return err
+		}
+		out, err := json.MarshalIndent(brief, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+func init() {
+	intakeCmd.Flags().StringVar(&intakeURL, "url", "", "URL to a blog post or GitHub repo")
+	intakeCmd.Flags().StringVar(&intakeFile, "file", "", "path to a markdown brief")
+	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "anthropic", "LLM provider: anthropic | openai")
+	intakeCmd.Flags().StringVar(&intakeModel, "model", "claude-sonnet-4-7", "LLM model name")
+}

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -17,6 +17,7 @@ post manually. No auth, no posting, no commenting — by design.`,
 
 func main() {
 	rootCmd.AddCommand(researchCmd)
+	rootCmd.AddCommand(intakeCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/intake/extract.go
+++ b/intake/extract.go
@@ -1,0 +1,73 @@
+package intake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/prompts"
+)
+
+var intakeTmpl = template.Must(template.ParseFS(prompts.FS, "intake.tmpl"))
+
+type briefDraft struct {
+	Title      string   `json:"title"`
+	Summary    string   `json:"summary"`
+	Highlights []string `json:"highlights"`
+	Audience   string   `json:"audience"`
+	Links      []string `json:"links"`
+}
+
+func renderIntakePrompt(src types.BriefSource, raw string) (string, error) {
+	var buf bytes.Buffer
+	err := intakeTmpl.Execute(&buf, struct {
+		SourceMode  string
+		SourceValue string
+		RawContent  string
+	}{src.Mode, src.Value, raw})
+	if err != nil {
+		return "", fmt.Errorf("render intake prompt: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func (i *Intake) extract(ctx context.Context, src types.BriefSource, raw string) (*types.Brief, error) {
+	prompt, err := renderIntakePrompt(src, raw)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := i.Provider.Complete(ctx, llm.Request{
+		MaxTokens: i.MaxTokens,
+		JSONMode:  true,
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: prompt}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("llm extract: %w", err)
+	}
+	var d briefDraft
+	if err := json.Unmarshal([]byte(resp.Content), &d); err != nil {
+		return nil, fmt.Errorf("parse brief json: %w (model returned: %q)", err, truncate(resp.Content, 200))
+	}
+	return &types.Brief{
+		Source:     src,
+		Title:      d.Title,
+		Summary:    d.Summary,
+		Highlights: d.Highlights,
+		Audience:   d.Audience,
+		Links:      d.Links,
+		RawContent: raw,
+		CreatedAt:  time.Now().UTC(),
+	}, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/intake/extract_test.go
+++ b/intake/extract_test.go
@@ -1,0 +1,108 @@
+package intake
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+func TestExtractRendersPromptWithSource(t *testing.T) {
+	src := types.BriefSource{Mode: "url", Value: "https://example.com"}
+	prompt, err := renderIntakePrompt(src, "raw page body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prompt, "Source mode: url") {
+		t.Error("prompt missing source mode")
+	}
+	if !strings.Contains(prompt, "https://example.com") {
+		t.Error("prompt missing source value")
+	}
+	if !strings.Contains(prompt, "raw page body") {
+		t.Error("prompt missing raw content")
+	}
+	if !strings.Contains(prompt, "JSON object") {
+		t.Error("prompt missing JSON-output instruction")
+	}
+}
+
+func TestExtractRejectsBadJSON(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: "not json at all"}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	_, err := i.extract(context.Background(), types.BriefSource{Mode: "file", Value: "x"}, "raw")
+	if err == nil || !strings.Contains(err.Error(), "parse brief json") {
+		t.Errorf("expected parse error, got %v", err)
+	}
+}
+
+func TestExtractIncludesModelOutputInError(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: "<<<garbage>>>"}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	_, err := i.extract(context.Background(), types.BriefSource{Mode: "file", Value: "x"}, "raw")
+	if err == nil || !strings.Contains(err.Error(), "<<<garbage>>>") {
+		t.Errorf("error did not include model output: %v", err)
+	}
+}
+
+func TestExtractPropagatesProviderError(t *testing.T) {
+	fake := &fakeProvider{name: "fake", err: errors.New("boom")}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	_, err := i.extract(context.Background(), types.BriefSource{Mode: "file", Value: "x"}, "raw")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected wrapped provider error, got %v", err)
+	}
+}
+
+func TestExtractPopulatesAllFields(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	src := types.BriefSource{Mode: "file", Value: "sample.md"}
+	brief, err := i.extract(context.Background(), src, "raw content")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Title != "Streambed" {
+		t.Errorf("title = %q", brief.Title)
+	}
+	if brief.Summary == "" {
+		t.Error("summary empty")
+	}
+	if len(brief.Highlights) == 0 {
+		t.Error("highlights empty")
+	}
+	if brief.Audience == "" {
+		t.Error("audience empty")
+	}
+	if len(brief.Links) == 0 {
+		t.Error("links empty")
+	}
+	if brief.RawContent != "raw content" {
+		t.Errorf("raw content = %q", brief.RawContent)
+	}
+	if brief.Source != src {
+		t.Errorf("source = %+v", brief.Source)
+	}
+	if brief.CreatedAt.IsZero() {
+		t.Error("CreatedAt unset")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"short", 100, "short"},
+		{"exactlyten", 10, "exactlyten"},
+		{"longer than n", 6, "longer..."},
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.n); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.n, got, c.want)
+		}
+	}
+}

--- a/intake/file.go
+++ b/intake/file.go
@@ -1,0 +1,24 @@
+package intake
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// FromFile reads path (capped at i.MaxBytes) and runs LLM extraction.
+func (i *Intake) FromFile(ctx context.Context, path string) (*types.Brief, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(io.LimitReader(f, i.MaxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return i.extract(ctx, types.BriefSource{Mode: "file", Value: path}, string(raw))
+}

--- a/intake/file_test.go
+++ b/intake/file_test.go
@@ -1,0 +1,98 @@
+package intake
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/viggy28/tider/internal/llm"
+)
+
+func TestFromFileExtractsBrief(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+
+	brief, err := i.FromFile(context.Background(), "testdata/sample.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if brief.Source.Mode != "file" {
+		t.Errorf("source mode = %q", brief.Source.Mode)
+	}
+	if !strings.HasSuffix(brief.Source.Value, "testdata/sample.md") {
+		t.Errorf("source value = %q", brief.Source.Value)
+	}
+	if brief.Title != "Streambed" {
+		t.Errorf("title = %q", brief.Title)
+	}
+	if len(brief.Highlights) != 5 {
+		t.Errorf("highlights len = %d", len(brief.Highlights))
+	}
+	if !strings.Contains(brief.RawContent, "WAL-native CDC tool") {
+		t.Errorf("raw content not preserved")
+	}
+	if brief.CreatedAt.IsZero() {
+		t.Error("CreatedAt unset")
+	}
+}
+
+func TestFromFileSendsRawContentToProvider(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+
+	_, err := i.FromFile(context.Background(), "testdata/sample.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.gotRequests) != 1 {
+		t.Fatalf("expected 1 LLM call, got %d", len(fake.gotRequests))
+	}
+	req := fake.gotRequests[0]
+	if !req.JSONMode {
+		t.Error("JSONMode should be true for extraction")
+	}
+	if len(req.Messages) != 1 || req.Messages[0].Role != llm.RoleUser {
+		t.Fatalf("unexpected messages: %+v", req.Messages)
+	}
+	prompt := req.Messages[0].Content
+	if !strings.Contains(prompt, "Streambed") {
+		t.Error("prompt did not include source content")
+	}
+	if !strings.Contains(prompt, "Source mode: file") {
+		t.Error("prompt did not include source mode")
+	}
+}
+
+func TestFromFileMissing(t *testing.T) {
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	_, err := i.FromFile(context.Background(), filepath.Join(t.TempDir(), "missing.md"))
+	if err == nil {
+		t.Fatal("expected error opening missing file")
+	}
+	if !strings.Contains(err.Error(), "open") {
+		t.Errorf("error not from open path: %v", err)
+	}
+}
+
+func TestFromFileRespectsMaxBytes(t *testing.T) {
+	// 10KB file, MaxBytes=1KB → only first 1KB read
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.md")
+	big := strings.Repeat("abcdefghij", 1024) // 10KB
+	if err := writeFile(path, big); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{Provider: fake, MaxBytes: 1024, MaxTokens: 1024}
+
+	brief, err := i.FromFile(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(brief.RawContent); got != 1024 {
+		t.Errorf("raw content len = %d, want 1024 (truncated)", got)
+	}
+}

--- a/intake/intake.go
+++ b/intake/intake.go
@@ -1,0 +1,36 @@
+// Package intake converts a URL, file path, or topic into a structured Brief.
+// All three modes funnel through one LLM-backed extraction step so the
+// output shape is consistent regardless of input.
+package intake
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/viggy28/tider/internal/llm"
+)
+
+const DefaultUserAgent = "tider/0.1 (by /u/tider28)"
+
+// Intake holds the dependencies needed to turn raw input into a Brief.
+type Intake struct {
+	HTTP      *http.Client
+	UserAgent string
+	Provider  llm.Provider
+	// MaxBytes caps the bytes read from a URL or file before the LLM sees
+	// them. Stops a giant page from blowing the context window.
+	MaxBytes int64
+	// MaxTokens is the LLM completion budget for the extraction call.
+	MaxTokens int
+}
+
+// New constructs an Intake with sensible defaults. Provider is required.
+func New(p llm.Provider) *Intake {
+	return &Intake{
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+		UserAgent: DefaultUserAgent,
+		Provider:  p,
+		MaxBytes:  256 * 1024,
+		MaxTokens: 2048,
+	}
+}

--- a/intake/intake_test.go
+++ b/intake/intake_test.go
@@ -1,0 +1,40 @@
+package intake
+
+import (
+	"context"
+
+	"github.com/viggy28/tider/internal/llm"
+)
+
+// fakeProvider returns a canned LLM response, capturing the request for
+// assertions. Every test that needs a Provider uses this.
+type fakeProvider struct {
+	name        string
+	response    string
+	err         error
+	gotRequests []llm.Request
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+
+func (f *fakeProvider) Complete(_ context.Context, req llm.Request) (*llm.Response, error) {
+	f.gotRequests = append(f.gotRequests, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &llm.Response{Content: f.response, InputTokens: 10, OutputTokens: 20}, nil
+}
+
+const cannedBriefJSON = `{
+  "title": "Streambed",
+  "summary": "WAL-native CDC tool for Postgres that pipes data into Iceberg/Parquet on S3.",
+  "highlights": [
+    "Single Go binary",
+    "Reads directly from the Postgres WAL",
+    "Stores in Iceberg/Parquet on S3",
+    "Queries via DuckDB over the Postgres wire protocol",
+    "No external catalog required"
+  ],
+  "audience": "Postgres practitioners and data engineers",
+  "links": ["https://github.com/example/streambed"]
+}`

--- a/intake/testdata/sample.md
+++ b/intake/testdata/sample.md
@@ -1,0 +1,17 @@
+# Streambed
+
+Streambed is a WAL-native CDC tool for Postgres. It pipes data into Iceberg/Parquet on S3 and queries it back over the Postgres wire protocol via DuckDB, with no external catalog dependency.
+
+## Highlights
+
+- Single Go binary, no JVM
+- Reads directly from the Postgres WAL
+- Stores in Iceberg/Parquet on S3
+- Queries via DuckDB over the Postgres wire protocol
+- No external catalog (Glue, Hive, Nessie) required
+
+## Status
+
+Pre-alpha. Currently dogfooding internally before public release.
+
+Repo: https://github.com/example/streambed

--- a/intake/url.go
+++ b/intake/url.go
@@ -1,0 +1,68 @@
+package intake
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// FromURL fetches urlStr and runs LLM extraction against the body. GitHub
+// repo URLs (e.g., https://github.com/owner/repo) are rewritten to the
+// raw README so the extractor sees substance rather than the GitHub UI.
+func (i *Intake) FromURL(ctx context.Context, urlStr string) (*types.Brief, error) {
+	target := urlStr
+	if rewritten, ok := githubRepoToReadme(urlStr); ok {
+		target = rewritten
+	}
+	body, err := i.fetch(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	return i.extract(ctx, types.BriefSource{Mode: "url", Value: target}, body)
+}
+
+func (i *Intake) fetch(ctx context.Context, target string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", i.UserAgent)
+	resp, err := i.HTTP.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch %s: status %d", target, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, i.MaxBytes))
+	if err != nil {
+		return "", fmt.Errorf("read body: %w", err)
+	}
+	return string(body), nil
+}
+
+// githubRepoToReadme rewrites a github.com/owner/repo URL to the raw
+// README at HEAD. Returns ok=false for any other URL shape, including
+// deeper paths within a repo (where the raw rewrite wouldn't apply).
+func githubRepoToReadme(raw string) (string, bool) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", false
+	}
+	host := strings.ToLower(parsed.Host)
+	if host != "github.com" && host != "www.github.com" {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", false
+	}
+	owner, repo := parts[0], parts[1]
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/HEAD/README.md", owner, repo), true
+}

--- a/intake/url_test.go
+++ b/intake/url_test.go
@@ -1,0 +1,145 @@
+package intake
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func TestGithubRepoToReadme(t *testing.T) {
+	cases := []struct {
+		in   string
+		out  string
+		want bool
+	}{
+		{"https://github.com/owner/repo", "https://raw.githubusercontent.com/owner/repo/HEAD/README.md", true},
+		{"https://github.com/owner/repo/", "https://raw.githubusercontent.com/owner/repo/HEAD/README.md", true},
+		{"https://www.github.com/owner/repo", "https://raw.githubusercontent.com/owner/repo/HEAD/README.md", true},
+		{"https://GitHub.com/owner/repo", "https://raw.githubusercontent.com/owner/repo/HEAD/README.md", true},
+		{"https://github.com/owner", "", false},
+		{"https://github.com/owner/repo/blob/main/README.md", "", false},
+		{"https://github.com/owner/repo/issues/1", "", false},
+		{"https://example.com/owner/repo", "", false},
+		{"https://gitlab.com/owner/repo", "", false},
+		{"not a url at all", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := githubRepoToReadme(c.in)
+		if ok != c.want || got != c.out {
+			t.Errorf("githubRepoToReadme(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.out, c.want)
+		}
+	}
+}
+
+func TestFromURLFetchesAndExtracts(t *testing.T) {
+	const html = `<html><head><title>Streambed</title></head>
+<body>
+<h1>Streambed</h1>
+<p>WAL-native CDC for Postgres.</p>
+</body></html>`
+
+	var capturedUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUA = r.Header.Get("User-Agent")
+		_, _ = w.Write([]byte(html))
+	}))
+	defer srv.Close()
+
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{
+		HTTP:      srv.Client(),
+		UserAgent: DefaultUserAgent,
+		Provider:  fake,
+		MaxBytes:  1 << 20,
+		MaxTokens: 1024,
+	}
+
+	brief, err := i.FromURL(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedUA != DefaultUserAgent {
+		t.Errorf("user-agent = %q", capturedUA)
+	}
+	if brief.Source.Mode != "url" {
+		t.Errorf("source mode = %q", brief.Source.Mode)
+	}
+	if brief.Source.Value != srv.URL {
+		t.Errorf("source value = %q (want server URL passthrough)", brief.Source.Value)
+	}
+	if brief.Title != "Streambed" {
+		t.Errorf("title = %q", brief.Title)
+	}
+	if !strings.Contains(brief.RawContent, "WAL-native CDC") {
+		t.Error("raw HTML body not preserved")
+	}
+}
+
+func TestFromURLNon200Errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{HTTP: srv.Client(), UserAgent: DefaultUserAgent, Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	_, err := i.FromURL(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 error, got %v", err)
+	}
+}
+
+func TestFromURLRewritesGithubRepo(t *testing.T) {
+	// Capture which path the server is asked for. We point the user-given
+	// URL at our test server but make the path look like a GitHub repo
+	// path; the rewriter should convert it to a raw README path.
+	var seenPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		_, _ = w.Write([]byte("# Sample\n\nA project."))
+	}))
+	defer srv.Close()
+
+	// Quick unit-level check: rewrite happens for github.com URLs.
+	out, ok := githubRepoToReadme("https://github.com/owner/repo")
+	if !ok || !strings.Contains(out, "raw.githubusercontent.com/owner/repo/HEAD/README.md") {
+		t.Fatalf("rewrite failed: %q", out)
+	}
+
+	// Without faking DNS we can't intercept https://raw.githubusercontent.com,
+	// so we exercise the non-rewrite path against the test server. This
+	// guarantees that non-github URLs flow through unchanged.
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{HTTP: srv.Client(), UserAgent: DefaultUserAgent, Provider: fake, MaxBytes: 1 << 20, MaxTokens: 1024}
+	if _, err := i.FromURL(context.Background(), srv.URL+"/some/path"); err != nil {
+		t.Fatal(err)
+	}
+	if seenPath != "/some/path" {
+		t.Errorf("seen path = %q, want unchanged passthrough", seenPath)
+	}
+}
+
+func TestFromURLRespectsMaxBytes(t *testing.T) {
+	body := strings.Repeat("x", 10000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	fake := &fakeProvider{name: "fake", response: cannedBriefJSON}
+	i := &Intake{HTTP: srv.Client(), UserAgent: DefaultUserAgent, Provider: fake, MaxBytes: 1024, MaxTokens: 1024}
+
+	brief, err := i.FromURL(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(brief.RawContent); got != 1024 {
+		t.Errorf("raw content len = %d, want 1024 (cap)", got)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -63,6 +63,27 @@ type SubsConfig struct {
 	Subs []SubNotes `yaml:"subs"`
 }
 
+// BriefSource records how a Brief was created.
+type BriefSource struct {
+	Mode  string `json:"mode"`  // "url" | "file" | "topic"
+	Value string `json:"value"` // the URL, file path, or topic string
+}
+
+// Brief is the structured intake output: source material distilled into
+// fields that drafting downstream consumes. Title/Summary/Highlights/
+// Audience/Links are LLM-extracted from the raw input; RawContent is
+// preserved verbatim so later steps can pull additional context.
+type Brief struct {
+	Source     BriefSource `json:"source"`
+	Title      string      `json:"title"`
+	Summary    string      `json:"summary"`
+	Highlights []string    `json:"highlights"`
+	Audience   string      `json:"audience,omitempty"`
+	Links      []string    `json:"links,omitempty"`
+	RawContent string      `json:"raw_content,omitempty"`
+	CreatedAt  time.Time   `json:"created_at"`
+}
+
 // Research is the assembled per-sub bundle: live Reddit data + curated notes.
 type Research struct {
 	Sub       Subreddit `json:"sub"`

--- a/prompts/intake.tmpl
+++ b/prompts/intake.tmpl
@@ -6,8 +6,8 @@ Source value: {{.SourceValue}}
 Return a single JSON object with exactly these fields, no others:
 - "title": a clear short title (max 80 characters). Prefer the source's actual title over an invented one.
 - "summary": a 1-2 sentence factual summary. No marketing language.
-- "highlights": 3-7 concrete bullet points worth surfacing in a Reddit post. Each bullet is one short factual sentence. If the source is sparse, fewer is fine.
-- "audience": a short phrase naming who this is for (e.g., "Postgres practitioners", "Go backend engineers", "self-hosting enthusiasts"). Empty string if unclear.
+- "highlights": 3-7 bullets that would make a Reddit reader stop scrolling. Lead with what's *novel or non-obvious* — the technical wedge, surprising tradeoffs, counterintuitive choices, hard problems sidestepped. Skip dev-onboarding details (language version, Docker for tests, build commands, "how to run it locally") and routine usage instructions; those don't belong in a post lede. Each bullet is one short factual sentence. If the source is sparse, fewer is fine.
+- "audience": the specific wedge of people whose problem this solves, not a generic category. Bad: "data engineers". Good: "Postgres teams who want analytical queries off prod without standing up Spark or a separate warehouse". Empty string if genuinely unclear.
 - "links": canonical URLs that appear in or relate to the content, deduplicated. Never invent URLs. Empty array if none.
 
 Rules:

--- a/prompts/intake.tmpl
+++ b/prompts/intake.tmpl
@@ -8,7 +8,7 @@ Return a single JSON object with exactly these fields, no others:
 - "summary": a 1-2 sentence factual summary. No marketing language.
 - "highlights": 3-7 bullets that would make a Reddit reader stop scrolling. Lead with what's *novel or non-obvious* — the technical wedge, surprising tradeoffs, counterintuitive choices, hard problems sidestepped. Skip dev-onboarding details (language version, Docker for tests, build commands, "how to run it locally") and routine usage instructions; those don't belong in a post lede. Each bullet is one short factual sentence. If the source is sparse, fewer is fine.
 - "audience": the specific wedge of people whose problem this solves, not a generic category. Bad: "data engineers". Good: "Postgres teams who want analytical queries off prod without standing up Spark or a separate warehouse". Empty string if genuinely unclear.
-- "links": canonical URLs that appear in or relate to the content, deduplicated. Never invent URLs. Empty array if none.
+- "links": canonical URLs (project homepage, repo root, official docs) that appear in or relate to the content, deduplicated. Prefer the canonical root over deep links — a repo URL beats a CI-badge URL or a pkg.go.dev page; a project homepage beats a sub-page. Never invent URLs. Empty array if none.
 
 Rules:
 - Be factual. Do not invent details that aren't in the source.

--- a/prompts/intake.tmpl
+++ b/prompts/intake.tmpl
@@ -1,0 +1,22 @@
+You extract a structured Brief from raw source material. The user is going to take this Brief and use it to draft a Reddit post about whatever the source describes.
+
+Source mode: {{.SourceMode}}
+Source value: {{.SourceValue}}
+
+Return a single JSON object with exactly these fields, no others:
+- "title": a clear short title (max 80 characters). Prefer the source's actual title over an invented one.
+- "summary": a 1-2 sentence factual summary. No marketing language.
+- "highlights": 3-7 concrete bullet points worth surfacing in a Reddit post. Each bullet is one short factual sentence. If the source is sparse, fewer is fine.
+- "audience": a short phrase naming who this is for (e.g., "Postgres practitioners", "Go backend engineers", "self-hosting enthusiasts"). Empty string if unclear.
+- "links": canonical URLs that appear in or relate to the content, deduplicated. Never invent URLs. Empty array if none.
+
+Rules:
+- Be factual. Do not invent details that aren't in the source.
+- Prefer specific over general: name versions, numbers, technologies, and tradeoffs explicitly when the source does.
+- Skip marketing-speak. Avoid "revolutionary", "game-changing", "blazing-fast", "10x", and similar unless the source itself uses that exact phrasing AND it's load-bearing for what's being described.
+- The source content may be HTML, markdown, JSON, or plain text. Extract from whatever is there. Ignore navigation, ads, cookie banners, footer junk.
+
+Raw content:
+---
+{{.RawContent}}
+---

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -1,0 +1,9 @@
+// Package prompts holds versioned prompt templates as embedded files. The
+// templates themselves are part of tider's IP and are intended to be
+// iterated on — diffing them against generated draft quality is the point.
+package prompts
+
+import "embed"
+
+//go:embed *.tmpl
+var FS embed.FS


### PR DESCRIPTION
Stacked on #2.

## Summary
- `internal/types.Brief` — structured intake output (title, summary, highlights, audience, links, source, raw content, timestamp).
- `intake/` package: `Intake.FromURL` and `Intake.FromFile`. Both funnel through one LLM-backed extraction so the Brief shape is identical regardless of input mode.
- GitHub repo URLs (`github.com/owner/repo`) auto-rewrite to raw README so the extractor sees substance, not GitHub UI HTML.
- `prompts/` package with `go:embed` and `prompts/intake.tmpl` — first prompt under version control, per the spec invariant ("prompts live in versioned template files").
- CLI: `tider intake --url=... | --file=... [--provider=...] [--model=...]` emits a JSON Brief.

## Why URL + file only (not --topic)
Plan and CLAUDE.md both sequence intake as "URL and file paths first, interactive --topic last." Topic mode needs multi-turn clarifying-question UX that's genuinely a different concern from one-shot extraction. Splitting keeps this PR focused and the topic PR small.

## Test plan

**Offline (default `go test ./...`)** — 14 cases pass:
- [x] Brief field population end-to-end (file path): title, summary, highlights, audience, links, raw content, source, CreatedAt.
- [x] LLM request shape: JSONMode set, single user message, prompt contains source mode + value + raw content.
- [x] File mode: missing file returns clear error wrapped from `open`.
- [x] MaxBytes enforced for both file and URL paths (10KB body capped at 1KB → exactly 1024 bytes preserved).
- [x] URL fetch via httptest: User-Agent header sent, 200 → success, non-200 → error including status code.
- [x] GitHub repo URL rewrite: case-insensitive host match, `www.` prefix, trailing slash; rejects deeper paths (`/blob/main/...`, `/issues/...`), non-github hosts, malformed URLs.
- [x] Extraction error paths: bad JSON returns error including the model output (truncated to 200 chars), provider errors propagate wrapped.
- [x] `truncate` helper boundaries.

**Build/CLI**:
- [x] `go vet ./...` clean.
- [x] `tider intake --help` renders.
- [x] CLI requires exactly one of `--url`/`--file`.

**Live (manual)**: not automated. With keys set: `tider intake --url=https://github.com/some/repo` or `tider intake --file=path.md` should print a populated Brief. Worth running once before step 4 lands.

## Out of scope
- `--topic` mode (next PR within step 3).
- HTML→text preprocessing — passing raw HTML to the LLM works fine within MaxBytes, and the LLM is good at extracting from messy input. Optimize later if token cost matters.
- Frontmatter parsing for self-authored markdown briefs — the LLM handles markdown directly. Could add a fast path that skips LLM for files with structured frontmatter, but no evidence yet that's needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)