### PR TITLE
step 2: llm provider interface + anthropic + openai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/tider
+/cmd/tider/tider
+*.out
+.DS_Store

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "tider",
+	Short: "Reddit drafting co-pilot (read-only)",
+	Long: `tider drafts Reddit posts and reply suggestions, grounded in each
+subreddit's rules and what's worked there. The bot reads Reddit; you
+post manually. No auth, no posting, no commenting — by design.`,
+}
+
+func main() {
+	rootCmd.AddCommand(researchCmd)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/tider/research.go
+++ b/cmd/tider/research.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/reddit"
+	"github.com/viggy28/tider/research"
+)
+
+var (
+	researchRefresh   bool
+	researchNotesPath string
+	researchCacheRoot string
+)
+
+var researchCmd = &cobra.Command{
+	Use:   "research <sub>",
+	Short: "Fetch and assemble a research bundle for a subreddit",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sub := args[0]
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		cacheRoot := researchCacheRoot
+		if cacheRoot == "" {
+			cacheRoot = filepath.Join(home, ".tider", "cache")
+		}
+		notesPath := researchNotesPath
+		if notesPath == "" {
+			notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
+		}
+
+		notes, err := research.LoadNotes(notesPath)
+		if err != nil {
+			return err
+		}
+
+		client := reddit.NewClient(reddit.NewCache(cacheRoot))
+		bundle, err := research.For(context.Background(), client, notes, sub, researchRefresh)
+		if err != nil {
+			return err
+		}
+		out, err := json.MarshalIndent(bundle, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+		return nil
+	},
+}
+
+func init() {
+	researchCmd.Flags().BoolVar(&researchRefresh, "refresh", false, "force fresh fetch, bypass cache")
+	researchCmd.Flags().StringVar(&researchNotesPath, "notes", "", "path to subreddits.yaml (default ~/.tider/subreddits.yaml)")
+	researchCmd.Flags().StringVar(&researchCacheRoot, "cache", "", "cache root dir (default ~/.tider/cache)")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/viggy28/tider
+
+go 1.26.1
+
+require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -1,0 +1,157 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	anthropicDefaultBaseURL = "https://api.anthropic.com"
+	anthropicAPIVersion     = "2023-06-01"
+	anthropicJSONInstruction = "Respond with a single valid JSON value only. No prose, no markdown fences, no commentary."
+)
+
+type Anthropic struct {
+	HTTP    *http.Client
+	BaseURL string
+	APIKey  string
+	Model   string
+}
+
+func NewAnthropic(model string) (*Anthropic, error) {
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("ANTHROPIC_API_KEY not set")
+	}
+	return &Anthropic{
+		HTTP:    &http.Client{Timeout: 120 * time.Second},
+		BaseURL: anthropicDefaultBaseURL,
+		APIKey:  key,
+		Model:   model,
+	}, nil
+}
+
+func (a *Anthropic) Name() string { return "anthropic" }
+
+type anthropicRequest struct {
+	Model       string             `json:"model"`
+	MaxTokens   int                `json:"max_tokens"`
+	Temperature float64            `json:"temperature,omitempty"`
+	System      string             `json:"system,omitempty"`
+	Messages    []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthropicResponse struct {
+	Type    string                  `json:"type"`
+	Content []anthropicContentBlock `json:"content"`
+	Usage   struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+type anthropicErrorResponse struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func (a *Anthropic) Complete(ctx context.Context, req Request) (*Response, error) {
+	model := req.Model
+	if model == "" {
+		model = a.Model
+	}
+	if model == "" {
+		return nil, fmt.Errorf("anthropic: model not set")
+	}
+	if req.MaxTokens <= 0 {
+		return nil, fmt.Errorf("anthropic: MaxTokens must be > 0")
+	}
+
+	body := anthropicRequest{
+		Model:       model,
+		MaxTokens:   req.MaxTokens,
+		Temperature: req.Temperature,
+	}
+	var systemParts []string
+	for _, m := range req.Messages {
+		switch m.Role {
+		case RoleSystem:
+			systemParts = append(systemParts, m.Content)
+		case RoleUser, RoleAssistant:
+			body.Messages = append(body.Messages, anthropicMessage{Role: m.Role, Content: m.Content})
+		default:
+			return nil, fmt.Errorf("anthropic: unknown role %q", m.Role)
+		}
+	}
+	body.System = strings.Join(systemParts, "\n\n")
+	if req.JSONMode {
+		if body.System == "" {
+			body.System = anthropicJSONInstruction
+		} else {
+			body.System += "\n\n" + anthropicJSONInstruction
+		}
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.BaseURL+"/v1/messages", bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", a.APIKey)
+	httpReq.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	httpResp, err := a.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: http: %w", err)
+	}
+	defer httpResp.Body.Close()
+	respBody, _ := io.ReadAll(httpResp.Body)
+
+	if httpResp.StatusCode != http.StatusOK {
+		var ae anthropicErrorResponse
+		if err := json.Unmarshal(respBody, &ae); err == nil && ae.Error.Message != "" {
+			return nil, fmt.Errorf("anthropic %d %s: %s", httpResp.StatusCode, ae.Error.Type, ae.Error.Message)
+		}
+		return nil, fmt.Errorf("anthropic %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp anthropicResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("anthropic: parse response: %w", err)
+	}
+	var content strings.Builder
+	for _, c := range resp.Content {
+		if c.Type == "text" {
+			content.WriteString(c.Text)
+		}
+	}
+	return &Response{
+		Content:      content.String(),
+		InputTokens:  resp.Usage.InputTokens,
+		OutputTokens: resp.Usage.OutputTokens,
+	}, nil
+}

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -1,0 +1,318 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAnthropicTest(t *testing.T, handler http.Handler) *Anthropic {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &Anthropic{
+		HTTP:    srv.Client(),
+		BaseURL: srv.URL,
+		APIKey:  "sk-test-key",
+		Model:   "claude-sonnet-4-7",
+	}
+}
+
+// captureRequest records the incoming JSON body so a test can assert on it.
+type captured struct {
+	headers http.Header
+	path    string
+	body    map[string]any
+}
+
+func captureHandler(t *testing.T, status int, respBody string) (*captured, http.Handler) {
+	t.Helper()
+	c := &captured{}
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.headers = r.Header.Clone()
+		c.path = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &c.body)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respBody))
+	})
+	return c, h
+}
+
+const anthropicSuccess = `{
+  "type": "message",
+  "content": [{"type": "text", "text": "hello world"}],
+  "usage": {"input_tokens": 12, "output_tokens": 7}
+}`
+
+func TestAnthropicHeadersAndPath(t *testing.T) {
+	cap, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 256,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cap.path != "/v1/messages" {
+		t.Errorf("path = %q", cap.path)
+	}
+	if cap.headers.Get("x-api-key") != "sk-test-key" {
+		t.Errorf("x-api-key = %q", cap.headers.Get("x-api-key"))
+	}
+	if cap.headers.Get("anthropic-version") != anthropicAPIVersion {
+		t.Errorf("anthropic-version = %q", cap.headers.Get("anthropic-version"))
+	}
+	if !strings.HasPrefix(cap.headers.Get("Content-Type"), "application/json") {
+		t.Errorf("content-type = %q", cap.headers.Get("Content-Type"))
+	}
+}
+
+func TestAnthropicBodyShape(t *testing.T) {
+	cap, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		Model:       "claude-haiku-4-5",
+		MaxTokens:   500,
+		Temperature: 0.7,
+		Messages: []Message{
+			{Role: RoleSystem, Content: "you are concise"},
+			{Role: RoleUser, Content: "hi"},
+			{Role: RoleAssistant, Content: "hello"},
+			{Role: RoleUser, Content: "again"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cap.body["model"]; got != "claude-haiku-4-5" {
+		t.Errorf("model = %v", got)
+	}
+	if got := cap.body["max_tokens"]; got != float64(500) {
+		t.Errorf("max_tokens = %v", got)
+	}
+	if got := cap.body["temperature"]; got != 0.7 {
+		t.Errorf("temperature = %v", got)
+	}
+	if got := cap.body["system"]; got != "you are concise" {
+		t.Errorf("system = %q", got)
+	}
+	msgs, ok := cap.body["messages"].([]any)
+	if !ok || len(msgs) != 3 {
+		t.Fatalf("messages = %#v", cap.body["messages"])
+	}
+	first := msgs[0].(map[string]any)
+	if first["role"] != "user" || first["content"] != "hi" {
+		t.Errorf("first message = %+v", first)
+	}
+}
+
+func TestAnthropicMultipleSystemMessagesJoined(t *testing.T) {
+	cap, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages: []Message{
+			{Role: RoleSystem, Content: "rule one"},
+			{Role: RoleSystem, Content: "rule two"},
+			{Role: RoleUser, Content: "go"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cap.body["system"]; got != "rule one\n\nrule two" {
+		t.Errorf("system join = %q", got)
+	}
+}
+
+func TestAnthropicJSONModeAddsInstruction(t *testing.T) {
+	cap, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		JSONMode:  true,
+		Messages: []Message{
+			{Role: RoleSystem, Content: "be helpful"},
+			{Role: RoleUser, Content: "give me a structured answer"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys, _ := cap.body["system"].(string)
+	if !strings.HasPrefix(sys, "be helpful") {
+		t.Errorf("system lost original: %q", sys)
+	}
+	if !strings.Contains(sys, "valid JSON") {
+		t.Errorf("system missing JSON instruction: %q", sys)
+	}
+}
+
+func TestAnthropicJSONModeWithoutSystem(t *testing.T) {
+	cap, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		JSONMode:  true,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys, _ := cap.body["system"].(string)
+	if !strings.Contains(sys, "valid JSON") {
+		t.Errorf("system missing JSON instruction: %q", sys)
+	}
+}
+
+func TestAnthropicResponseParsing(t *testing.T) {
+	_, h := captureHandler(t, 200, anthropicSuccess)
+	a := newAnthropicTest(t, h)
+	resp, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "hello world" {
+		t.Errorf("content = %q", resp.Content)
+	}
+	if resp.InputTokens != 12 || resp.OutputTokens != 7 {
+		t.Errorf("usage = in=%d out=%d", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+func TestAnthropicMultipleContentBlocksConcatenated(t *testing.T) {
+	const body = `{
+      "type": "message",
+      "content": [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": " second"}
+      ],
+      "usage": {"input_tokens": 1, "output_tokens": 2}
+    }`
+	_, h := captureHandler(t, 200, body)
+	a := newAnthropicTest(t, h)
+	resp, err := a.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "first second" {
+		t.Errorf("content = %q", resp.Content)
+	}
+}
+
+func TestAnthropicNonTextBlocksIgnored(t *testing.T) {
+	const body = `{
+      "type": "message",
+      "content": [
+        {"type": "text", "text": "hi"},
+        {"type": "tool_use", "text": "should be ignored"}
+      ],
+      "usage": {"input_tokens": 1, "output_tokens": 1}
+    }`
+	_, h := captureHandler(t, 200, body)
+	a := newAnthropicTest(t, h)
+	resp, err := a.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "hi" {
+		t.Errorf("content = %q (non-text block leaked)", resp.Content)
+	}
+}
+
+func TestAnthropicErrorResponse(t *testing.T) {
+	const body = `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens too high"}}`
+	_, h := captureHandler(t, 400, body)
+	a := newAnthropicTest(t, h)
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_request_error") {
+		t.Errorf("error type missing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "max_tokens too high") {
+		t.Errorf("error message missing: %v", err)
+	}
+}
+
+func TestAnthropicValidationModelRequired(t *testing.T) {
+	a := &Anthropic{HTTP: http.DefaultClient, BaseURL: "http://invalid", APIKey: "x"}
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "model not set") {
+		t.Errorf("expected model-not-set error, got %v", err)
+	}
+}
+
+func TestAnthropicValidationMaxTokensRequired(t *testing.T) {
+	a := &Anthropic{HTTP: http.DefaultClient, BaseURL: "http://invalid", APIKey: "x", Model: "m"}
+	_, err := a.Complete(context.Background(), Request{
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "MaxTokens") {
+		t.Errorf("expected MaxTokens error, got %v", err)
+	}
+}
+
+func TestAnthropicUnknownRoleRejected(t *testing.T) {
+	a := newAnthropicTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: "weirdo", Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown role") {
+		t.Errorf("expected unknown-role error, got %v", err)
+	}
+}
+
+func TestAnthropicName(t *testing.T) {
+	a := &Anthropic{}
+	if a.Name() != "anthropic" {
+		t.Errorf("name = %q", a.Name())
+	}
+}
+
+func TestNewAnthropicMissingKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	_, err := NewAnthropic("claude-sonnet-4-7")
+	if err == nil || !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("expected env-var error, got %v", err)
+	}
+}
+
+func TestNewAnthropicReadsEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "from-env")
+	a, err := NewAnthropic("claude-sonnet-4-7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.APIKey != "from-env" {
+		t.Errorf("APIKey = %q", a.APIKey)
+	}
+	if a.Model != "claude-sonnet-4-7" {
+		t.Errorf("Model = %q", a.Model)
+	}
+}

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -1,0 +1,40 @@
+package llm
+
+import "fmt"
+
+// Config is the minimum llm-related configuration the factory needs.
+// Full config loading (viper, ~/.tider/config.yaml) lives in a future step;
+// this struct is what that loader will populate.
+type Config struct {
+	Provider string
+	Model    string
+	Tasks    map[string]TaskConfig
+}
+
+type TaskConfig struct {
+	Provider string
+	Model    string
+}
+
+// New constructs the provider implied by cfg.
+func New(cfg Config) (Provider, error) {
+	switch cfg.Provider {
+	case "anthropic":
+		return NewAnthropic(cfg.Model)
+	case "openai":
+		return NewOpenAI(cfg.Model)
+	case "":
+		return nil, fmt.Errorf("llm: provider not configured")
+	default:
+		return nil, fmt.Errorf("llm: unknown provider %q", cfg.Provider)
+	}
+}
+
+// ForTask returns the provider for a named task, falling back to the base
+// config when no task-specific override exists.
+func ForTask(cfg Config, task string) (Provider, error) {
+	if t, ok := cfg.Tasks[task]; ok {
+		return New(Config{Provider: t.Provider, Model: t.Model})
+	}
+	return New(cfg)
+}

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -1,0 +1,96 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewAnthropicProvider(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test")
+	p, err := New(Config{Provider: "anthropic", Model: "claude-sonnet-4-7"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "anthropic" {
+		t.Errorf("name = %q", p.Name())
+	}
+}
+
+func TestNewOpenAIProvider(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test")
+	p, err := New(Config{Provider: "openai", Model: "gpt-5"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "openai" {
+		t.Errorf("name = %q", p.Name())
+	}
+}
+
+func TestNewUnknownProvider(t *testing.T) {
+	_, err := New(Config{Provider: "cohere"})
+	if err == nil || !strings.Contains(err.Error(), `unknown provider "cohere"`) {
+		t.Errorf("expected unknown-provider error, got %v", err)
+	}
+}
+
+func TestNewEmptyProvider(t *testing.T) {
+	_, err := New(Config{})
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("expected not-configured error, got %v", err)
+	}
+}
+
+func TestNewMissingAPIKeyPropagated(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	_, err := New(Config{Provider: "anthropic", Model: "claude-sonnet-4-7"})
+	if err == nil || !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("expected missing-key error, got %v", err)
+	}
+}
+
+func TestForTaskOverride(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "ak")
+	t.Setenv("OPENAI_API_KEY", "ok")
+	cfg := Config{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-7",
+		Tasks: map[string]TaskConfig{
+			"draft": {Provider: "openai", Model: "gpt-5"},
+		},
+	}
+	p, err := ForTask(cfg, "draft")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "openai" {
+		t.Errorf("override not applied: name = %q", p.Name())
+	}
+	if openai, ok := p.(*OpenAI); !ok || openai.Model != "gpt-5" {
+		t.Errorf("override model not applied: %+v", p)
+	}
+}
+
+func TestForTaskFallsBackToBase(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "ak")
+	cfg := Config{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-7",
+		Tasks:    map[string]TaskConfig{},
+	}
+	p, err := ForTask(cfg, "anything")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "anthropic" {
+		t.Errorf("fallback failed: name = %q", p.Name())
+	}
+}
+
+func TestForTaskNilMap(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "ak")
+	cfg := Config{Provider: "anthropic", Model: "m"}
+	if _, err := ForTask(cfg, "draft"); err != nil {
+		t.Errorf("nil tasks map should be safe: %v", err)
+	}
+}

--- a/internal/llm/live_test.go
+++ b/internal/llm/live_test.go
@@ -1,0 +1,152 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Live tests hit the real provider APIs. They are gated behind TIDER_LIVE_LLM
+// so default `go test ./...` runs offline. Set TIDER_LIVE_LLM=1 plus the
+// relevant API key(s) to exercise them.
+//
+//   TIDER_LIVE_LLM=1 ANTHROPIC_API_KEY=... OPENAI_API_KEY=... go test ./internal/llm/ -v -run Live
+
+func liveEnabled(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TIDER_LIVE_LLM") == "" {
+		t.Skip("set TIDER_LIVE_LLM=1 to enable live API tests")
+	}
+}
+
+func TestLiveAnthropic(t *testing.T) {
+	liveEnabled(t)
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	model := os.Getenv("TIDER_LIVE_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-haiku-4-5"
+	}
+	p, err := NewAnthropic(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := p.Complete(ctx, Request{
+		MaxTokens: 32,
+		Messages: []Message{
+			{Role: RoleUser, Content: "Reply with exactly: ok"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live anthropic: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("empty content")
+	}
+	if resp.OutputTokens == 0 {
+		t.Errorf("output_tokens=0 (parsing usage failed?): %+v", resp)
+	}
+	t.Logf("anthropic %s → %q  (in=%d out=%d)", model, strings.TrimSpace(resp.Content), resp.InputTokens, resp.OutputTokens)
+}
+
+func TestLiveAnthropicJSONMode(t *testing.T) {
+	liveEnabled(t)
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	model := os.Getenv("TIDER_LIVE_ANTHROPIC_MODEL")
+	if model == "" {
+		model = "claude-haiku-4-5"
+	}
+	p, err := NewAnthropic(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := p.Complete(ctx, Request{
+		MaxTokens: 64,
+		JSONMode:  true,
+		Messages: []Message{
+			{Role: RoleUser, Content: `Return a JSON object with one key "ok" set to true.`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live anthropic json: %v", err)
+	}
+	got := strings.TrimSpace(resp.Content)
+	if !strings.HasPrefix(got, "{") {
+		t.Errorf("expected JSON object, got: %q", got)
+	}
+	t.Logf("anthropic json mode → %s", got)
+}
+
+func TestLiveOpenAI(t *testing.T) {
+	liveEnabled(t)
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	model := os.Getenv("TIDER_LIVE_OPENAI_MODEL")
+	if model == "" {
+		model = "gpt-4o-mini"
+	}
+	p, err := NewOpenAI(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := p.Complete(ctx, Request{
+		MaxTokens: 32,
+		Messages: []Message{
+			{Role: RoleUser, Content: "Reply with exactly: ok"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live openai: %v", err)
+	}
+	if resp.Content == "" {
+		t.Fatal("empty content")
+	}
+	if resp.OutputTokens == 0 {
+		t.Errorf("output_tokens=0 (parsing usage failed?): %+v", resp)
+	}
+	t.Logf("openai %s → %q  (in=%d out=%d)", model, strings.TrimSpace(resp.Content), resp.InputTokens, resp.OutputTokens)
+}
+
+func TestLiveOpenAIJSONMode(t *testing.T) {
+	liveEnabled(t)
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY not set")
+	}
+	model := os.Getenv("TIDER_LIVE_OPENAI_MODEL")
+	if model == "" {
+		model = "gpt-4o-mini"
+	}
+	p, err := NewOpenAI(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := p.Complete(ctx, Request{
+		MaxTokens: 64,
+		JSONMode:  true,
+		Messages: []Message{
+			{Role: RoleUser, Content: `Return a JSON object with one key "ok" set to true.`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("live openai json: %v", err)
+	}
+	got := strings.TrimSpace(resp.Content)
+	if !strings.HasPrefix(got, "{") {
+		t.Errorf("expected JSON object, got: %q", got)
+	}
+	t.Logf("openai json mode → %s", got)
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,0 +1,39 @@
+// Package llm is the only package in tider allowed to talk to LLM providers.
+// All callers go through the Provider interface; provider-native types
+// (Anthropic, OpenAI) never leak past this package boundary.
+package llm
+
+import "context"
+
+const (
+	RoleSystem    = "system"
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+)
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type Request struct {
+	Model       string
+	Messages    []Message
+	MaxTokens   int
+	Temperature float64
+	// JSONMode signals "I want a JSON value back, no prose." Each provider
+	// implements this idiomatically: OpenAI uses native response_format,
+	// Anthropic uses a system-instruction nudge.
+	JSONMode bool
+}
+
+type Response struct {
+	Content      string
+	InputTokens  int
+	OutputTokens int
+}
+
+type Provider interface {
+	Name() string
+	Complete(ctx context.Context, req Request) (*Response, error)
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -1,0 +1,140 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const openaiDefaultBaseURL = "https://api.openai.com"
+
+type OpenAI struct {
+	HTTP    *http.Client
+	BaseURL string
+	APIKey  string
+	Model   string
+}
+
+func NewOpenAI(model string) (*OpenAI, error) {
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY not set")
+	}
+	return &OpenAI{
+		HTTP:    &http.Client{Timeout: 120 * time.Second},
+		BaseURL: openaiDefaultBaseURL,
+		APIKey:  key,
+		Model:   model,
+	}, nil
+}
+
+func (o *OpenAI) Name() string { return "openai" }
+
+type openaiRequest struct {
+	Model          string                `json:"model"`
+	Messages       []openaiMessage       `json:"messages"`
+	MaxTokens      int                   `json:"max_completion_tokens,omitempty"`
+	Temperature    *float64              `json:"temperature,omitempty"`
+	ResponseFormat *openaiResponseFormat `json:"response_format,omitempty"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiResponseFormat struct {
+	Type string `json:"type"`
+}
+
+type openaiResponse struct {
+	Choices []struct {
+		Message openaiMessage `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+type openaiErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+
+func (o *OpenAI) Complete(ctx context.Context, req Request) (*Response, error) {
+	model := req.Model
+	if model == "" {
+		model = o.Model
+	}
+	if model == "" {
+		return nil, fmt.Errorf("openai: model not set")
+	}
+
+	body := openaiRequest{
+		Model:     model,
+		MaxTokens: req.MaxTokens,
+	}
+	if req.Temperature != 0 {
+		t := req.Temperature
+		body.Temperature = &t
+	}
+	if req.JSONMode {
+		body.ResponseFormat = &openaiResponseFormat{Type: "json_object"}
+	}
+	for _, m := range req.Messages {
+		switch m.Role {
+		case RoleSystem, RoleUser, RoleAssistant:
+			body.Messages = append(body.Messages, openaiMessage{Role: m.Role, Content: m.Content})
+		default:
+			return nil, fmt.Errorf("openai: unknown role %q", m.Role)
+		}
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("openai: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.BaseURL+"/v1/chat/completions", bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("openai: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+o.APIKey)
+
+	httpResp, err := o.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("openai: http: %w", err)
+	}
+	defer httpResp.Body.Close()
+	respBody, _ := io.ReadAll(httpResp.Body)
+
+	if httpResp.StatusCode != http.StatusOK {
+		var oe openaiErrorResponse
+		if err := json.Unmarshal(respBody, &oe); err == nil && oe.Error.Message != "" {
+			return nil, fmt.Errorf("openai %d %s: %s", httpResp.StatusCode, oe.Error.Type, oe.Error.Message)
+		}
+		return nil, fmt.Errorf("openai %d: %s", httpResp.StatusCode, string(respBody))
+	}
+
+	var resp openaiResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("openai: parse response: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("openai: no choices in response")
+	}
+	return &Response{
+		Content:      resp.Choices[0].Message.Content,
+		InputTokens:  resp.Usage.PromptTokens,
+		OutputTokens: resp.Usage.CompletionTokens,
+	}, nil
+}

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,240 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newOpenAITest(t *testing.T, handler http.Handler) *OpenAI {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &OpenAI{
+		HTTP:    srv.Client(),
+		BaseURL: srv.URL,
+		APIKey:  "sk-openai-test",
+		Model:   "gpt-4o-mini",
+	}
+}
+
+const openaiSuccess = `{
+  "id": "chatcmpl-1",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "the answer is 42"}}],
+  "usage": {"prompt_tokens": 9, "completion_tokens": 4, "total_tokens": 13}
+}`
+
+func TestOpenAIHeadersAndPath(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cap.path != "/v1/chat/completions" {
+		t.Errorf("path = %q", cap.path)
+	}
+	if cap.headers.Get("Authorization") != "Bearer sk-openai-test" {
+		t.Errorf("authorization = %q", cap.headers.Get("Authorization"))
+	}
+	if !strings.HasPrefix(cap.headers.Get("Content-Type"), "application/json") {
+		t.Errorf("content-type = %q", cap.headers.Get("Content-Type"))
+	}
+}
+
+func TestOpenAIBodyShape(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		Model:       "gpt-5",
+		MaxTokens:   1024,
+		Temperature: 0.5,
+		Messages: []Message{
+			{Role: RoleSystem, Content: "be terse"},
+			{Role: RoleUser, Content: "hi"},
+			{Role: RoleAssistant, Content: "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cap.body["model"]; got != "gpt-5" {
+		t.Errorf("model = %v", got)
+	}
+	if got := cap.body["max_completion_tokens"]; got != float64(1024) {
+		t.Errorf("max_completion_tokens = %v", got)
+	}
+	if got := cap.body["temperature"]; got != 0.5 {
+		t.Errorf("temperature = %v", got)
+	}
+	msgs, ok := cap.body["messages"].([]any)
+	if !ok || len(msgs) != 3 {
+		t.Fatalf("messages = %#v", cap.body["messages"])
+	}
+	sys := msgs[0].(map[string]any)
+	if sys["role"] != "system" || sys["content"] != "be terse" {
+		t.Errorf("system message = %+v", sys)
+	}
+}
+
+func TestOpenAIDefaultModelUsed(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 50,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cap.body["model"]; got != "gpt-4o-mini" {
+		t.Errorf("default model not used: %v", got)
+	}
+}
+
+func TestOpenAIJSONModeSetsResponseFormat(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 50,
+		JSONMode:  true,
+		Messages:  []Message{{Role: RoleUser, Content: "structured"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rf, ok := cap.body["response_format"].(map[string]any)
+	if !ok {
+		t.Fatalf("response_format missing or wrong type: %#v", cap.body["response_format"])
+	}
+	if rf["type"] != "json_object" {
+		t.Errorf("response_format.type = %v", rf["type"])
+	}
+}
+
+func TestOpenAIJSONModeOmittedWhenFalse(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 50,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := cap.body["response_format"]; present {
+		t.Errorf("response_format should be omitted when JSONMode=false")
+	}
+}
+
+func TestOpenAITemperatureOmittedWhenZero(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 50,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := cap.body["temperature"]; present {
+		t.Errorf("temperature should be omitted when zero (let server default apply)")
+	}
+}
+
+func TestOpenAIResponseParsing(t *testing.T) {
+	_, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	resp, err := o.Complete(context.Background(), Request{
+		MaxTokens: 50,
+		Messages:  []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "the answer is 42" {
+		t.Errorf("content = %q", resp.Content)
+	}
+	if resp.InputTokens != 9 || resp.OutputTokens != 4 {
+		t.Errorf("usage = in=%d out=%d", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+func TestOpenAIErrorResponse(t *testing.T) {
+	const body = `{"error":{"message":"invalid api key","type":"invalid_request_error","code":"invalid_api_key"}}`
+	_, h := captureHandler(t, 401, body)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid_request_error") {
+		t.Errorf("error type missing: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid api key") {
+		t.Errorf("error message missing: %v", err)
+	}
+}
+
+func TestOpenAIEmptyChoicesError(t *testing.T) {
+	const body = `{"choices": [], "usage": {"prompt_tokens": 0, "completion_tokens": 0}}`
+	_, h := captureHandler(t, 200, body)
+	o := newOpenAITest(t, h)
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no choices") {
+		t.Errorf("expected no-choices error, got %v", err)
+	}
+}
+
+func TestOpenAIUnknownRoleRejected(t *testing.T) {
+	o := newOpenAITest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 10,
+		Messages:  []Message{{Role: "weirdo", Content: "x"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown role") {
+		t.Errorf("expected unknown-role error, got %v", err)
+	}
+}
+
+func TestOpenAIName(t *testing.T) {
+	o := &OpenAI{}
+	if o.Name() != "openai" {
+		t.Errorf("name = %q", o.Name())
+	}
+}
+
+func TestNewOpenAIMissingKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	_, err := NewOpenAI("gpt-4o-mini")
+	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
+		t.Errorf("expected env-var error, got %v", err)
+	}
+}
+
+func TestNewOpenAIReadsEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "from-env")
+	o, err := NewOpenAI("gpt-4o-mini")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.APIKey != "from-env" {
+		t.Errorf("APIKey = %q", o.APIKey)
+	}
+}
+
+// pin httptest import in case other tests are skipped
+var _ = httptest.NewServer

--- a/internal/reddit/cache.go
+++ b/internal/reddit/cache.go
@@ -1,0 +1,109 @@
+package reddit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Cache stores per-sub Reddit responses on disk under Root/subs/{name}/,
+// with TTLs tracked in a sibling _meta.json.
+type Cache struct {
+	Root string
+	mu   sync.Mutex
+}
+
+type cacheMeta struct {
+	FetchedAt map[string]time.Time `json:"fetched_at"`
+	TTLNanos  map[string]int64     `json:"ttl_nanos"`
+}
+
+func NewCache(root string) *Cache { return &Cache{Root: root} }
+
+func (c *Cache) subDir(sub string) string  { return filepath.Join(c.Root, "subs", sub) }
+func (c *Cache) metaPath(sub string) string { return filepath.Join(c.subDir(sub), "_meta.json") }
+
+func (c *Cache) loadMeta(sub string) (*cacheMeta, error) {
+	data, err := os.ReadFile(c.metaPath(sub))
+	if errors.Is(err, os.ErrNotExist) {
+		return &cacheMeta{
+			FetchedAt: map[string]time.Time{},
+			TTLNanos:  map[string]int64{},
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read cache meta: %w", err)
+	}
+	var m cacheMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse cache meta: %w", err)
+	}
+	if m.FetchedAt == nil {
+		m.FetchedAt = map[string]time.Time{}
+	}
+	if m.TTLNanos == nil {
+		m.TTLNanos = map[string]int64{}
+	}
+	return &m, nil
+}
+
+func (c *Cache) saveMeta(sub string, m *cacheMeta) error {
+	if err := os.MkdirAll(c.subDir(sub), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache: %w", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cache meta: %w", err)
+	}
+	return os.WriteFile(c.metaPath(sub), data, 0o644)
+}
+
+// Get returns cached bytes for (sub, file). fresh==false means caller should
+// fetch — either the entry is missing or its TTL has expired.
+func (c *Cache) Get(sub, file string) (data []byte, fresh bool, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m, err := c.loadMeta(sub)
+	if err != nil {
+		return nil, false, err
+	}
+	fetchedAt, ok := m.FetchedAt[file]
+	if !ok {
+		return nil, false, nil
+	}
+	ttl := time.Duration(m.TTLNanos[file])
+	if ttl > 0 && time.Since(fetchedAt) > ttl {
+		return nil, false, nil
+	}
+	body, err := os.ReadFile(filepath.Join(c.subDir(sub), file))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read cached file: %w", err)
+	}
+	return body, true, nil
+}
+
+// Put stores bytes for (sub, file) with the given TTL.
+func (c *Cache) Put(sub, file string, data []byte, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := os.MkdirAll(c.subDir(sub), 0o755); err != nil {
+		return fmt.Errorf("mkdir cache: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(c.subDir(sub), file), data, 0o644); err != nil {
+		return fmt.Errorf("write cache file: %w", err)
+	}
+	m, err := c.loadMeta(sub)
+	if err != nil {
+		return err
+	}
+	m.FetchedAt[file] = time.Now().UTC()
+	m.TTLNanos[file] = int64(ttl)
+	return c.saveMeta(sub, m)
+}

--- a/internal/reddit/cache_test.go
+++ b/internal/reddit/cache_test.go
@@ -1,0 +1,64 @@
+package reddit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCachePutGetFresh(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "about.json", []byte(`{"x":1}`), time.Hour); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	data, fresh, err := c.Get("golang", "about.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !fresh {
+		t.Fatal("expected fresh entry")
+	}
+	if string(data) != `{"x":1}` {
+		t.Fatalf("data = %q", data)
+	}
+}
+
+func TestCacheExpired(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "hot.json", []byte(`x`), time.Millisecond); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	_, fresh, err := c.Get("golang", "hot.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh {
+		t.Fatal("expected stale entry")
+	}
+}
+
+func TestCacheMissing(t *testing.T) {
+	c := NewCache(t.TempDir())
+	_, fresh, err := c.Get("nonexistent", "file.json")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if fresh {
+		t.Fatal("expected miss")
+	}
+}
+
+func TestCacheMultipleFiles(t *testing.T) {
+	c := NewCache(t.TempDir())
+	if err := c.Put("golang", "about.json", []byte(`a`), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Put("golang", "rules.json", []byte(`r`), time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	a, _, _ := c.Get("golang", "about.json")
+	r, _, _ := c.Get("golang", "rules.json")
+	if string(a) != "a" || string(r) != "r" {
+		t.Fatalf("crosstalk: a=%q r=%q", a, r)
+	}
+}

--- a/internal/reddit/client.go
+++ b/internal/reddit/client.go
@@ -1,0 +1,203 @@
+// Package reddit is the only package that talks to Reddit. It exposes a
+// cached HTTP client with a polite User-Agent and exponential backoff.
+package reddit
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+const (
+	DefaultUserAgent = "tider/0.1 (by /u/tider28)"
+	DefaultBaseURL   = "https://www.reddit.com"
+)
+
+// Tiered TTLs as specified in the project plan.
+const (
+	TTLAbout  = 7 * 24 * time.Hour
+	TTLRules  = 7 * 24 * time.Hour
+	TTLWiki   = 7 * 24 * time.Hour
+	TTLFlairs = 7 * 24 * time.Hour
+	TTLTop    = 24 * time.Hour
+	TTLHot    = 6 * time.Hour
+)
+
+type Client struct {
+	HTTP      *http.Client
+	BaseURL   string
+	UserAgent string
+	Cache     *Cache
+	MaxRetry  int
+	BaseDelay time.Duration
+}
+
+func NewClient(cache *Cache) *Client {
+	return &Client{
+		HTTP:      &http.Client{Timeout: 30 * time.Second},
+		BaseURL:   DefaultBaseURL,
+		UserAgent: DefaultUserAgent,
+		Cache:     cache,
+		MaxRetry:  3,
+		BaseDelay: 500 * time.Millisecond,
+	}
+}
+
+// get performs a GET with exponential backoff on 429/5xx/network errors.
+// The status code is returned alongside the body so callers can soft-fail
+// on 403/404 without losing the signal.
+func (c *Client) get(ctx context.Context, path string) ([]byte, int, error) {
+	var lastStatus int
+	var lastErr error
+	for attempt := 0; attempt <= c.MaxRetry; attempt++ {
+		if attempt > 0 {
+			delay := c.BaseDelay << (attempt - 1)
+			select {
+			case <-ctx.Done():
+				return nil, lastStatus, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+path, nil)
+		if err != nil {
+			return nil, 0, fmt.Errorf("build request: %w", err)
+		}
+		req.Header.Set("User-Agent", c.UserAgent)
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			lastStatus = 0
+			lastErr = err
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		lastStatus = resp.StatusCode
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			return body, resp.StatusCode, nil
+		case resp.StatusCode == http.StatusTooManyRequests, resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+			continue
+		default:
+			return body, resp.StatusCode, fmt.Errorf("reddit %s: status %d", path, resp.StatusCode)
+		}
+	}
+	return nil, lastStatus, fmt.Errorf("reddit %s: exhausted retries: %w", path, lastErr)
+}
+
+// fetch returns cached bytes if fresh; otherwise fetches and caches.
+func (c *Client) fetch(ctx context.Context, sub, file, path string, ttl time.Duration, refresh bool) ([]byte, error) {
+	if !refresh {
+		if data, fresh, err := c.Cache.Get(sub, file); err == nil && fresh {
+			return data, nil
+		}
+	}
+	body, _, err := c.get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Cache.Put(sub, file, body, ttl); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// fetchSoft is fetch with 403/404 → (nil, nil) for endpoints that many subs
+// gate or omit (wiki rules, link flairs).
+func (c *Client) fetchSoft(ctx context.Context, sub, file, path string, ttl time.Duration, refresh bool) ([]byte, error) {
+	if !refresh {
+		if data, fresh, err := c.Cache.Get(sub, file); err == nil && fresh {
+			return data, nil
+		}
+	}
+	body, status, err := c.get(ctx, path)
+	if err != nil {
+		if status == http.StatusForbidden || status == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if err := c.Cache.Put(sub, file, body, ttl); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *Client) About(ctx context.Context, sub string, refresh bool) (types.Subreddit, error) {
+	body, err := c.fetch(ctx, sub, "about.json", "/r/"+sub+"/about.json", TTLAbout, refresh)
+	if err != nil {
+		return types.Subreddit{}, err
+	}
+	return parseAbout(body)
+}
+
+func (c *Client) Rules(ctx context.Context, sub string, refresh bool) ([]types.Rule, error) {
+	body, err := c.fetch(ctx, sub, "rules.json", "/r/"+sub+"/about/rules.json", TTLRules, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseRules(body)
+}
+
+func (c *Client) WikiRules(ctx context.Context, sub string, refresh bool) (string, error) {
+	body, err := c.fetchSoft(ctx, sub, "wiki_rules.json", "/r/"+sub+"/wiki/rules.json", TTLWiki, refresh)
+	if err != nil {
+		return "", err
+	}
+	if body == nil {
+		return "", nil
+	}
+	return parseWiki(body)
+}
+
+func (c *Client) Top(ctx context.Context, sub, period string, refresh bool) ([]types.Post, error) {
+	var file string
+	switch period {
+	case "week":
+		file = "top_week.json"
+	case "month":
+		file = "top_month.json"
+	default:
+		return nil, fmt.Errorf("unknown top period: %s", period)
+	}
+	path := "/r/" + sub + "/top.json?t=" + period + "&limit=25"
+	body, err := c.fetch(ctx, sub, file, path, TTLTop, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseListing(body)
+}
+
+func (c *Client) Hot(ctx context.Context, sub string, refresh bool) ([]types.Post, error) {
+	body, err := c.fetch(ctx, sub, "hot.json", "/r/"+sub+"/hot.json?limit=25", TTLHot, refresh)
+	if err != nil {
+		return nil, err
+	}
+	return parseListing(body)
+}
+
+func (c *Client) Flairs(ctx context.Context, sub string, refresh bool) ([]types.Flair, error) {
+	body, err := c.fetchSoft(ctx, sub, "flairs.json", "/r/"+sub+"/api/link_flair_v2.json", TTLFlairs, refresh)
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, nil
+	}
+	return parseFlairs(body)
+}
+
+// Stickies derives stickied posts from the hot listing.
+func Stickies(hot []types.Post) []types.Post {
+	var out []types.Post
+	for _, p := range hot {
+		if p.Stickied {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/reddit/client_test.go
+++ b/internal/reddit/client_test.go
@@ -1,0 +1,229 @@
+package reddit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const aboutJSON = `{"kind":"t5","data":{"display_name":"golang","subscribers":250000,"public_description":"Go community","over18":false,"url":"/r/golang/"}}`
+
+const rulesJSON = `{"rules":[{"short_name":"No spam","description":"do not spam","kind":"link","priority":0}]}`
+
+const wikiJSON = `{"data":{"content_md":"# Detailed rules\n\n* No spam"}}`
+
+const listingJSON = `{"kind":"Listing","data":{"children":[
+  {"kind":"t3","data":{"id":"abc","title":"Hello","author":"alice","score":100,"num_comments":5,"is_self":true,"selftext":"hi","stickied":false,"link_flair_text":"discussion","created_utc":1700000000.0,"permalink":"/r/golang/comments/abc/hello/","url":"https://reddit.com/r/golang/comments/abc/hello/"}},
+  {"kind":"t3","data":{"id":"def","title":"Sticky announcement","stickied":true,"created_utc":1700000100.0}}
+]}}`
+
+const flairsJSON = `[{"id":"f1","text":"discussion","text_editable":false},{"id":"f2","text":"show & tell","text_editable":false}]`
+
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient(NewCache(t.TempDir()))
+	c.BaseURL = srv.URL
+	c.MaxRetry = 2
+	c.BaseDelay = time.Millisecond
+	return c
+}
+
+func TestClientAboutCachesAndRefreshes(t *testing.T) {
+	var hits int32
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != DefaultUserAgent {
+			t.Errorf("user-agent = %q, want %q", got, DefaultUserAgent)
+		}
+		if r.URL.Path != "/r/golang/about.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(aboutJSON))
+	})
+	c := newTestClient(t, h)
+
+	sub, err := c.About(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("about: %v", err)
+	}
+	if sub.Name != "golang" || sub.Subscribers != 250000 {
+		t.Fatalf("parsed: %+v", sub)
+	}
+	// second call: cache hit, no new HTTP
+	if _, err := c.About(context.Background(), "golang", false); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("hits after cache hit = %d, want 1", got)
+	}
+	// refresh: forces fresh fetch
+	if _, err := c.About(context.Background(), "golang", true); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("hits after refresh = %d, want 2", got)
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var calls int32
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(aboutJSON))
+	})
+	c := newTestClient(t, h)
+	if _, err := c.About(context.Background(), "golang", false); err != nil {
+		t.Fatalf("about: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("calls = %d, want 3", got)
+	}
+}
+
+func TestClientRules(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/about/rules.json") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(rulesJSON))
+	})
+	c := newTestClient(t, h)
+	rules, err := c.Rules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 1 || rules[0].ShortName != "No spam" {
+		t.Fatalf("rules = %+v", rules)
+	}
+}
+
+func TestClientWikiSoftFails404(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	c := newTestClient(t, h)
+	s, err := c.WikiRules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if s != "" {
+		t.Fatalf("expected empty, got %q", s)
+	}
+}
+
+func TestClientWikiSuccess(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(wikiJSON))
+	})
+	c := newTestClient(t, h)
+	s, err := c.WikiRules(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "Detailed rules") {
+		t.Fatalf("wiki content = %q", s)
+	}
+}
+
+func TestClientFlairsSoftFails403(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if flairs != nil {
+		t.Fatalf("expected nil, got %+v", flairs)
+	}
+}
+
+func TestClientFlairsAuthEnvelope(t *testing.T) {
+	// Reddit returns 200 with a json-errors envelope when auth is required.
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"json":{"errors":[["USER_REQUIRED","Please log in to do that.",null]]}}`))
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatalf("expected soft fail, got %v", err)
+	}
+	if flairs != nil {
+		t.Fatalf("expected nil, got %+v", flairs)
+	}
+}
+
+func TestClientFlairsSuccess(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(flairsJSON))
+	})
+	c := newTestClient(t, h)
+	flairs, err := c.Flairs(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(flairs) != 2 || flairs[0].Text != "discussion" {
+		t.Fatalf("flairs = %+v", flairs)
+	}
+}
+
+func TestClientHotAndStickies(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(listingJSON))
+	})
+	c := newTestClient(t, h)
+	hot, err := c.Hot(context.Background(), "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hot) != 2 {
+		t.Fatalf("hot len = %d", len(hot))
+	}
+	stickies := Stickies(hot)
+	if len(stickies) != 1 || stickies[0].ID != "def" {
+		t.Fatalf("stickies = %+v", stickies)
+	}
+}
+
+func TestClientTopPeriodInQuery(t *testing.T) {
+	var captured string
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		_, _ = w.Write([]byte(listingJSON))
+	})
+	c := newTestClient(t, h)
+	if _, err := c.Top(context.Background(), "golang", "week", false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(captured, "t=week") {
+		t.Fatalf("query = %q, missing t=week", captured)
+	}
+}
+
+func TestClientTopUnknownPeriod(t *testing.T) {
+	c := newTestClient(t, http.NewServeMux())
+	if _, err := c.Top(context.Background(), "golang", "yearly", false); err == nil {
+		t.Fatal("expected error for unknown period")
+	}
+}
+
+func TestClientPropagatesHardError(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	c := newTestClient(t, h)
+	if _, err := c.About(context.Background(), "doesnotexist", false); err == nil {
+		t.Fatal("expected error on 404 for non-soft endpoint")
+	}
+}

--- a/internal/reddit/parse.go
+++ b/internal/reddit/parse.go
@@ -1,0 +1,101 @@
+package reddit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+type aboutResponse struct {
+	Data struct {
+		DisplayName       string `json:"display_name"`
+		Subscribers       int    `json:"subscribers"`
+		Description       string `json:"description"`
+		PublicDescription string `json:"public_description"`
+		Over18            bool   `json:"over18"`
+		URL               string `json:"url"`
+	} `json:"data"`
+}
+
+func parseAbout(data []byte) (types.Subreddit, error) {
+	var r aboutResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return types.Subreddit{}, fmt.Errorf("parse about: %w", err)
+	}
+	return types.Subreddit{
+		Name:              r.Data.DisplayName,
+		Subscribers:       r.Data.Subscribers,
+		Description:       r.Data.Description,
+		PublicDescription: r.Data.PublicDescription,
+		Over18:            r.Data.Over18,
+		URL:               r.Data.URL,
+	}, nil
+}
+
+type rulesResponse struct {
+	Rules []types.Rule `json:"rules"`
+}
+
+func parseRules(data []byte) ([]types.Rule, error) {
+	var r rulesResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse rules: %w", err)
+	}
+	if r.Rules == nil {
+		return []types.Rule{}, nil
+	}
+	return r.Rules, nil
+}
+
+type wikiResponse struct {
+	Data struct {
+		ContentMD string `json:"content_md"`
+	} `json:"data"`
+}
+
+func parseWiki(data []byte) (string, error) {
+	var r wikiResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return "", fmt.Errorf("parse wiki: %w", err)
+	}
+	return r.Data.ContentMD, nil
+}
+
+type listingResponse struct {
+	Data struct {
+		Children []struct {
+			Data types.Post `json:"data"`
+		} `json:"children"`
+	} `json:"data"`
+}
+
+func parseListing(data []byte) ([]types.Post, error) {
+	var r listingResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse listing: %w", err)
+	}
+	out := make([]types.Post, 0, len(r.Data.Children))
+	for _, c := range r.Data.Children {
+		out = append(out, c.Data)
+	}
+	return out, nil
+}
+
+// parseFlairs accepts the array Reddit returns on success and treats the
+// `{"json":{"errors":[["USER_REQUIRED",...]]}}` envelope (200 with error
+// payload, returned when the endpoint requires auth) as soft-fail → nil.
+func parseFlairs(data []byte) ([]types.Flair, error) {
+	var probe any
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("parse flairs: %w", err)
+	}
+	if _, ok := probe.([]any); !ok {
+		return nil, nil
+	}
+	var r []types.Flair
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse flairs: %w", err)
+	}
+	return r, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,78 @@
+// Package types holds the shared domain types used across tider packages.
+package types
+
+import "time"
+
+type Subreddit struct {
+	Name              string `json:"name"`
+	Subscribers       int    `json:"subscribers"`
+	Description       string `json:"description,omitempty"`
+	PublicDescription string `json:"public_description,omitempty"`
+	Over18            bool   `json:"over_18"`
+	URL               string `json:"url,omitempty"`
+}
+
+type Rule struct {
+	ShortName   string `json:"short_name"`
+	Description string `json:"description"`
+	Kind        string `json:"kind,omitempty"`
+	Priority    int    `json:"priority"`
+}
+
+type Post struct {
+	ID            string  `json:"id"`
+	Title         string  `json:"title"`
+	Author        string  `json:"author,omitempty"`
+	Score         int     `json:"score"`
+	NumComments   int     `json:"num_comments"`
+	URL           string  `json:"url,omitempty"`
+	Permalink     string  `json:"permalink,omitempty"`
+	Selftext      string  `json:"selftext,omitempty"`
+	IsSelf        bool    `json:"is_self"`
+	Stickied      bool    `json:"stickied"`
+	LinkFlairText string  `json:"link_flair_text,omitempty"`
+	CreatedUTC    float64 `json:"created_utc"`
+}
+
+type Flair struct {
+	ID           string `json:"id"`
+	Text         string `json:"text"`
+	TextEditable bool   `json:"text_editable"`
+}
+
+// SubNotes is the curated knowledge layer for a single subreddit, loaded
+// from subreddits.yaml. All fields are optional; free-form Notes is the
+// catch-all for observations that don't fit a structured field.
+type SubNotes struct {
+	Name               string     `yaml:"name" json:"name"`
+	Tone               string     `yaml:"tone,omitempty" json:"tone,omitempty"`
+	SelfPromoTolerance string     `yaml:"self_promo_tolerance,omitempty" json:"self_promo_tolerance,omitempty"`
+	FormatPreferences  []string   `yaml:"format_preferences,omitempty" json:"format_preferences,omitempty"`
+	Flair              FlairNotes `yaml:"flair" json:"flair"`
+	DoNot              []string   `yaml:"do_not,omitempty" json:"do_not,omitempty"`
+	Notes              string     `yaml:"notes,omitempty" json:"notes,omitempty"`
+	ExemplarURLs       []string   `yaml:"exemplar_urls,omitempty" json:"exemplar_urls,omitempty"`
+}
+
+type FlairNotes struct {
+	Required bool     `yaml:"required" json:"required"`
+	Common   []string `yaml:"common,omitempty" json:"common,omitempty"`
+}
+
+type SubsConfig struct {
+	Subs []SubNotes `yaml:"subs"`
+}
+
+// Research is the assembled per-sub bundle: live Reddit data + curated notes.
+type Research struct {
+	Sub       Subreddit `json:"sub"`
+	Notes     *SubNotes `json:"notes,omitempty"`
+	Rules     []Rule    `json:"rules"`
+	WikiRules string    `json:"wiki_rules,omitempty"`
+	TopWeek   []Post    `json:"top_week"`
+	TopMonth  []Post    `json:"top_month"`
+	Hot       []Post    `json:"hot"`
+	Stickies  []Post    `json:"stickies"`
+	Flairs    []Flair   `json:"flairs"`
+	Generated time.Time `json:"generated"`
+}

--- a/research/notes.go
+++ b/research/notes.go
@@ -1,0 +1,42 @@
+package research
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// LoadNotes reads subreddits.yaml from path. A missing file returns (nil, nil)
+// — the curated layer is optional.
+func LoadNotes(path string) (*types.SubsConfig, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read subreddits.yaml: %w", err)
+	}
+	var cfg types.SubsConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse subreddits.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// FindSub returns the curated notes for sub (case-insensitive), or nil.
+func FindSub(cfg *types.SubsConfig, sub string) *types.SubNotes {
+	if cfg == nil {
+		return nil
+	}
+	for i := range cfg.Subs {
+		if strings.EqualFold(cfg.Subs[i].Name, sub) {
+			return &cfg.Subs[i]
+		}
+	}
+	return nil
+}

--- a/research/research.go
+++ b/research/research.go
@@ -1,0 +1,67 @@
+// Package research assembles per-subreddit research bundles by combining
+// curated notes (subreddits.yaml) with live (cached) Reddit data.
+package research
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/viggy28/tider/internal/reddit"
+	"github.com/viggy28/tider/internal/types"
+)
+
+// Fetcher is the subset of reddit.Client that research depends on.
+// Defining it here keeps research/ free of HTTP/cache plumbing in tests.
+type Fetcher interface {
+	About(ctx context.Context, sub string, refresh bool) (types.Subreddit, error)
+	Rules(ctx context.Context, sub string, refresh bool) ([]types.Rule, error)
+	WikiRules(ctx context.Context, sub string, refresh bool) (string, error)
+	Top(ctx context.Context, sub, period string, refresh bool) ([]types.Post, error)
+	Hot(ctx context.Context, sub string, refresh bool) ([]types.Post, error)
+	Flairs(ctx context.Context, sub string, refresh bool) ([]types.Flair, error)
+}
+
+// For assembles a Research bundle for sub.
+func For(ctx context.Context, f Fetcher, notes *types.SubsConfig, sub string, refresh bool) (*types.Research, error) {
+	about, err := f.About(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("about: %w", err)
+	}
+	rules, err := f.Rules(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("rules: %w", err)
+	}
+	wiki, err := f.WikiRules(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("wiki rules: %w", err)
+	}
+	topW, err := f.Top(ctx, sub, "week", refresh)
+	if err != nil {
+		return nil, fmt.Errorf("top week: %w", err)
+	}
+	topM, err := f.Top(ctx, sub, "month", refresh)
+	if err != nil {
+		return nil, fmt.Errorf("top month: %w", err)
+	}
+	hot, err := f.Hot(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("hot: %w", err)
+	}
+	flairs, err := f.Flairs(ctx, sub, refresh)
+	if err != nil {
+		return nil, fmt.Errorf("flairs: %w", err)
+	}
+	return &types.Research{
+		Sub:       about,
+		Notes:     FindSub(notes, sub),
+		Rules:     rules,
+		WikiRules: wiki,
+		TopWeek:   topW,
+		TopMonth:  topM,
+		Hot:       hot,
+		Stickies:  reddit.Stickies(hot),
+		Flairs:    flairs,
+		Generated: time.Now().UTC(),
+	}, nil
+}

--- a/research/research_test.go
+++ b/research/research_test.go
@@ -1,0 +1,116 @@
+package research
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+type fakeFetcher struct {
+	about  types.Subreddit
+	rules  []types.Rule
+	wiki   string
+	topW   []types.Post
+	topM   []types.Post
+	hot    []types.Post
+	flairs []types.Flair
+}
+
+func (f *fakeFetcher) About(_ context.Context, _ string, _ bool) (types.Subreddit, error) {
+	return f.about, nil
+}
+func (f *fakeFetcher) Rules(_ context.Context, _ string, _ bool) ([]types.Rule, error) {
+	return f.rules, nil
+}
+func (f *fakeFetcher) WikiRules(_ context.Context, _ string, _ bool) (string, error) {
+	return f.wiki, nil
+}
+func (f *fakeFetcher) Top(_ context.Context, _, period string, _ bool) ([]types.Post, error) {
+	if period == "week" {
+		return f.topW, nil
+	}
+	return f.topM, nil
+}
+func (f *fakeFetcher) Hot(_ context.Context, _ string, _ bool) ([]types.Post, error) {
+	return f.hot, nil
+}
+func (f *fakeFetcher) Flairs(_ context.Context, _ string, _ bool) ([]types.Flair, error) {
+	return f.flairs, nil
+}
+
+func TestForAssemblesBundle(t *testing.T) {
+	f := &fakeFetcher{
+		about:  types.Subreddit{Name: "golang", Subscribers: 250000},
+		rules:  []types.Rule{{ShortName: "No spam"}},
+		wiki:   "Detailed rules",
+		topW:   []types.Post{{ID: "a"}},
+		topM:   []types.Post{{ID: "b"}},
+		hot:    []types.Post{{ID: "c", Stickied: true}, {ID: "d", Stickied: false}},
+		flairs: []types.Flair{{ID: "f1", Text: "discussion"}},
+	}
+	notes := &types.SubsConfig{Subs: []types.SubNotes{{Name: "golang", Tone: "terse"}}}
+
+	r, err := For(context.Background(), f, notes, "golang", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Sub.Name != "golang" {
+		t.Fatalf("sub: %+v", r.Sub)
+	}
+	if r.Notes == nil || r.Notes.Tone != "terse" {
+		t.Fatalf("notes: %+v", r.Notes)
+	}
+	if len(r.Stickies) != 1 || r.Stickies[0].ID != "c" {
+		t.Fatalf("stickies: %+v", r.Stickies)
+	}
+	if r.WikiRules != "Detailed rules" {
+		t.Fatalf("wiki: %q", r.WikiRules)
+	}
+	if r.Generated.IsZero() {
+		t.Fatal("generated not set")
+	}
+}
+
+func TestForNotesAbsent(t *testing.T) {
+	f := &fakeFetcher{about: types.Subreddit{Name: "obscuresub"}}
+	r, err := For(context.Background(), f, nil, "obscuresub", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Notes != nil {
+		t.Fatalf("expected nil notes, got %+v", r.Notes)
+	}
+}
+
+func TestLoadNotesMissing(t *testing.T) {
+	cfg, err := LoadNotes(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil cfg, got %+v", cfg)
+	}
+}
+
+func TestLoadNotesParse(t *testing.T) {
+	cfg, err := LoadNotes("testdata/subreddits.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg == nil || len(cfg.Subs) != 2 {
+		t.Fatalf("cfg: %+v", cfg)
+	}
+	g := FindSub(cfg, "golang")
+	if g == nil || g.Tone == "" || !g.Flair.Required {
+		t.Fatalf("golang notes: %+v", g)
+	}
+	// case-insensitive match
+	if FindSub(cfg, "POSTGRESQL") == nil {
+		t.Fatal("case-insensitive lookup failed")
+	}
+	if FindSub(cfg, "doesnotexist") != nil {
+		t.Fatal("expected nil for unknown sub")
+	}
+}

--- a/research/testdata/subreddits.yaml
+++ b/research/testdata/subreddits.yaml
@@ -1,0 +1,23 @@
+subs:
+  - name: golang
+    tone: "technical, terse, hype-allergic"
+    self_promo_tolerance: low
+    format_preferences:
+      - "self-posts > link posts"
+      - "code blocks expected for technical claims"
+    flair:
+      required: true
+      common: ["discussion", "show & tell"]
+    do_not:
+      - "no 'I built X' show-offs without code"
+    notes: |
+      Mods are active. Showcase posts without substance get removed.
+    exemplar_urls: []
+  - name: PostgreSQL
+    tone: "engineering-focused"
+    self_promo_tolerance: medium
+    flair:
+      required: false
+      common: []
+    notes: |
+      Smaller community. Goes deep on internals.


### PR DESCRIPTION
Stacked on #1.

## Summary
- `internal/llm/Provider` interface with `Complete(ctx, Request) → Response`.
- Anthropic and OpenAI implementations talking to `/v1/messages` and `/v1/chat/completions` over stdlib `net/http`.
- JSON mode handled idiomatically: OpenAI sets `response_format: json_object`; Anthropic appends a system-message nudge (tool-use enforcement is a future upgrade when callers need a strict schema).
- Factory (`New`, `ForTask`) routes config → provider, with per-task override fallback. API keys from env vars only — `Config` never holds keys, only the env-var names are baked in via the constructors.

## Deviation from plan worth flagging
Plan listed the official Anthropic and OpenAI Go SDKs as deps; this PR uses stdlib HTTP instead. The Provider interface is what callers see, so swapping to SDKs later is mechanical. Reasoning:
- Both HTTP APIs are simple, versioned, and stable — Anthropic via the `anthropic-version` header.
- stdlib lets us point `BaseURL` at `httptest.NewServer` for clean unit tests; SDKs add a layer of option-plumbing.
- Avoids SDK API churn (the Anthropic Go SDK has been redesigned more than once).
- Lighter dep tree; `go.mod` stays minimal.

Happy to swap if you'd rather keep the SDK dep. The Provider abstraction insulates everything downstream.

## Test plan

**Offline (default `go test ./...`)** — 31 cases pass:
- [x] Headers + path correct (`x-api-key` + `anthropic-version` for Anthropic, `Authorization: Bearer` for OpenAI).
- [x] Request body shape: model, max_tokens / max_completion_tokens, temperature, system extraction (Anthropic), message ordering preserved.
- [x] Multiple system messages joined with `\n\n` for Anthropic.
- [x] JSON mode: Anthropic appends instruction without dropping the original system; OpenAI sets `response_format` only when enabled; OpenAI omits `response_format` and `temperature` when not requested.
- [x] Response parsing: content + token usage; multiple text blocks concatenated for Anthropic; non-text blocks ignored.
- [x] Error responses: structured error envelopes (`{type, message}` for Anthropic, `{error: {message, type, code}}` for OpenAI) surface message + type in the returned error.
- [x] OpenAI empty `choices` returns clear error.
- [x] Validation: model required, MaxTokens required (Anthropic), unknown roles rejected.
- [x] Factory: routes anthropic/openai, errors on empty/unknown provider, propagates missing-API-key error, ForTask override + fallback + nil-map safe.
- [x] Env-var loading: `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` required; constructors error cleanly when missing.

**Live (gated)** — `TIDER_LIVE_LLM=1 ANTHROPIC_API_KEY=... OPENAI_API_KEY=... go test -v ./internal/llm/ -run Live`:
- [ ] `TestLiveAnthropic` — \"Reply with: ok\" against `claude-haiku-4-5` (override via `TIDER_LIVE_ANTHROPIC_MODEL`).
- [ ] `TestLiveAnthropicJSONMode` — verifies the nudge produces JSON.
- [ ] `TestLiveOpenAI` — same against `gpt-4o-mini` (override via `TIDER_LIVE_OPENAI_MODEL`).
- [ ] `TestLiveOpenAIJSONMode` — verifies `response_format` is honored.

I couldn't run live tests in this session (no keys in env). Worth running once locally to validate the full path before step 3 lands.

## Out of scope (deferred)
- Retry/backoff on 429/5xx (mirror what `internal/reddit/` does — easy add when call volume justifies it).
- Tool-use-based JSON enforcement for Anthropic (only matters when draft generation needs strict schema validation).
- Streaming responses.
- Full viper-based config loading (this PR ships a minimal `Config` struct; the loader is a separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)