### PR TITLE
step 4: draft (multi-provider fan-out, JSON + markdown)

### DIFF
--- a/cmd/tider/draft.go
+++ b/cmd/tider/draft.go
@@ -179,7 +179,7 @@ func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]dra
 func init() {
 	draftCmd.Flags().StringVar(&draftBriefPath, "brief", "", "path to a brief.json (output of `tider intake`)")
 	draftCmd.Flags().StringVar(&draftSub, "sub", "", "subreddit name to draft for (e.g., golang)")
-	draftCmd.Flags().StringVar(&draftProviders, "providers", "anthropic,openai", "comma-separated providers to fan out across")
+	draftCmd.Flags().StringVar(&draftProviders, "providers", "openai,anthropic", "comma-separated providers to fan out across")
 	draftCmd.Flags().StringVar(&draftAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
 	draftCmd.Flags().StringVar(&draftOpenAI, "openai-model", "gpt-5", "OpenAI model to use")
 	draftCmd.Flags().StringVar(&draftRender, "render", "json", "output format: json | markdown")

--- a/cmd/tider/draft.go
+++ b/cmd/tider/draft.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/draft"
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/reddit"
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/research"
+)
+
+var (
+	draftBriefPath  string
+	draftSub        string
+	draftProviders  string
+	draftAnthropic  string
+	draftOpenAI     string
+	draftRender     string
+	draftDryRun     bool
+	draftRefresh    bool
+	draftNotesPath  string
+	draftCacheRoot  string
+	draftMaxTokens  int
+	draftVariantSet string
+)
+
+var draftCmd = &cobra.Command{
+	Use:   "draft",
+	Short: "Generate drafts (fan-out across providers) for a Brief on one subreddit",
+	Long: `draft turns a Brief + per-sub research into structured Drafts. By default
+it fans out across both Anthropic and OpenAI concurrently so you can
+compare framings side-by-side.
+
+  tider draft --brief=brief.json --sub=golang
+  tider draft --brief=brief.json --sub=PostgreSQL --providers=anthropic
+  tider draft --brief=brief.json --sub=golang --render=markdown
+  tider draft --brief=brief.json --sub=golang --dry-run    # show prompt only
+
+API keys come from env vars: ANTHROPIC_API_KEY, OPENAI_API_KEY. Providers
+without a key are skipped with a warning rather than failing the run.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if draftBriefPath == "" || draftSub == "" {
+			return errors.New("--brief and --sub are required")
+		}
+		brief, err := loadBrief(draftBriefPath)
+		if err != nil {
+			return err
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		cacheRoot := draftCacheRoot
+		if cacheRoot == "" {
+			cacheRoot = filepath.Join(home, ".tider", "cache")
+		}
+		notesPath := draftNotesPath
+		if notesPath == "" {
+			notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
+		}
+
+		notes, err := research.LoadNotes(notesPath)
+		if err != nil {
+			return err
+		}
+		client := reddit.NewClient(reddit.NewCache(cacheRoot))
+		ctx := context.Background()
+		researchBundle, err := research.For(ctx, client, notes, draftSub, draftRefresh)
+		if err != nil {
+			return fmt.Errorf("research %s: %w", draftSub, err)
+		}
+
+		opts := draft.Default()
+		if draftVariantSet == "full" {
+			opts = draft.Full()
+		}
+		if draftMaxTokens > 0 {
+			opts.MaxTokens = draftMaxTokens
+		}
+
+		if draftDryRun {
+			prompt, err := draft.RenderPrompt(*brief, *researchBundle, opts)
+			if err != nil {
+				return err
+			}
+			fmt.Println(prompt)
+			return nil
+		}
+
+		refs, err := buildProviderRefs(draftProviders, draftAnthropic, draftOpenAI)
+		if err != nil {
+			return err
+		}
+		if len(refs) == 0 {
+			return errors.New("no usable providers — set ANTHROPIC_API_KEY and/or OPENAI_API_KEY")
+		}
+
+		bundle, err := draft.Generate(ctx, refs, *brief, *researchBundle, opts)
+		if err != nil {
+			return err
+		}
+
+		switch draftRender {
+		case "markdown":
+			fmt.Print(draft.RenderMarkdown(bundle))
+		case "json", "":
+			out, err := json.MarshalIndent(bundle, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+		default:
+			return fmt.Errorf("unknown --render value: %s (use json or markdown)", draftRender)
+		}
+		return nil
+	},
+}
+
+func loadBrief(path string) (*types.Brief, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read brief: %w", err)
+	}
+	var b types.Brief
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("parse brief: %w", err)
+	}
+	if b.Title == "" {
+		return nil, errors.New("brief has no title — is this a real Brief JSON?")
+	}
+	return &b, nil
+}
+
+// buildProviderRefs constructs the list of providers to fan out across.
+// providersFlag is comma-separated ("anthropic,openai"). Each requested
+// provider needs its API key in the environment; missing keys cause that
+// provider to be silently skipped (with a stderr warning) rather than
+// failing the whole run, so a working provider isn't blocked by a missing
+// key for the other.
+func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]draft.ProviderRef, error) {
+	want := strings.Split(providersFlag, ",")
+	var refs []draft.ProviderRef
+	for _, name := range want {
+		name = strings.TrimSpace(name)
+		switch name {
+		case "anthropic":
+			p, err := llm.NewAnthropic(anthropicModel)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "skipping anthropic: %v\n", err)
+				continue
+			}
+			refs = append(refs, draft.ProviderRef{Provider: p, Model: anthropicModel})
+		case "openai":
+			p, err := llm.NewOpenAI(openaiModel)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "skipping openai: %v\n", err)
+				continue
+			}
+			refs = append(refs, draft.ProviderRef{Provider: p, Model: openaiModel})
+		case "":
+			// trailing comma; ignore
+		default:
+			return nil, fmt.Errorf("unknown provider %q (supported: anthropic, openai)", name)
+		}
+	}
+	return refs, nil
+}
+
+func init() {
+	draftCmd.Flags().StringVar(&draftBriefPath, "brief", "", "path to a brief.json (output of `tider intake`)")
+	draftCmd.Flags().StringVar(&draftSub, "sub", "", "subreddit name to draft for (e.g., golang)")
+	draftCmd.Flags().StringVar(&draftProviders, "providers", "anthropic,openai", "comma-separated providers to fan out across")
+	draftCmd.Flags().StringVar(&draftAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
+	draftCmd.Flags().StringVar(&draftOpenAI, "openai-model", "gpt-5", "OpenAI model to use")
+	draftCmd.Flags().StringVar(&draftRender, "render", "json", "output format: json | markdown")
+	draftCmd.Flags().BoolVar(&draftDryRun, "dry-run", false, "render the prompt only, do not call the LLM")
+	draftCmd.Flags().BoolVar(&draftRefresh, "refresh", false, "force fresh Reddit fetch, bypass cache")
+	draftCmd.Flags().StringVar(&draftNotesPath, "notes", "", "path to subreddits.yaml (default ~/.tider/subreddits.yaml)")
+	draftCmd.Flags().StringVar(&draftCacheRoot, "cache", "", "Reddit cache root dir (default ~/.tider/cache)")
+	draftCmd.Flags().IntVar(&draftMaxTokens, "max-tokens", 0, "LLM completion budget; 0 uses variant default")
+	draftCmd.Flags().StringVar(&draftVariantSet, "variants", "default", "variant set: default (2×3×2) | full (3×5×3)")
+}

--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -67,7 +67,7 @@ API key for the chosen provider must be set in the environment
 func init() {
 	intakeCmd.Flags().StringVar(&intakeURL, "url", "", "URL to a blog post or GitHub repo")
 	intakeCmd.Flags().StringVar(&intakeFile, "file", "", "path to a markdown brief")
-	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "anthropic", "LLM provider: anthropic | openai")
-	intakeCmd.Flags().StringVar(&intakeModel, "model", "claude-sonnet-4-7", "LLM model name")
-	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget; 0 uses package default (2048). Bump for reasoning models.")
+	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "openai", "LLM provider: anthropic | openai")
+	intakeCmd.Flags().StringVar(&intakeModel, "model", "gpt-5", "LLM model name")
+	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget; 0 uses package default (8192).")
 }

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -18,6 +18,7 @@ post manually. No auth, no posting, no commenting — by design.`,
 func main() {
 	rootCmd.AddCommand(researchCmd)
 	rootCmd.AddCommand(intakeCmd)
+	rootCmd.AddCommand(draftCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/draft/draft.go
+++ b/draft/draft.go
@@ -1,0 +1,192 @@
+// Package draft turns a Brief + Research into per-provider Drafts so the
+// user can compare framings side-by-side before posting.
+package draft
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/prompts"
+)
+
+var draftTmpl = template.Must(template.ParseFS(prompts.FS, "draft.tmpl"))
+
+// Options control variant counts and the LLM token budget.
+type Options struct {
+	AngleCount     int
+	TitlesPerAngle int
+	BodiesPerAngle int
+	MaxTokens      int
+}
+
+// Default is the spec's "2 angles × 3 titles × 2 bodies" — ~12 artifacts.
+func Default() Options {
+	return Options{
+		AngleCount:     2,
+		TitlesPerAngle: 3,
+		BodiesPerAngle: 2,
+		MaxTokens:      4096,
+	}
+}
+
+// Full is the wider "3 × 5 × 3" spread for when the user wants more options.
+func Full() Options {
+	return Options{
+		AngleCount:     3,
+		TitlesPerAngle: 5,
+		BodiesPerAngle: 3,
+		MaxTokens:      8192,
+	}
+}
+
+// ProviderRef pairs a Provider with the model name to record in output.
+// Model is reported back in the Draft so the user knows which model
+// produced which framing.
+type ProviderRef struct {
+	Provider llm.Provider
+	Model    string
+}
+
+// RenderPrompt produces the user-facing prompt the LLM will see. Exposed
+// so `--dry-run` can print it without burning a real API call.
+func RenderPrompt(brief types.Brief, research types.Research, opts Options) (string, error) {
+	if opts.AngleCount <= 0 || opts.TitlesPerAngle <= 0 || opts.BodiesPerAngle <= 0 {
+		return "", fmt.Errorf("draft: variant counts must be > 0")
+	}
+	var buf bytes.Buffer
+	err := draftTmpl.Execute(&buf, struct {
+		SubName        string
+		Subscribers    int
+		CuratedNotes   *types.SubNotes
+		Rules          []types.Rule
+		TopWeek        []types.Post
+		TopMonth       []types.Post
+		Hot            []types.Post
+		Stickies       []types.Post
+		Flairs         []types.Flair
+		Brief          types.Brief
+		AngleCount     int
+		TitlesPerAngle int
+		BodiesPerAngle int
+	}{
+		SubName:        research.Sub.Name,
+		Subscribers:    research.Sub.Subscribers,
+		CuratedNotes:   research.Notes,
+		Rules:          research.Rules,
+		TopWeek:        research.TopWeek,
+		TopMonth:       research.TopMonth,
+		Hot:            research.Hot,
+		Stickies:       research.Stickies,
+		Flairs:         research.Flairs,
+		Brief:          brief,
+		AngleCount:     opts.AngleCount,
+		TitlesPerAngle: opts.TitlesPerAngle,
+		BodiesPerAngle: opts.BodiesPerAngle,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render draft prompt: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// Generate fans out across providers concurrently and returns the bundle.
+// Per-provider errors are recorded on the Draft (not propagated) so a
+// transient failure in one provider doesn't kill the whole comparison.
+func Generate(ctx context.Context, refs []ProviderRef, brief types.Brief, research types.Research, opts Options) (*types.DraftBundle, error) {
+	if len(refs) == 0 {
+		return nil, errors.New("draft: at least one provider required")
+	}
+	prompt, err := RenderPrompt(brief, research, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	drafts := make([]types.Draft, len(refs))
+	var wg sync.WaitGroup
+	for i, ref := range refs {
+		wg.Add(1)
+		go func(i int, ref ProviderRef) {
+			defer wg.Done()
+			drafts[i] = generateOne(ctx, ref, research.Sub.Name, prompt, opts.MaxTokens)
+		}(i, ref)
+	}
+	wg.Wait()
+
+	return &types.DraftBundle{
+		Sub:       research.Sub.Name,
+		Brief:     brief,
+		Drafts:    drafts,
+		Generated: time.Now().UTC(),
+	}, nil
+}
+
+func generateOne(ctx context.Context, ref ProviderRef, sub, prompt string, maxTokens int) types.Draft {
+	d := types.Draft{
+		Sub:       sub,
+		Provider:  ref.Provider.Name(),
+		Model:     ref.Model,
+		Generated: time.Now().UTC(),
+	}
+	resp, err := ref.Provider.Complete(ctx, llm.Request{
+		Model:     ref.Model,
+		MaxTokens: maxTokens,
+		JSONMode:  true,
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: prompt}},
+	})
+	if err != nil {
+		d.Error = err.Error()
+		return d
+	}
+	d.InputTokens = resp.InputTokens
+	d.OutputTokens = resp.OutputTokens
+	if err := parseInto(&d, resp.Content); err != nil {
+		d.Error = err.Error()
+	}
+	return d
+}
+
+// parseInto unmarshals the LLM JSON into d, preserving Provider/Model/etc.
+// fields already set on the struct. Strict on shape but tolerant on extras.
+func parseInto(d *types.Draft, raw string) error {
+	if raw == "" {
+		return errors.New("empty response")
+	}
+	var payload struct {
+		Risk                string                `json:"risk"`
+		RiskReason          string                `json:"risk_reason"`
+		Angles              []types.Angle         `json:"angles"`
+		Recommendation      types.Recommendation  `json:"recommendation"`
+		Flair               types.FlairRec        `json:"flair"`
+		SuggestedWindow     string                `json:"suggested_window"`
+		MediaRecommendation string                `json:"media_recommendation"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return fmt.Errorf("parse draft json: %w (model returned: %q)", err, truncate(raw, 200))
+	}
+	if payload.Risk == "" {
+		return errors.New("draft missing required field: risk")
+	}
+	d.Risk = payload.Risk
+	d.RiskReason = payload.RiskReason
+	d.Angles = payload.Angles
+	d.Recommendation = payload.Recommendation
+	d.Flair = payload.Flair
+	d.SuggestedWindow = payload.SuggestedWindow
+	d.MediaRecommendation = payload.MediaRecommendation
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/draft/draft.go
+++ b/draft/draft.go
@@ -28,22 +28,25 @@ type Options struct {
 }
 
 // Default is the spec's "2 angles × 3 titles × 2 bodies" — ~12 artifacts.
+// MaxTokens sized for reasoning models (gpt-5, o-series): real-run usage
+// has been ~5K output tokens, so 10K leaves headroom for reasoning.
 func Default() Options {
 	return Options{
 		AngleCount:     2,
 		TitlesPerAngle: 3,
 		BodiesPerAngle: 2,
-		MaxTokens:      4096,
+		MaxTokens:      10000,
 	}
 }
 
-// Full is the wider "3 × 5 × 3" spread for when the user wants more options.
+// Full is the wider "3 × 5 × 3" spread — ~33 artifacts. Bump max tokens
+// proportionally.
 func Full() Options {
 	return Options{
 		AngleCount:     3,
 		TitlesPerAngle: 5,
 		BodiesPerAngle: 3,
-		MaxTokens:      8192,
+		MaxTokens:      16384,
 	}
 }
 

--- a/draft/draft_test.go
+++ b/draft/draft_test.go
@@ -1,0 +1,303 @@
+package draft
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+)
+
+// fakeProvider returns a canned response and records the request it saw.
+type fakeProvider struct {
+	name     string
+	response string
+	err      error
+	delay    time.Duration
+	calls    int32
+	gotReq   llm.Request
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+
+func (f *fakeProvider) Complete(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	atomic.AddInt32(&f.calls, 1)
+	f.gotReq = req
+	if f.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(f.delay):
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &llm.Response{Content: f.response, InputTokens: 100, OutputTokens: 200}, nil
+}
+
+const cannedDraftJSON = `{
+  "risk": "low",
+  "angles": [
+    {
+      "id": 1,
+      "premise": "war story about WAL ordering",
+      "hook": "what surprised me about logical replication",
+      "titles": [
+        {"id": "1.1", "text": "WAL ordering bit me; here's what I missed"},
+        {"id": "1.2", "text": "Logical replication: the gotcha I wish I'd known"},
+        {"id": "1.3", "text": "Three weeks lost to one WAL ordering assumption"}
+      ],
+      "bodies": [
+        {"id": "1.1", "text": "Spent two sprints assuming...", "tags": ["opener:war-story", "close:invite-stories"]},
+        {"id": "1.2", "text": "Quick one for folks running logical replication...", "tags": ["opener:question"]}
+      ]
+    },
+    {
+      "id": 2,
+      "premise": "technical comparison vs Debezium",
+      "hook": "what we got from going single-binary",
+      "titles": [
+        {"id": "2.1", "text": "Single-binary CDC: tradeoffs vs Debezium"},
+        {"id": "2.2", "text": "Why we built our own CDC instead of using Debezium"},
+        {"id": "2.3", "text": "Debezium served us well; here's why we replaced it"}
+      ],
+      "bodies": [
+        {"id": "2.1", "text": "We ran Debezium for 18 months...", "tags": ["opener:context", "hook:contrarian"]},
+        {"id": "2.2", "text": "Cards on the table — Debezium does X well...", "tags": ["opener:disclosure"]}
+      ]
+    }
+  ],
+  "recommendation": {
+    "angle_id": 1,
+    "title_id": "1.3",
+    "body_id": "1.1",
+    "reasoning": "war stories outperform feature pitches in this sub"
+  },
+  "flair": {"required": true, "suggested": "discussion"},
+  "suggested_window": "Tue-Thu 9-11am ET",
+  "media_recommendation": ""
+}`
+
+func sampleBrief() types.Brief {
+	return types.Brief{
+		Source:     types.BriefSource{Mode: "url", Value: "https://example.com"},
+		Title:      "Streambed",
+		Summary:    "WAL-native CDC for Postgres.",
+		Highlights: []string{"Single binary", "Postgres wire protocol"},
+		Audience:   "Postgres teams",
+		CreatedAt:  time.Now().UTC(),
+	}
+}
+
+func sampleResearch() types.Research {
+	return types.Research{
+		Sub:   types.Subreddit{Name: "golang", Subscribers: 250000},
+		Notes: &types.SubNotes{Name: "golang", Tone: "terse, hype-allergic", SelfPromoTolerance: "low"},
+		Rules: []types.Rule{{ShortName: "No spam", Description: "do not spam"}},
+		TopWeek: []types.Post{
+			{Title: "Some discussion post", Score: 500, NumComments: 80, LinkFlairText: "discussion"},
+		},
+		Hot: []types.Post{
+			{Title: "What's hot now", Score: 200, NumComments: 30},
+		},
+		Generated: time.Now().UTC(),
+	}
+}
+
+func TestRenderPromptIncludesContextAndCounts(t *testing.T) {
+	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSubstrings := []string{
+		"r/golang",                  // sub header
+		"Some discussion post",      // top post leaked in
+		"terse, hype-allergic",      // curated notes leaked in
+		"Streambed",                 // brief title
+		"Postgres wire protocol",    // highlight
+		"2 *distinct* angles",       // variant count
+		"3 candidate titles",        // titles per angle
+		"2 candidate bodies",        // bodies per angle
+		"Anti-tells",                // anti-tells section present
+		"\"risk\":",                 // output schema present
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing %q", s)
+		}
+	}
+}
+
+func TestRenderPromptRejectsZeroCounts(t *testing.T) {
+	_, err := RenderPrompt(sampleBrief(), sampleResearch(), Options{AngleCount: 0, TitlesPerAngle: 3, BodiesPerAngle: 2})
+	if err == nil {
+		t.Fatal("expected error for zero AngleCount")
+	}
+}
+
+func TestGenerateFanOutAcrossProviders(t *testing.T) {
+	a := &fakeProvider{name: "anthropic", response: cannedDraftJSON, delay: 50 * time.Millisecond}
+	b := &fakeProvider{name: "openai", response: cannedDraftJSON, delay: 50 * time.Millisecond}
+
+	start := time.Now()
+	bundle, err := Generate(context.Background(), []ProviderRef{
+		{Provider: a, Model: "claude-sonnet-4-7"},
+		{Provider: b, Model: "gpt-5"},
+	}, sampleBrief(), sampleResearch(), Default())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sequential would be >= 100ms. Concurrent should land closer to 50ms.
+	// Allow some slack for test machine variability but require it's clearly under sequential.
+	if elapsed > 90*time.Millisecond {
+		t.Errorf("fan-out not concurrent: elapsed = %v (want < 90ms)", elapsed)
+	}
+
+	if bundle.Sub != "golang" {
+		t.Errorf("sub = %q", bundle.Sub)
+	}
+	if len(bundle.Drafts) != 2 {
+		t.Fatalf("drafts len = %d", len(bundle.Drafts))
+	}
+	gotProviders := map[string]string{}
+	for _, d := range bundle.Drafts {
+		gotProviders[d.Provider] = d.Model
+		if d.Error != "" {
+			t.Errorf("draft from %s errored: %s", d.Provider, d.Error)
+		}
+		if d.Risk != "low" {
+			t.Errorf("risk = %q (parse failed?)", d.Risk)
+		}
+		if len(d.Angles) != 2 {
+			t.Errorf("angles = %d", len(d.Angles))
+		}
+	}
+	if gotProviders["anthropic"] != "claude-sonnet-4-7" {
+		t.Errorf("anthropic model not preserved: %q", gotProviders["anthropic"])
+	}
+	if gotProviders["openai"] != "gpt-5" {
+		t.Errorf("openai model not preserved: %q", gotProviders["openai"])
+	}
+}
+
+func TestGenerateRequiresAtLeastOneProvider(t *testing.T) {
+	_, err := Generate(context.Background(), nil, sampleBrief(), sampleResearch(), Default())
+	if err == nil {
+		t.Fatal("expected error for empty providers")
+	}
+}
+
+func TestGenerateRecordsPerProviderError(t *testing.T) {
+	good := &fakeProvider{name: "anthropic", response: cannedDraftJSON}
+	bad := &fakeProvider{name: "openai", err: errors.New("rate limited")}
+
+	bundle, err := Generate(context.Background(), []ProviderRef{
+		{Provider: good, Model: "claude-sonnet-4-7"},
+		{Provider: bad, Model: "gpt-5"},
+	}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatalf("bundle should succeed even when one provider fails: %v", err)
+	}
+	if len(bundle.Drafts) != 2 {
+		t.Fatalf("drafts len = %d", len(bundle.Drafts))
+	}
+	var goodDraft, badDraft types.Draft
+	for _, d := range bundle.Drafts {
+		switch d.Provider {
+		case "anthropic":
+			goodDraft = d
+		case "openai":
+			badDraft = d
+		}
+	}
+	if goodDraft.Error != "" {
+		t.Errorf("good provider got error: %s", goodDraft.Error)
+	}
+	if badDraft.Error == "" || !strings.Contains(badDraft.Error, "rate limited") {
+		t.Errorf("bad provider error not recorded: %q", badDraft.Error)
+	}
+	if len(badDraft.Angles) != 0 {
+		t.Errorf("failed draft should not have angles")
+	}
+}
+
+func TestGenerateBadJSONRecordedAsError(t *testing.T) {
+	p := &fakeProvider{name: "anthropic", response: "not json at all"}
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := bundle.Drafts[0]
+	if d.Error == "" || !strings.Contains(d.Error, "parse draft json") {
+		t.Errorf("expected parse error, got %q", d.Error)
+	}
+}
+
+func TestGenerateRefusePath(t *testing.T) {
+	const refuseJSON = `{"risk":"refuse","risk_reason":"this sub rejects launch posts","angles":[]}`
+	p := &fakeProvider{name: "anthropic", response: refuseJSON}
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := bundle.Drafts[0]
+	if d.Risk != types.RiskRefuse {
+		t.Errorf("risk = %q", d.Risk)
+	}
+	if d.RiskReason != "this sub rejects launch posts" {
+		t.Errorf("risk reason = %q", d.RiskReason)
+	}
+	if len(d.Angles) != 0 {
+		t.Errorf("refuse should have no angles, got %d", len(d.Angles))
+	}
+}
+
+func TestGenerateMissingRiskFieldErrors(t *testing.T) {
+	p := &fakeProvider{name: "anthropic", response: `{"angles":[]}`}
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := bundle.Drafts[0]
+	if d.Error == "" || !strings.Contains(d.Error, "risk") {
+		t.Errorf("expected missing-risk error, got %q", d.Error)
+	}
+}
+
+func TestGenerateSendsJSONModeRequest(t *testing.T) {
+	p := &fakeProvider{name: "anthropic", response: cannedDraftJSON}
+	_, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "claude-sonnet-4-7"}}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.gotReq.JSONMode {
+		t.Error("JSONMode should be true for draft generation")
+	}
+	if p.gotReq.MaxTokens != Default().MaxTokens {
+		t.Errorf("MaxTokens = %d, want %d", p.gotReq.MaxTokens, Default().MaxTokens)
+	}
+	if p.gotReq.Model != "claude-sonnet-4-7" {
+		t.Errorf("Model = %q (should pass through ref.Model)", p.gotReq.Model)
+	}
+	if len(p.gotReq.Messages) != 1 || p.gotReq.Messages[0].Role != llm.RoleUser {
+		t.Errorf("messages = %+v", p.gotReq.Messages)
+	}
+}
+
+func TestTokenUsageRecorded(t *testing.T) {
+	p := &fakeProvider{name: "anthropic", response: cannedDraftJSON}
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := bundle.Drafts[0]
+	if d.InputTokens != 100 || d.OutputTokens != 200 {
+		t.Errorf("token usage not recorded: in=%d out=%d", d.InputTokens, d.OutputTokens)
+	}
+}

--- a/draft/render.go
+++ b/draft/render.go
@@ -7,9 +7,11 @@ import (
 	"github.com/viggy28/tider/internal/types"
 )
 
-// RenderMarkdown turns a DraftBundle into reviewable markdown, organized
-// to make per-provider comparison easy: same sections in the same order
-// for every provider, recommendation called out at the top of each.
+// RenderMarkdown turns a DraftBundle into reviewable markdown. The
+// recommendation leads with full title + body so the user can decide
+// in 30 seconds; alternatives are listed below in compressed form so a
+// disagreement with the pick still has somewhere to go without scrolling
+// through every variant's full text.
 func RenderMarkdown(b *types.DraftBundle) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# Drafts for r/%s\n\n", b.Sub)
@@ -28,73 +30,155 @@ func RenderMarkdown(b *types.DraftBundle) string {
 }
 
 func renderDraft(sb *strings.Builder, d types.Draft) {
-	fmt.Fprintf(sb, "## %s · %s\n\n", d.Provider, d.Model)
+	fmt.Fprintf(sb, "## %s · %s · risk: %s\n\n", d.Provider, d.Model, d.Risk)
 
 	if d.Error != "" {
 		fmt.Fprintf(sb, "**Error:** %s\n\n", d.Error)
 		return
 	}
-
-	fmt.Fprintf(sb, "**Risk:** %s", d.Risk)
-	if d.RiskReason != "" {
-		fmt.Fprintf(sb, " — %s", d.RiskReason)
-	}
-	sb.WriteString("\n\n")
-
 	if d.Risk == types.RiskRefuse {
-		// Nothing else to render — refuse means no angles by design.
+		fmt.Fprintf(sb, "**Refused:** %s\n\n", d.RiskReason)
 		return
 	}
 
-	if d.Recommendation.AngleID != 0 || d.Recommendation.TitleID != "" {
-		fmt.Fprintf(sb, "**Recommendation:** angle %d, title %s, body %s",
-			d.Recommendation.AngleID, d.Recommendation.TitleID, d.Recommendation.BodyID)
-		if d.Recommendation.Reasoning != "" {
-			fmt.Fprintf(sb, " — %s", d.Recommendation.Reasoning)
-		}
-		sb.WriteString("\n\n")
-	}
-
-	if d.Flair.Suggested != "" {
-		marker := "optional"
-		if d.Flair.Required {
-			marker = "required"
-		}
-		fmt.Fprintf(sb, "**Flair:** %s (%s)\n\n", d.Flair.Suggested, marker)
-	}
-	if d.SuggestedWindow != "" {
-		fmt.Fprintf(sb, "**Suggested window:** %s\n\n", d.SuggestedWindow)
-	}
-	if d.MediaRecommendation != "" {
-		fmt.Fprintf(sb, "**Media:** %s\n\n", d.MediaRecommendation)
-	}
-
-	for _, a := range d.Angles {
-		fmt.Fprintf(sb, "### Angle %d: %s\n\n", a.ID, a.Premise)
-		if a.Hook != "" {
-			fmt.Fprintf(sb, "*Hook:* %s\n\n", a.Hook)
-		}
-		if len(a.Titles) > 0 {
-			sb.WriteString("**Titles**\n\n")
-			for _, t := range a.Titles {
-				fmt.Fprintf(sb, "- `%s` %s\n", t.ID, t.Text)
-			}
-			sb.WriteString("\n")
-		}
-		if len(a.Bodies) > 0 {
-			sb.WriteString("**Bodies**\n\n")
-			for _, body := range a.Bodies {
-				tagSuffix := ""
-				if len(body.Tags) > 0 {
-					tagSuffix = " — _" + strings.Join(body.Tags, ", ") + "_"
-				}
-				fmt.Fprintf(sb, "**`%s`**%s\n\n", body.ID, tagSuffix)
-				fmt.Fprintf(sb, "%s\n\n", body.Text)
-			}
-		}
-	}
+	renderPick(sb, d)
+	renderMeta(sb, d)
+	renderAlternatives(sb, d)
 
 	if d.InputTokens+d.OutputTokens > 0 {
 		fmt.Fprintf(sb, "_tokens: in=%d out=%d_\n", d.InputTokens, d.OutputTokens)
 	}
 }
+
+func renderPick(sb *strings.Builder, d types.Draft) {
+	a := findAngle(d.Angles, d.Recommendation.AngleID)
+	t := findTitle(a, d.Recommendation.TitleID)
+	body := findBody(a, d.Recommendation.BodyID)
+	if a == nil || t == nil || body == nil {
+		sb.WriteString("**Pick:** none (recommendation references missing ids)\n\n")
+		return
+	}
+	fmt.Fprintf(sb, "### Pick: angle %d / title %s / body %s\n\n",
+		d.Recommendation.AngleID, d.Recommendation.TitleID, d.Recommendation.BodyID)
+	if d.Recommendation.Reasoning != "" {
+		fmt.Fprintf(sb, "> %s\n\n", d.Recommendation.Reasoning)
+	}
+	fmt.Fprintf(sb, "**Title:** %s\n\n", t.Text)
+	sb.WriteString("**Body:**\n\n")
+	fmt.Fprintf(sb, "%s\n\n", strings.TrimSpace(body.Text))
+}
+
+func renderMeta(sb *strings.Builder, d types.Draft) {
+	wrote := false
+	if d.Flair.Suggested != "" {
+		marker := "optional"
+		if d.Flair.Required {
+			marker = "required"
+		}
+		fmt.Fprintf(sb, "**Flair:** %s (%s)\n", d.Flair.Suggested, marker)
+		wrote = true
+	}
+	if d.SuggestedWindow != "" {
+		fmt.Fprintf(sb, "**Suggested window:** %s\n", d.SuggestedWindow)
+		wrote = true
+	}
+	if d.MediaRecommendation != "" {
+		fmt.Fprintf(sb, "**Media:** %s\n", d.MediaRecommendation)
+		wrote = true
+	}
+	if wrote {
+		sb.WriteString("\n")
+	}
+}
+
+func renderAlternatives(sb *strings.Builder, d types.Draft) {
+	if len(d.Angles) == 0 {
+		return
+	}
+	sb.WriteString("### Alternatives\n\n")
+	for _, a := range d.Angles {
+		isRecAngle := a.ID == d.Recommendation.AngleID
+
+		header := fmt.Sprintf("**Angle %d** — %s", a.ID, a.Premise)
+		if isRecAngle {
+			header += " *(recommended angle)*"
+		}
+		fmt.Fprintf(sb, "%s\n", header)
+		if a.Hook != "" {
+			fmt.Fprintf(sb, "*Hook:* %s\n", a.Hook)
+		}
+		sb.WriteString("\n")
+
+		if len(a.Titles) > 0 {
+			sb.WriteString("Titles:\n")
+			for _, t := range a.Titles {
+				marker := ""
+				if isRecAngle && t.ID == d.Recommendation.TitleID {
+					marker = " ← picked"
+				}
+				fmt.Fprintf(sb, "- `%s` %s%s\n", t.ID, t.Text, marker)
+			}
+			sb.WriteString("\n")
+		}
+
+		// Skip the picked body (already shown in full above); list the rest as
+		// metadata only so the user can scan and request a regen if needed.
+		var remaining []types.Body
+		for _, body := range a.Bodies {
+			if isRecAngle && body.ID == d.Recommendation.BodyID {
+				continue
+			}
+			remaining = append(remaining, body)
+		}
+		if len(remaining) > 0 {
+			label := "Bodies:"
+			if isRecAngle {
+				label = "Other bodies:"
+			}
+			sb.WriteString(label + "\n")
+			for _, body := range remaining {
+				tagSuffix := ""
+				if len(body.Tags) > 0 {
+					tagSuffix = " — _" + strings.Join(body.Tags, ", ") + "_"
+				}
+				fmt.Fprintf(sb, "- `%s` (~%d words)%s\n", body.ID, wordCount(body.Text), tagSuffix)
+			}
+			sb.WriteString("\n")
+		}
+	}
+}
+
+func findAngle(angles []types.Angle, id int) *types.Angle {
+	for i := range angles {
+		if angles[i].ID == id {
+			return &angles[i]
+		}
+	}
+	return nil
+}
+
+func findTitle(a *types.Angle, id string) *types.Title {
+	if a == nil {
+		return nil
+	}
+	for i := range a.Titles {
+		if a.Titles[i].ID == id {
+			return &a.Titles[i]
+		}
+	}
+	return nil
+}
+
+func findBody(a *types.Angle, id string) *types.Body {
+	if a == nil {
+		return nil
+	}
+	for i := range a.Bodies {
+		if a.Bodies[i].ID == id {
+			return &a.Bodies[i]
+		}
+	}
+	return nil
+}
+
+func wordCount(s string) int { return len(strings.Fields(s)) }

--- a/draft/render.go
+++ b/draft/render.go
@@ -1,0 +1,100 @@
+package draft
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// RenderMarkdown turns a DraftBundle into reviewable markdown, organized
+// to make per-provider comparison easy: same sections in the same order
+// for every provider, recommendation called out at the top of each.
+func RenderMarkdown(b *types.DraftBundle) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Drafts for r/%s\n\n", b.Sub)
+	fmt.Fprintf(&sb, "**Brief:** %s\n\n", b.Brief.Title)
+	if b.Brief.Summary != "" {
+		fmt.Fprintf(&sb, "%s\n\n", b.Brief.Summary)
+	}
+	fmt.Fprintf(&sb, "Generated: %s · %d provider(s)\n\n", b.Generated.Format("2006-01-02 15:04 UTC"), len(b.Drafts))
+	sb.WriteString("---\n\n")
+
+	for _, d := range b.Drafts {
+		renderDraft(&sb, d)
+		sb.WriteString("\n---\n\n")
+	}
+	return sb.String()
+}
+
+func renderDraft(sb *strings.Builder, d types.Draft) {
+	fmt.Fprintf(sb, "## %s · %s\n\n", d.Provider, d.Model)
+
+	if d.Error != "" {
+		fmt.Fprintf(sb, "**Error:** %s\n\n", d.Error)
+		return
+	}
+
+	fmt.Fprintf(sb, "**Risk:** %s", d.Risk)
+	if d.RiskReason != "" {
+		fmt.Fprintf(sb, " — %s", d.RiskReason)
+	}
+	sb.WriteString("\n\n")
+
+	if d.Risk == types.RiskRefuse {
+		// Nothing else to render — refuse means no angles by design.
+		return
+	}
+
+	if d.Recommendation.AngleID != 0 || d.Recommendation.TitleID != "" {
+		fmt.Fprintf(sb, "**Recommendation:** angle %d, title %s, body %s",
+			d.Recommendation.AngleID, d.Recommendation.TitleID, d.Recommendation.BodyID)
+		if d.Recommendation.Reasoning != "" {
+			fmt.Fprintf(sb, " — %s", d.Recommendation.Reasoning)
+		}
+		sb.WriteString("\n\n")
+	}
+
+	if d.Flair.Suggested != "" {
+		marker := "optional"
+		if d.Flair.Required {
+			marker = "required"
+		}
+		fmt.Fprintf(sb, "**Flair:** %s (%s)\n\n", d.Flair.Suggested, marker)
+	}
+	if d.SuggestedWindow != "" {
+		fmt.Fprintf(sb, "**Suggested window:** %s\n\n", d.SuggestedWindow)
+	}
+	if d.MediaRecommendation != "" {
+		fmt.Fprintf(sb, "**Media:** %s\n\n", d.MediaRecommendation)
+	}
+
+	for _, a := range d.Angles {
+		fmt.Fprintf(sb, "### Angle %d: %s\n\n", a.ID, a.Premise)
+		if a.Hook != "" {
+			fmt.Fprintf(sb, "*Hook:* %s\n\n", a.Hook)
+		}
+		if len(a.Titles) > 0 {
+			sb.WriteString("**Titles**\n\n")
+			for _, t := range a.Titles {
+				fmt.Fprintf(sb, "- `%s` %s\n", t.ID, t.Text)
+			}
+			sb.WriteString("\n")
+		}
+		if len(a.Bodies) > 0 {
+			sb.WriteString("**Bodies**\n\n")
+			for _, body := range a.Bodies {
+				tagSuffix := ""
+				if len(body.Tags) > 0 {
+					tagSuffix = " — _" + strings.Join(body.Tags, ", ") + "_"
+				}
+				fmt.Fprintf(sb, "**`%s`**%s\n\n", body.ID, tagSuffix)
+				fmt.Fprintf(sb, "%s\n\n", body.Text)
+			}
+		}
+	}
+
+	if d.InputTokens+d.OutputTokens > 0 {
+		fmt.Fprintf(sb, "_tokens: in=%d out=%d_\n", d.InputTokens, d.OutputTokens)
+	}
+}

--- a/draft/render_test.go
+++ b/draft/render_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/viggy28/tider/internal/types"
 )
 
-func TestRenderMarkdownHappyPath(t *testing.T) {
-	bundle := &types.DraftBundle{
+func sampleBundle() *types.DraftBundle {
+	return &types.DraftBundle{
 		Sub:       "golang",
 		Brief:     types.Brief{Title: "Streambed", Summary: "WAL-native CDC."},
 		Generated: time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC),
@@ -22,63 +22,131 @@ func TestRenderMarkdownHappyPath(t *testing.T) {
 				Angles: []types.Angle{
 					{
 						ID: 1, Premise: "war story", Hook: "what surprised me",
-						Titles: []types.Title{{ID: "1.1", Text: "Title A"}, {ID: "1.2", Text: "Title B"}},
-						Bodies: []types.Body{{ID: "1.1", Text: "Body content here.", Tags: []string{"opener:war-story"}}},
+						Titles: []types.Title{
+							{ID: "1.1", Text: "Title A1"},
+							{ID: "1.2", Text: "Title A2"},
+						},
+						Bodies: []types.Body{
+							{ID: "1.1", Text: "Body A1 content one two three.", Tags: []string{"opener:war-story"}},
+							{ID: "1.2", Text: "Body A2 content here with a few more words for counting.", Tags: []string{"opener:question"}},
+						},
 					},
-				},
-				Recommendation: types.Recommendation{AngleID: 1, TitleID: "1.2", BodyID: "1.1", Reasoning: "fits the sub"},
-				Flair:          types.FlairRec{Required: true, Suggested: "discussion"},
-				SuggestedWindow: "Tue-Thu 9-11am ET",
-				InputTokens:    1500, OutputTokens: 800,
-				Generated: time.Now(),
-			},
-			{
-				Sub:      "golang",
-				Provider: "openai",
-				Model:    "gpt-5",
-				Risk:     "medium",
-				Angles: []types.Angle{
 					{
-						ID: 1, Premise: "technical pitch",
-						Titles: []types.Title{{ID: "1.1", Text: "Different angle title"}},
-						Bodies: []types.Body{{ID: "1.1", Text: "Different body content."}},
+						ID: 2, Premise: "technical pitch", Hook: "what we got",
+						Titles: []types.Title{
+							{ID: "2.1", Text: "Title B1"},
+						},
+						Bodies: []types.Body{
+							{ID: "2.1", Text: "Body B1 content with some words.", Tags: []string{"opener:context"}},
+						},
 					},
 				},
-				Recommendation: types.Recommendation{AngleID: 1, TitleID: "1.1", BodyID: "1.1"},
-				Flair:          types.FlairRec{Required: false, Suggested: "show & tell"},
+				Recommendation: types.Recommendation{
+					AngleID:   1,
+					TitleID:   "1.2",
+					BodyID:    "1.1",
+					Reasoning: "fits the sub better than a pitch",
+				},
+				Flair:           types.FlairRec{Required: true, Suggested: "discussion"},
+				SuggestedWindow: "Tue-Thu 9-11am ET",
+				InputTokens:     1500, OutputTokens: 800,
 				Generated: time.Now(),
 			},
 		},
 	}
+}
 
-	md := RenderMarkdown(bundle)
+func TestRenderMarkdownPickLeadsWithFullContent(t *testing.T) {
+	md := RenderMarkdown(sampleBundle())
 
-	checks := []string{
-		"# Drafts for r/golang",
-		"**Brief:** Streambed",
-		"WAL-native CDC.",
-		"2 provider(s)",
-		"## anthropic · claude-sonnet-4-7",
-		"## openai · gpt-5",
-		"**Risk:** low",
-		"**Risk:** medium",
-		"**Recommendation:** angle 1, title 1.2, body 1.1",
-		"fits the sub",
-		"### Angle 1: war story",
-		"*Hook:* what surprised me",
-		"`1.1` Title A",
-		"`1.2` Title B",
-		"opener:war-story",
-		"Body content here.",
-		"**Flair:** discussion (required)",
-		"**Flair:** show & tell (optional)",
-		"**Suggested window:** Tue-Thu 9-11am ET",
-		"tokens: in=1500 out=800",
+	pickIdx := strings.Index(md, "### Pick: angle 1 / title 1.2 / body 1.1")
+	if pickIdx == -1 {
+		t.Fatalf("Pick header missing\n%s", md)
 	}
-	for _, c := range checks {
-		if !strings.Contains(md, c) {
-			t.Errorf("markdown missing %q\n--- output ---\n%s", c, md)
-		}
+	altIdx := strings.Index(md, "### Alternatives")
+	if altIdx == -1 {
+		t.Fatalf("Alternatives header missing\n%s", md)
+	}
+	if pickIdx > altIdx {
+		t.Errorf("Pick should appear before Alternatives (pick=%d, alt=%d)", pickIdx, altIdx)
+	}
+
+	// Reasoning rendered as a blockquote
+	if !strings.Contains(md, "> fits the sub better than a pitch") {
+		t.Error("reasoning blockquote missing")
+	}
+	// Recommended title text rendered in full
+	if !strings.Contains(md, "**Title:** Title A2") {
+		t.Errorf("recommended title text not rendered in full")
+	}
+	// Recommended body text rendered in full (not just metadata)
+	if !strings.Contains(md, "Body A1 content one two three.") {
+		t.Errorf("recommended body text not rendered in full")
+	}
+}
+
+func TestRenderMarkdownAlternativesAreCompressed(t *testing.T) {
+	md := RenderMarkdown(sampleBundle())
+
+	// Picked body must NOT appear a second time as full content under Alternatives.
+	pickedBodyText := "Body A1 content one two three."
+	if strings.Count(md, pickedBodyText) != 1 {
+		t.Errorf("picked body should appear exactly once (in Pick), got %d occurrences", strings.Count(md, pickedBodyText))
+	}
+
+	// Picked title should be marked in the alternatives Titles list
+	if !strings.Contains(md, "`1.2` Title A2 ← picked") {
+		t.Errorf("picked title not marked in alternatives\n%s", md)
+	}
+
+	// Recommended angle should be marked
+	if !strings.Contains(md, "**Angle 1** — war story *(recommended angle)*") {
+		t.Errorf("recommended angle not marked")
+	}
+	// Non-recommended angle should NOT have the marker
+	if strings.Contains(md, "**Angle 2** — technical pitch *(recommended angle)*") {
+		t.Errorf("non-recommended angle wrongly marked as recommended")
+	}
+
+	// Other bodies in the recommended angle: appear as metadata with word count + tags
+	if !strings.Contains(md, "Other bodies:") {
+		t.Error("'Other bodies:' label missing for recommended angle")
+	}
+	if !strings.Contains(md, "`1.2` (~11 words)") {
+		t.Errorf("body 1.2 word count metadata wrong\n%s", md)
+	}
+	if !strings.Contains(md, "_opener:question_") {
+		t.Errorf("body 1.2 tag missing")
+	}
+
+	// Body 2.1 is NOT the picked body, but is the only body in non-recommended angle 2.
+	// Should appear under "Bodies:" (not "Other bodies:") with metadata only.
+	if !strings.Contains(md, "Bodies:\n- `2.1`") {
+		t.Errorf("non-recommended angle bodies section wrong\n%s", md)
+	}
+	// Body 2.1's full text should NOT be rendered.
+	if strings.Contains(md, "Body B1 content with some words.") {
+		t.Error("non-recommended body text should not be rendered in full")
+	}
+}
+
+func TestRenderMarkdownMetaSection(t *testing.T) {
+	md := RenderMarkdown(sampleBundle())
+	if !strings.Contains(md, "**Flair:** discussion (required)") {
+		t.Error("flair not rendered")
+	}
+	if !strings.Contains(md, "**Suggested window:** Tue-Thu 9-11am ET") {
+		t.Error("suggested window not rendered")
+	}
+	if !strings.Contains(md, "_tokens: in=1500 out=800_") {
+		t.Error("token usage not rendered")
+	}
+}
+
+func TestRenderMarkdownProviderHeader(t *testing.T) {
+	md := RenderMarkdown(sampleBundle())
+	if !strings.Contains(md, "## anthropic · claude-sonnet-4-7 · risk: low") {
+		t.Errorf("provider header format wrong\n%s", md)
 	}
 }
 
@@ -98,11 +166,14 @@ func TestRenderMarkdownRefusePath(t *testing.T) {
 		},
 	}
 	md := RenderMarkdown(bundle)
-	if !strings.Contains(md, "**Risk:** refuse — r/golang rejects bare promotion") {
-		t.Errorf("refuse rendering wrong:\n%s", md)
+	if !strings.Contains(md, "## anthropic · claude-sonnet-4-7 · risk: refuse") {
+		t.Errorf("refuse provider header wrong:\n%s", md)
 	}
-	if strings.Contains(md, "### Angle") {
-		t.Error("refuse should not render any angles")
+	if !strings.Contains(md, "**Refused:** r/golang rejects bare promotion") {
+		t.Errorf("refuse reason wrong:\n%s", md)
+	}
+	if strings.Contains(md, "### Pick:") || strings.Contains(md, "### Alternatives") {
+		t.Error("refuse should not render Pick or Alternatives")
 	}
 }
 
@@ -122,5 +193,53 @@ func TestRenderMarkdownErrorPath(t *testing.T) {
 	md := RenderMarkdown(bundle)
 	if !strings.Contains(md, "**Error:** rate limited") {
 		t.Errorf("error rendering wrong:\n%s", md)
+	}
+	if strings.Contains(md, "### Pick:") || strings.Contains(md, "### Alternatives") {
+		t.Error("error path should not render Pick or Alternatives")
+	}
+}
+
+func TestRenderMarkdownMissingRecommendationIDs(t *testing.T) {
+	bundle := &types.DraftBundle{
+		Sub:       "golang",
+		Brief:     types.Brief{Title: "X"},
+		Generated: time.Now(),
+		Drafts: []types.Draft{
+			{
+				Provider: "anthropic", Model: "x", Risk: "low",
+				Angles: []types.Angle{
+					{ID: 1, Titles: []types.Title{{ID: "1.1", Text: "T"}}, Bodies: []types.Body{{ID: "1.1", Text: "B"}}},
+				},
+				// Recommendation points at non-existent angle 99
+				Recommendation: types.Recommendation{AngleID: 99, TitleID: "9.9", BodyID: "9.9"},
+				Generated:      time.Now(),
+			},
+		},
+	}
+	md := RenderMarkdown(bundle)
+	if !strings.Contains(md, "**Pick:** none (recommendation references missing ids)") {
+		t.Errorf("missing-id fallback not rendered:\n%s", md)
+	}
+	// Alternatives should still render so the user has something to work with.
+	if !strings.Contains(md, "### Alternatives") {
+		t.Errorf("alternatives should still render when recommendation is broken")
+	}
+}
+
+func TestWordCount(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"one", 1},
+		{"one two three", 3},
+		{"  spaced   out  words  ", 3},
+		{"newlines\nbetween\nwords", 3},
+	}
+	for _, c := range cases {
+		if got := wordCount(c.in); got != c.want {
+			t.Errorf("wordCount(%q) = %d, want %d", c.in, got, c.want)
+		}
 	}
 }

--- a/draft/render_test.go
+++ b/draft/render_test.go
@@ -1,0 +1,126 @@
+package draft
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+func TestRenderMarkdownHappyPath(t *testing.T) {
+	bundle := &types.DraftBundle{
+		Sub:       "golang",
+		Brief:     types.Brief{Title: "Streambed", Summary: "WAL-native CDC."},
+		Generated: time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC),
+		Drafts: []types.Draft{
+			{
+				Sub:      "golang",
+				Provider: "anthropic",
+				Model:    "claude-sonnet-4-7",
+				Risk:     "low",
+				Angles: []types.Angle{
+					{
+						ID: 1, Premise: "war story", Hook: "what surprised me",
+						Titles: []types.Title{{ID: "1.1", Text: "Title A"}, {ID: "1.2", Text: "Title B"}},
+						Bodies: []types.Body{{ID: "1.1", Text: "Body content here.", Tags: []string{"opener:war-story"}}},
+					},
+				},
+				Recommendation: types.Recommendation{AngleID: 1, TitleID: "1.2", BodyID: "1.1", Reasoning: "fits the sub"},
+				Flair:          types.FlairRec{Required: true, Suggested: "discussion"},
+				SuggestedWindow: "Tue-Thu 9-11am ET",
+				InputTokens:    1500, OutputTokens: 800,
+				Generated: time.Now(),
+			},
+			{
+				Sub:      "golang",
+				Provider: "openai",
+				Model:    "gpt-5",
+				Risk:     "medium",
+				Angles: []types.Angle{
+					{
+						ID: 1, Premise: "technical pitch",
+						Titles: []types.Title{{ID: "1.1", Text: "Different angle title"}},
+						Bodies: []types.Body{{ID: "1.1", Text: "Different body content."}},
+					},
+				},
+				Recommendation: types.Recommendation{AngleID: 1, TitleID: "1.1", BodyID: "1.1"},
+				Flair:          types.FlairRec{Required: false, Suggested: "show & tell"},
+				Generated: time.Now(),
+			},
+		},
+	}
+
+	md := RenderMarkdown(bundle)
+
+	checks := []string{
+		"# Drafts for r/golang",
+		"**Brief:** Streambed",
+		"WAL-native CDC.",
+		"2 provider(s)",
+		"## anthropic · claude-sonnet-4-7",
+		"## openai · gpt-5",
+		"**Risk:** low",
+		"**Risk:** medium",
+		"**Recommendation:** angle 1, title 1.2, body 1.1",
+		"fits the sub",
+		"### Angle 1: war story",
+		"*Hook:* what surprised me",
+		"`1.1` Title A",
+		"`1.2` Title B",
+		"opener:war-story",
+		"Body content here.",
+		"**Flair:** discussion (required)",
+		"**Flair:** show & tell (optional)",
+		"**Suggested window:** Tue-Thu 9-11am ET",
+		"tokens: in=1500 out=800",
+	}
+	for _, c := range checks {
+		if !strings.Contains(md, c) {
+			t.Errorf("markdown missing %q\n--- output ---\n%s", c, md)
+		}
+	}
+}
+
+func TestRenderMarkdownRefusePath(t *testing.T) {
+	bundle := &types.DraftBundle{
+		Sub:       "golang",
+		Brief:     types.Brief{Title: "Marketing post"},
+		Generated: time.Now(),
+		Drafts: []types.Draft{
+			{
+				Provider:   "anthropic",
+				Model:      "claude-sonnet-4-7",
+				Risk:       types.RiskRefuse,
+				RiskReason: "r/golang rejects bare promotion",
+				Generated:  time.Now(),
+			},
+		},
+	}
+	md := RenderMarkdown(bundle)
+	if !strings.Contains(md, "**Risk:** refuse — r/golang rejects bare promotion") {
+		t.Errorf("refuse rendering wrong:\n%s", md)
+	}
+	if strings.Contains(md, "### Angle") {
+		t.Error("refuse should not render any angles")
+	}
+}
+
+func TestRenderMarkdownErrorPath(t *testing.T) {
+	bundle := &types.DraftBundle{
+		Sub:       "golang",
+		Generated: time.Now(),
+		Drafts: []types.Draft{
+			{
+				Provider:  "openai",
+				Model:     "gpt-5",
+				Error:     "rate limited",
+				Generated: time.Now(),
+			},
+		},
+	}
+	md := RenderMarkdown(bundle)
+	if !strings.Contains(md, "**Error:** rate limited") {
+		t.Errorf("error rendering wrong:\n%s", md)
+	}
+}

--- a/intake/intake.go
+++ b/intake/intake.go
@@ -31,6 +31,10 @@ func New(p llm.Provider) *Intake {
 		UserAgent: DefaultUserAgent,
 		Provider:  p,
 		MaxBytes:  256 * 1024,
-		MaxTokens: 2048,
+		// 8192 by default so reasoning models (gpt-5, o-series) don't spend
+		// the whole budget on internal reasoning and return empty content.
+		// Non-reasoning models won't use it all — token budget is a cap, not
+		// a target.
+		MaxTokens: 8192,
 	}
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -84,6 +84,79 @@ type Brief struct {
 	CreatedAt  time.Time   `json:"created_at"`
 }
 
+// Risk ratings on a Draft. "refuse" means the LLM declined to generate
+// content because the sub's culture would reject this kind of post; the
+// reason goes in RiskReason and Angles must be empty.
+const (
+	RiskLow    = "low"
+	RiskMedium = "medium"
+	RiskHigh   = "high"
+	RiskRefuse = "refuse"
+)
+
+type Title struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+}
+
+type Body struct {
+	ID   string   `json:"id"`
+	Text string   `json:"text"`
+	Tags []string `json:"tags,omitempty"` // e.g., "opener:question", "close:invite-stories"
+}
+
+type Angle struct {
+	ID      int     `json:"id"`
+	Premise string  `json:"premise"`
+	Hook    string  `json:"hook"`
+	Titles  []Title `json:"titles"`
+	Bodies  []Body  `json:"bodies"`
+}
+
+type Recommendation struct {
+	AngleID   int    `json:"angle_id"`
+	TitleID   string `json:"title_id"`
+	BodyID    string `json:"body_id"`
+	Reasoning string `json:"reasoning,omitempty"`
+}
+
+type FlairRec struct {
+	Required  bool   `json:"required"`
+	Suggested string `json:"suggested,omitempty"`
+}
+
+// Draft is one provider's output: angles + titles + bodies + meta. The
+// full DraftBundle holds N of these (one per provider) for side-by-side
+// comparison.
+type Draft struct {
+	Sub                 string         `json:"sub"`
+	Provider            string         `json:"provider"`
+	Model               string         `json:"model"`
+	Risk                string         `json:"risk"`
+	RiskReason          string         `json:"risk_reason,omitempty"`
+	Angles              []Angle        `json:"angles"`
+	Recommendation      Recommendation `json:"recommendation"`
+	Flair               FlairRec       `json:"flair"`
+	SuggestedWindow     string         `json:"suggested_window,omitempty"`
+	MediaRecommendation string         `json:"media_recommendation,omitempty"`
+	InputTokens         int            `json:"input_tokens,omitempty"`
+	OutputTokens        int            `json:"output_tokens,omitempty"`
+	Generated           time.Time      `json:"generated"`
+	// Error is set if this provider's generation failed; the bundle keeps
+	// the entry so the user can see which provider broke and why.
+	Error string `json:"error,omitempty"`
+}
+
+// DraftBundle holds drafts produced by N providers for one (Brief, Sub)
+// pair. Drafts are intentionally a slice — comparing across providers is
+// the entire point of this step.
+type DraftBundle struct {
+	Sub       string    `json:"sub"`
+	Brief     Brief     `json:"brief"`
+	Drafts    []Draft   `json:"drafts"`
+	Generated time.Time `json:"generated"`
+}
+
 // Research is the assembled per-sub bundle: live Reddit data + curated notes.
 type Research struct {
 	Sub       Subreddit `json:"sub"`

--- a/prompts/draft.tmpl
+++ b/prompts/draft.tmpl
@@ -1,0 +1,156 @@
+You are drafting Reddit posts for a specific subreddit. You write FROM the user's perspective; you never post anything yourself. The user reviews drafts, picks one, and posts manually.
+
+# Subreddit: r/{{.SubName}}
+
+Subscribers: {{.Subscribers}}
+{{- if .CuratedNotes }}
+
+## Curated notes (the user's own observations about this sub)
+{{- if .CuratedNotes.Tone }}
+Tone: {{.CuratedNotes.Tone}}
+{{- end }}
+{{- if .CuratedNotes.SelfPromoTolerance }}
+Self-promo tolerance: {{.CuratedNotes.SelfPromoTolerance}}
+{{- end }}
+{{- if .CuratedNotes.FormatPreferences }}
+Format preferences:
+{{- range .CuratedNotes.FormatPreferences }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- if .CuratedNotes.DoNot }}
+Don't:
+{{- range .CuratedNotes.DoNot }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- if .CuratedNotes.Notes }}
+Notes: {{.CuratedNotes.Notes}}
+{{- end }}
+{{- end }}
+
+## Sub rules
+{{- range .Rules }}
+- {{.ShortName}}: {{.Description}}
+{{- end }}
+{{- if not .Rules }}
+(none returned by Reddit)
+{{- end }}
+
+## Recent top posts (this week)
+{{- range .TopWeek }}
+- "{{.Title}}" — {{.Score}} pts, {{.NumComments}} comments{{if .LinkFlairText}} [{{.LinkFlairText}}]{{end}}
+{{- end }}
+
+## Recent top posts (this month)
+{{- range .TopMonth }}
+- "{{.Title}}" — {{.Score}} pts, {{.NumComments}} comments{{if .LinkFlairText}} [{{.LinkFlairText}}]{{end}}
+{{- end }}
+
+## Currently hot
+{{- range .Hot }}
+- "{{.Title}}" — {{.Score}} pts{{if .LinkFlairText}} [{{.LinkFlairText}}]{{end}}
+{{- end }}
+{{- if .Stickies }}
+
+## Mod stickies (read these — they signal what mods care about)
+{{- range .Stickies }}
+- "{{.Title}}"
+{{- end }}
+{{- end }}
+{{- if .Flairs }}
+
+## Available flairs
+{{- range .Flairs }}
+- {{.Text}}
+{{- end }}
+{{- end }}
+
+# What you're posting about
+
+Title: {{.Brief.Title}}
+Summary: {{.Brief.Summary}}
+{{- if .Brief.Audience }}
+Target audience: {{.Brief.Audience}}
+{{- end }}
+
+Highlights:
+{{- range .Brief.Highlights }}
+- {{.}}
+{{- end }}
+{{- if .Brief.Links }}
+
+Reference links:
+{{- range .Brief.Links }}
+- {{.}}
+{{- end }}
+{{- end }}
+
+# Task
+
+Generate {{.AngleCount}} *distinct* angles — different ways to frame this for r/{{.SubName}}. Angles should differ in *premise*, not just word choice. (e.g., "war story" vs "technical deep-dive" vs "question to the community" vs "comparison to existing tools".)
+
+For each angle, produce {{.TitlesPerAngle}} candidate titles and {{.BodiesPerAngle}} candidate bodies. Bodies should match the format that wins in this sub — look at the recent top posts and pattern-match form (length, structure, link-vs-self, code blocks, etc.).
+
+Then evaluate:
+- "risk": "low" | "medium" | "high" | "refuse" — refuse if this sub's culture genuinely rejects the *kind* of post being attempted (e.g., bare promotion in a sub that wants questions and discussion). When refusing, return empty `angles` and explain in `risk_reason`. Refuse forces the user to make a deliberate decision rather than receiving a bad-fit draft.
+- "recommendation": pick the angle/title/body combination that best fits this sub's culture, with one short sentence of reasoning grounded in the recent top posts or curated notes.
+- "flair": which sub flair fits, and whether the sub conventions require it.
+- "suggested_window": posting time recommendation if you have signal (e.g., "Tue-Thu 9-11am ET"); empty string if you don't.
+- "media_recommendation": if top posts in this sub commonly include screenshots / diagrams / demos / charts, name what would help. Empty if not applicable. Don't generate the asset; just describe what the user should create.
+
+# Anti-tells (mandatory — drafts violating these will be rejected)
+
+Never produce:
+- Rocket 🚀, fire 🔥, sparkles ✨, or any emoji-laden tone
+- "Excited to share", "thrilled to announce", "blown away", "game-changing", "revolutionary", "blazing-fast", "10x"
+- Three-bullet feature dumps as the body
+- "Great question!" or "Thanks for sharing!" as reply openers (not relevant here but a tell of LLM voice)
+- "Let me know if you have any questions/feedback!" closes
+- "Hey r/{{.SubName}}!" type openers — they read as marketing
+- Marketing voice generally. Posts should sound like a developer talking to peers about something they actually built, used, or have an opinion on.
+
+# Output format
+
+Return a single JSON object with exactly this shape and these field names:
+
+{
+  "risk": "low" | "medium" | "high" | "refuse",
+  "risk_reason": "string — required and only present if risk is refuse",
+  "angles": [
+    {
+      "id": 1,
+      "premise": "one sentence framing this angle's overall stance",
+      "hook": "the specific tension, claim, or question this angle leads with",
+      "titles": [
+        {"id": "1.1", "text": "..."},
+        {"id": "1.2", "text": "..."}
+      ],
+      "bodies": [
+        {"id": "1.1", "text": "...", "tags": ["opener:question", "close:invite-stories"]},
+        {"id": "1.2", "text": "...", "tags": ["opener:war-story", "close:none"]}
+      ]
+    }
+  ],
+  "recommendation": {
+    "angle_id": 1,
+    "title_id": "1.2",
+    "body_id": "1.1",
+    "reasoning": "one short sentence"
+  },
+  "flair": {
+    "required": true,
+    "suggested": "discussion"
+  },
+  "suggested_window": "...",
+  "media_recommendation": "..."
+}
+
+If risk is "refuse", return ONLY:
+{
+  "risk": "refuse",
+  "risk_reason": "explain why this kind of post would land badly here",
+  "angles": []
+}
+
+Title IDs are "<angle_id>.<n>"; body IDs use the same scheme. `tags` on bodies are optional but useful for the regen step later — short slugs like "opener:question", "hook:contrarian", "close:invite-stories", or any others that fit.


### PR DESCRIPTION
## Summary

Generates structured Drafts from a Brief + per-sub research, fanning out across providers concurrently so framings can be compared side-by-side — the design intent that's been baked into the LLM abstraction since step 2.

- `Draft` / `DraftBundle` types: angles × titles × bodies, plus risk, recommendation, flair, suggested window, media recommendation. `Recommendation` and `FlairRec` are nested structs the LLM populates.
- `prompts/draft.tmpl` as the IP — versioned, embedded, includes anti-tells (no rocket emojis, no "excited to share", no three-bullet feature dumps, no "Hey r/sub!" openers, etc.).
- `draft.Generate` fans out via goroutines + waitgroup. Per-provider errors are recorded on the `Draft` (not propagated) so one provider going down doesn't kill the comparison.
- `draft.RenderMarkdown` produces review-ready output, organized for side-by-side scanning across providers (same sections, same order, recommendation called out at the top of each).
- Default 2×3×2 variant set (~12 artifacts per provider). `--variants=full` for 3×5×3.
- **Refuse path is first-class**: when the LLM judges the post would land badly in this sub, it returns `risk: "refuse"` + a reason, with empty angles. The renderer shows the reason explicitly so the user makes a deliberate decision rather than receiving a bad-fit draft.

## CLI

```
tider draft --brief=brief.json --sub=golang
tider draft --brief=... --sub=... --providers=anthropic
tider draft --brief=... --sub=... --render=markdown
tider draft --brief=... --sub=... --dry-run        # prints the rendered prompt
```

Missing API keys produce a stderr warning and skip that provider, so a working provider isn't blocked by a missing key on the other.

## Test plan

**Offline (default `go test ./...`)** — 13 new draft tests pass:

Prompt rendering:
- [x] Includes sub header, top posts, curated notes, brief title/highlights, variant counts, anti-tells section, output schema.
- [x] Rejects zero variant counts.

Generate orchestration:
- [x] Fan-out is concurrent (two providers each with 50ms delay → total < 90ms; sequential would be ≥ 100ms).
- [x] Empty providers list errors.
- [x] Per-provider error is recorded on `Draft.Error`, doesn't fail the whole bundle, doesn't leak to the working provider.
- [x] Bad JSON from LLM → `Draft.Error` includes `parse draft json` and (truncated) model output.
- [x] Refuse path → `risk=refuse` parses cleanly with empty angles.
- [x] Missing required `risk` field → recorded as error.
- [x] Request shape correct: `JSONMode=true`, `Model` passed through from `ProviderRef`, `MaxTokens` from `Options`, single user message.
- [x] Token usage propagated from `llm.Response` to `Draft`.

Markdown rendering:
- [x] Happy path: every field renders (provider/model header, risk, recommendation, flair required/optional, suggested window, angles with hooks, titles + bodies + tags, token footer).
- [x] Refuse path: shows `risk: refuse — reason`, no angles section.
- [x] Error path: shows `**Error:** <message>` instead of body.

**Live (manual smoke)** — `--dry-run` confirmed end-to-end against r/golang: live Reddit fetch + cached load + curated notes from `subreddits.yaml` + brief.json all flow into the rendered prompt cleanly. Live LLM run requires an API key and is the natural next user-facing test.

## Out of scope (deferred)

- `author_context` voice calibration from config (config loading hasn't landed; flag-level workaround is fine for now)
- Cross-post timing analysis across multiple subs
- Scoped regen commands (step 5)
- `media_recommendation` is currently an LLM-populated string field; no programmatic logic to suggest visuals

## Commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)