### PR TITLE
draft: ANSI-render markdown when stdout is a terminal (re-apply)

### DIFF
--- a/cmd/tider/draft.go
+++ b/cmd/tider/draft.go
@@ -112,7 +112,11 @@ without a key are skipped with a warning rather than failing the run.`,
 
 		switch draftRender {
 		case "markdown":
-			fmt.Print(draft.RenderMarkdown(bundle))
+			md := draft.RenderMarkdown(bundle)
+			if isTerminal(os.Stdout) {
+				md = renderTerminal(md)
+			}
+			fmt.Print(md)
 		case "json", "":
 			out, err := json.MarshalIndent(bundle, "", "  ")
 			if err != nil {

--- a/cmd/tider/term.go
+++ b/cmd/tider/term.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Tiny ANSI renderer for the specific markdown subset that
+// draft.RenderMarkdown emits. Not a general renderer — handles only the
+// constructs we actually produce. Trade-off: zero deps, full control,
+// behavior is obvious. Anything more elaborate (tables, fenced code,
+// nested lists) will need a real library.
+
+const (
+	ansiReset   = "\x1b[0m"
+	ansiBold    = "\x1b[1m"
+	ansiDim     = "\x1b[2m"
+	ansiItalic  = "\x1b[3m"
+	ansiCyan    = "\x1b[36m"
+	ansiGreen   = "\x1b[32m"
+	ansiMagenta = "\x1b[35m"
+)
+
+var (
+	// Order of regex application matters in applyInline (bold before
+	// italic so ** doesn't get eaten as two single *).
+	reBold        = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	reCode        = regexp.MustCompile("`([^`]+)`")
+	reItalicUnder = regexp.MustCompile(`(^|[\s(])_([^_]+)_($|[\s).,;:!?])`)
+	reItalicStar  = regexp.MustCompile(`(^|[\s(])\*([^*]+)\*($|[\s).,;:!?])`)
+)
+
+// renderTerminal converts the markdown produced by draft.RenderMarkdown
+// into ANSI-styled text suitable for a terminal.
+func renderTerminal(md string) string {
+	var out strings.Builder
+	for line := range strings.SplitSeq(md, "\n") {
+		out.WriteString(renderLine(line))
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func renderLine(line string) string {
+	switch {
+	case line == "---":
+		return ansiDim + strings.Repeat("─", 60) + ansiReset
+	case strings.HasPrefix(line, "### "):
+		return ansiBold + ansiCyan + strings.TrimPrefix(line, "### ") + ansiReset
+	case strings.HasPrefix(line, "## "):
+		return ansiBold + ansiGreen + strings.TrimPrefix(line, "## ") + ansiReset
+	case strings.HasPrefix(line, "# "):
+		return ansiBold + ansiMagenta + strings.TrimPrefix(line, "# ") + ansiReset
+	case strings.HasPrefix(line, "> "):
+		return ansiDim + "│ " + applyInline(strings.TrimPrefix(line, "> ")) + ansiReset
+	case strings.HasPrefix(line, "- "):
+		return "  • " + applyInline(strings.TrimPrefix(line, "- "))
+	default:
+		return applyInline(line)
+	}
+}
+
+func applyInline(s string) string {
+	s = reBold.ReplaceAllString(s, ansiBold+"$1"+ansiReset)
+	s = reCode.ReplaceAllString(s, ansiCyan+"$1"+ansiReset)
+	s = reItalicUnder.ReplaceAllString(s, "$1"+ansiItalic+"$2"+ansiReset+"$3")
+	s = reItalicStar.ReplaceAllString(s, "$1"+ansiItalic+"$2"+ansiReset+"$3")
+	return s
+}
+
+// isTerminal reports whether f is connected to an interactive terminal.
+// Used to decide whether to ANSI-render markdown output: TTY → rendered,
+// pipe/redirect → raw markdown so downstream tooling sees clean text.
+// NO_COLOR (https://no-color.org) forces raw even in a TTY.
+func isTerminal(f *os.File) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/tider/term_test.go
+++ b/cmd/tider/term_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderLineHeadings(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"# Heading 1", ansiBold + ansiMagenta + "Heading 1" + ansiReset},
+		{"## Heading 2", ansiBold + ansiGreen + "Heading 2" + ansiReset},
+		{"### Heading 3", ansiBold + ansiCyan + "Heading 3" + ansiReset},
+	}
+	for _, c := range cases {
+		if got := renderLine(c.in); got != c.want {
+			t.Errorf("renderLine(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRenderLineHorizontalRule(t *testing.T) {
+	got := renderLine("---")
+	if !strings.Contains(got, "─") {
+		t.Errorf("hr should render as box-drawing chars, got %q", got)
+	}
+	if !strings.Contains(got, ansiDim) {
+		t.Errorf("hr should be dim, got %q", got)
+	}
+}
+
+func TestRenderLineBlockquote(t *testing.T) {
+	got := renderLine("> reasoning here")
+	if !strings.Contains(got, "│") {
+		t.Errorf("blockquote should have left bar, got %q", got)
+	}
+	if !strings.Contains(got, "reasoning here") {
+		t.Errorf("blockquote text missing: %q", got)
+	}
+	if !strings.Contains(got, ansiDim) {
+		t.Errorf("blockquote should be dim, got %q", got)
+	}
+}
+
+func TestRenderLineListItem(t *testing.T) {
+	got := renderLine("- some item")
+	if !strings.Contains(got, "•") {
+		t.Errorf("list bullet should be •, got %q", got)
+	}
+	if !strings.Contains(got, "some item") {
+		t.Errorf("list text missing: %q", got)
+	}
+}
+
+func TestApplyInlineBold(t *testing.T) {
+	got := applyInline("normal **bold text** normal")
+	if !strings.Contains(got, ansiBold+"bold text"+ansiReset) {
+		t.Errorf("bold not wrapped, got %q", got)
+	}
+	if !strings.Contains(got, "normal") {
+		t.Errorf("surrounding text dropped: %q", got)
+	}
+}
+
+func TestApplyInlineCode(t *testing.T) {
+	got := applyInline("see `1.1` for details")
+	if !strings.Contains(got, ansiCyan+"1.1"+ansiReset) {
+		t.Errorf("inline code not styled, got %q", got)
+	}
+}
+
+func TestApplyInlineItalicUnderscore(t *testing.T) {
+	got := applyInline("a _word_ here")
+	if !strings.Contains(got, ansiItalic+"word"+ansiReset) {
+		t.Errorf("underscore italic missed, got %q", got)
+	}
+}
+
+func TestApplyInlineItalicStar(t *testing.T) {
+	got := applyInline("a *phrase* here")
+	if !strings.Contains(got, ansiItalic+"phrase"+ansiReset) {
+		t.Errorf("star italic missed, got %q", got)
+	}
+}
+
+func TestApplyInlineDoesNotEatBoldAsItalic(t *testing.T) {
+	// **bold** should not be partially matched as italic.
+	got := applyInline("**Pick:** something")
+	if strings.Contains(got, ansiItalic) {
+		t.Errorf("bold leaked into italic match: %q", got)
+	}
+	if !strings.Contains(got, ansiBold+"Pick:"+ansiReset) {
+		t.Errorf("bold not applied: %q", got)
+	}
+}
+
+func TestApplyInlineUnderscoreDoesNotMatchIdentifiers(t *testing.T) {
+	// snake_case identifiers should not be italicized by the underscore rule.
+	got := applyInline("the my_var_name field")
+	if strings.Contains(got, ansiItalic) {
+		t.Errorf("snake_case wrongly italicized: %q", got)
+	}
+}
+
+func TestRenderTerminalRoundTripFromDraftMarkdown(t *testing.T) {
+	// Real-shape input: the kind of lines draft.RenderMarkdown produces.
+	in := strings.Join([]string{
+		"# Drafts for r/golang",
+		"",
+		"**Brief:** Streambed",
+		"",
+		"---",
+		"",
+		"## openai · gpt-5 · risk: low",
+		"",
+		"### Pick: angle 2 / title 2.1 / body 2.1",
+		"",
+		"> reasoning here",
+		"",
+		"**Title:** Some title",
+		"",
+		"### Alternatives",
+		"",
+		"**Angle 1** — premise *(recommended angle)*",
+		"*Hook:* what surprised me",
+		"",
+		"Titles:",
+		"- `1.1` First title ← picked",
+		"- `1.2` Second title",
+		"",
+		"_tokens: in=1500 out=800_",
+	}, "\n")
+	out := renderTerminal(in)
+
+	mustContain := []string{
+		"Drafts for r/golang",
+		"openai · gpt-5",
+		"Pick:",
+		"reasoning here",
+		"Streambed",
+		"recommended angle",
+		"what surprised me",
+		"First title",
+		"in=1500 out=800",
+		ansiBold,
+		ansiCyan,
+		ansiGreen,
+		ansiMagenta,
+		ansiDim,
+		ansiItalic,
+		"•",
+		"│",
+		"─",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(out, s) {
+			t.Errorf("rendered output missing %q\n--- output ---\n%s", s, out)
+		}
+	}
+	mustNotContain := []string{"**", "###", "## ", "# ", "> ", "- `"}
+	for _, s := range mustNotContain {
+		if strings.Contains(out, s) {
+			t.Errorf("raw markdown leftover %q in output\n--- output ---\n%s", s, out)
+		}
+	}
+}


### PR DESCRIPTION
The squash merge of PR #6 dropped this commit (last one on the branch). Re-applying as a small standalone PR so step 5 starts from a complete step 4.

## Summary
Tiny ~150 LOC ANSI renderer for the specific markdown subset that \`draft.RenderMarkdown\` produces. When stdout is a TTY, \`--render=markdown\` becomes properly styled: bold/colored headings, dim blockquotes for reasoning, cyan for IDs and code spans, italic for hooks and tags. When piped or redirected, raw markdown passes through unchanged. \`NO_COLOR\` honored.

Zero new deps — chose this over \`charmbracelet/glamour\` (~40 transitive deps) because we control both the producer and the consumer of the markdown, so a general-purpose engine isn't justified. CLAUDE.md's "no SDKs / minimal deps" stance applies here too.

## Test plan
- [x] 10 tests cover headings, lists, blockquotes, hr, inline bold/italic/code, the bold-not-eaten-as-italic trap, snake_case-not-italicized, and a round-trip on a realistic \`draft.RenderMarkdown\` sample.
- [x] All other packages still pass.
- [x] Manually verified end-to-end on the prior step-4-draft branch — colored output rendered correctly in terminal, raw markdown through pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)