### PR TITLE
cmd/tider: default --render to markdown in TTY, json when piped

### DIFF
--- a/cmd/tider/draft.go
+++ b/cmd/tider/draft.go
@@ -121,14 +121,14 @@ without a key are skipped with a warning rather than failing the run.`,
 			}
 		}
 
-		switch draftRender {
+		switch resolveRender(draftRender) {
 		case "markdown":
 			md := draft.RenderMarkdown(bundle)
 			if isTerminal(os.Stdout) {
 				md = renderTerminal(md)
 			}
 			fmt.Print(md)
-		case "json", "":
+		case "json":
 			out, err := json.MarshalIndent(bundle, "", "  ")
 			if err != nil {
 				return err
@@ -197,7 +197,7 @@ func init() {
 	draftCmd.Flags().StringVar(&draftProviders, "providers", "openai,anthropic", "comma-separated providers to fan out across")
 	draftCmd.Flags().StringVar(&draftAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
 	draftCmd.Flags().StringVar(&draftOpenAI, "openai-model", "gpt-5", "OpenAI model to use")
-	draftCmd.Flags().StringVar(&draftRender, "render", "json", "output format: json | markdown")
+	draftCmd.Flags().StringVar(&draftRender, "render", "", "output format: json | markdown (default: markdown in TTY, json when piped)")
 	draftCmd.Flags().BoolVar(&draftDryRun, "dry-run", false, "render the prompt only, do not call the LLM")
 	draftCmd.Flags().BoolVar(&draftRefresh, "refresh", false, "force fresh Reddit fetch, bypass cache")
 	draftCmd.Flags().StringVar(&draftNotesPath, "notes", "", "path to subreddits.yaml (default ~/.tider/subreddits.yaml)")

--- a/cmd/tider/regen.go
+++ b/cmd/tider/regen.go
@@ -119,14 +119,14 @@ func finishRegen(snap *types.Snapshot, bundle *types.DraftBundle) error {
 	if err := lastdraft.Save(root, regenSub, snap); err != nil {
 		return err
 	}
-	switch regenRender {
+	switch resolveRender(regenRender) {
 	case "markdown":
 		md := draft.RenderMarkdown(bundle)
 		if isTerminal(os.Stdout) {
 			md = renderTerminal(md)
 		}
 		fmt.Print(md)
-	case "json", "":
+	case "json":
 		out, err := json.MarshalIndent(bundle, "", "  ")
 		if err != nil {
 			return err
@@ -142,7 +142,7 @@ func init() {
 	for _, c := range []*cobra.Command{regenTitlesCmd, regenBodyCmd} {
 		c.Flags().StringVar(&regenSub, "sub", "", "subreddit (the same one you ran `tider draft --sub` with)")
 		c.Flags().StringVar(&regenNote, "note", "", "guidance for the regeneration (e.g. \"more provocative\")")
-		c.Flags().StringVar(&regenRender, "render", "json", "output format: json | markdown")
+		c.Flags().StringVar(&regenRender, "render", "", "output format: json | markdown (default: markdown in TTY, json when piped)")
 		c.Flags().StringVar(&regenProviders, "providers", "openai,anthropic", "comma-separated providers (must include the providers in the saved bundle)")
 		c.Flags().StringVar(&regenAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
 		c.Flags().StringVar(&regenOpenAI, "openai-model", "gpt-5", "OpenAI model to use")

--- a/cmd/tider/term.go
+++ b/cmd/tider/term.go
@@ -69,6 +69,20 @@ func applyInline(s string) string {
 	return s
 }
 
+// resolveRender picks the output format when --render isn't set explicitly:
+// markdown when stdout is a terminal (and we'll ANSI-style it),
+// json when stdout is piped/redirected (so jq, files, downstream tools
+// see clean structured output).
+func resolveRender(flagVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	if isTerminal(os.Stdout) {
+		return "markdown"
+	}
+	return "json"
+}
+
 // isTerminal reports whether f is connected to an interactive terminal.
 // Used to decide whether to ANSI-render markdown output: TTY → rendered,
 // pipe/redirect → raw markdown so downstream tooling sees clean text.

--- a/cmd/tider/term_test.go
+++ b/cmd/tider/term_test.go
@@ -104,6 +104,29 @@ func TestApplyInlineUnderscoreDoesNotMatchIdentifiers(t *testing.T) {
 	}
 }
 
+func TestResolveRenderHonorsExplicitFlag(t *testing.T) {
+	// Explicit values pass through regardless of TTY state.
+	for _, v := range []string{"markdown", "json"} {
+		if got := resolveRender(v); got != v {
+			t.Errorf("resolveRender(%q) = %q, want %q", v, got, v)
+		}
+	}
+}
+
+func TestResolveRenderEmptyFallsBackToTTYDetection(t *testing.T) {
+	// Tests can't easily simulate a real TTY, but we can verify the empty-string
+	// path delegates to isTerminal() rather than returning the literal flag.
+	got := resolveRender("")
+	if got != "json" && got != "markdown" {
+		t.Errorf("resolveRender(\"\") = %q, want json or markdown", got)
+	}
+	// In a `go test` run stdout is a pipe (not a TTY), so empty should
+	// resolve to json.
+	if got != "json" {
+		t.Logf("test stdout is unexpectedly a TTY; got %q", got)
+	}
+}
+
 func TestRenderTerminalRoundTripFromDraftMarkdown(t *testing.T) {
 	// Real-shape input: the kind of lines draft.RenderMarkdown produces.
 	in := strings.Join([]string{


### PR DESCRIPTION
## Summary
You'd been typing \`--render=markdown\` on every draft and regen call. The ANSI rendering already adapted to TTY presence; the flag default just needed to follow suit.

- Empty \`--render\` → markdown when stdout is a terminal, json when piped/redirected.
- Explicit values (\`--render=markdown\` / \`--render=json\`) still work.
- jq, file redirects, downstream tooling all see clean json without needing to opt out.

Tiny change: ~20 LOC across one helper (\`resolveRender\` in term.go), updated to use it from draft/regen, plus tests + help-text refresh.

## Test plan
- [x] \`resolveRender\` returns explicit values verbatim.
- [x] Empty input falls back to TTY detection (returns json or markdown).
- [x] All other tests still pass.
- [x] \`tider draft --help\` and \`tider regen titles --help\` now show "default: markdown in TTY, json when piped".

## After this lands
\`\`\`
tider draft --brief=brief.json --sub=databases             # auto-markdown in terminal
tider draft --brief=brief.json --sub=databases > out.json  # auto-json when piped
\`\`\`

PR B (config file) is queued next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)