### PR TITLE
config: ~/.tider/config.yaml with per-task models + author_context

### DIFF
--- a/cmd/tider/config.go
+++ b/cmd/tider/config.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/config"
+)
+
+const seedAuthorContext = `Software engineering leader and serial founder with deep roots in Postgres
+and distributed systems. Five years at Cloudflare leading the Postgres /
+storage platform team (scaling to 1M+ QPS). Co-founder of Omnigres
+(Postgres-as-a-runtime). Currently building Streambed — a WAL-native CDC
+tool written in Go that pipes Postgres data into Iceberg/Parquet on S3
+and queries it via DuckDB over the Postgres wire protocol, with no
+external catalog dependencies and a single-binary architecture. Go-first
+builder; speaks at QConSF and other technical conferences.
+`
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Inspect or scaffold ~/.tider/config.yaml",
+	Long: `tider's config lives at ~/.tider/config.yaml. It holds provider/model
+defaults (per-task overrides supported), default render mode, and your
+author_context — the multi-line voice description that grounds drafts in
+your real lived experience instead of generic developer-tone prose.
+
+Subcommands:
+  tider config show   # print the effective config (defaults + overrides)
+  tider config init   # scaffold ~/.tider/config.yaml with sane defaults`,
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Print the effective config",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		c, err := config.Load()
+		if err != nil {
+			return err
+		}
+		data, err := c.Marshal()
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(data))
+		return nil
+	},
+}
+
+var configInitForce bool
+
+var configInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Scaffold ~/.tider/config.yaml with defaults",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := config.Path()
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stat(path); err == nil && !configInitForce {
+			return errors.New(path + " already exists; use --force to overwrite")
+		}
+		c := config.Default()
+		c.AuthorContext = seedAuthorContext
+		if err := c.Save(); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "wrote %s — edit author_context to match your voice.\n", path)
+		return nil
+	},
+}
+
+func init() {
+	configInitCmd.Flags().BoolVar(&configInitForce, "force", false, "overwrite an existing config file")
+	configCmd.AddCommand(configShowCmd)
+	configCmd.AddCommand(configInitCmd)
+}

--- a/cmd/tider/draft.go
+++ b/cmd/tider/draft.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/viggy28/tider/config"
 	"github.com/viggy28/tider/draft"
 	"github.com/viggy28/tider/internal/llm"
 	"github.com/viggy28/tider/internal/reddit"
@@ -81,13 +82,23 @@ without a key are skipped with a warning rather than failing the run.`,
 			return fmt.Errorf("research %s: %w", draftSub, err)
 		}
 
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		_, _, cfgMaxTokens := cfg.FanOutModels("draft")
+
 		opts := draft.Default()
 		if draftVariantSet == "full" {
 			opts = draft.Full()
 		}
+		// Resolve max_tokens: explicit flag wins, then config, then opts default.
 		if draftMaxTokens > 0 {
 			opts.MaxTokens = draftMaxTokens
+		} else if cfgMaxTokens > 0 {
+			opts.MaxTokens = cfgMaxTokens
 		}
+		opts.AuthorContext = cfg.AuthorContext
 
 		if draftDryRun {
 			prompt, err := draft.RenderPrompt(*brief, *researchBundle, opts)
@@ -98,7 +109,20 @@ without a key are skipped with a warning rather than failing the run.`,
 			return nil
 		}
 
-		refs, err := buildProviderRefs(draftProviders, draftAnthropic, draftOpenAI)
+		// Resolve fan-out provider list and per-provider models with config fallback.
+		providers := draftProviders
+		if providers == "" {
+			providers = cfg.Defaults.Providers
+		}
+		anthropicModel := draftAnthropic
+		openaiModel := draftOpenAI
+		if anthropicModel == "" {
+			anthropicModel = cfg.LLM.AnthropicModel
+		}
+		if openaiModel == "" {
+			openaiModel = cfg.LLM.OpenAIModel
+		}
+		refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
 		if err != nil {
 			return err
 		}
@@ -194,9 +218,9 @@ func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]dra
 func init() {
 	draftCmd.Flags().StringVar(&draftBriefPath, "brief", "", "path to a brief.json (output of `tider intake`)")
 	draftCmd.Flags().StringVar(&draftSub, "sub", "", "subreddit name to draft for (e.g., golang)")
-	draftCmd.Flags().StringVar(&draftProviders, "providers", "openai,anthropic", "comma-separated providers to fan out across")
-	draftCmd.Flags().StringVar(&draftAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
-	draftCmd.Flags().StringVar(&draftOpenAI, "openai-model", "gpt-5", "OpenAI model to use")
+	draftCmd.Flags().StringVar(&draftProviders, "providers", "", "comma-separated providers to fan out across (default from config)")
+	draftCmd.Flags().StringVar(&draftAnthropic, "anthropic-model", "", "Anthropic model to use (default from config)")
+	draftCmd.Flags().StringVar(&draftOpenAI, "openai-model", "", "OpenAI model to use (default from config)")
 	draftCmd.Flags().StringVar(&draftRender, "render", "", "output format: json | markdown (default: markdown in TTY, json when piped)")
 	draftCmd.Flags().BoolVar(&draftDryRun, "dry-run", false, "render the prompt only, do not call the LLM")
 	draftCmd.Flags().BoolVar(&draftRefresh, "refresh", false, "force fresh Reddit fetch, bypass cache")

--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/viggy28/tider/config"
 	"github.com/viggy28/tider/intake"
 	"github.com/viggy28/tider/internal/llm"
 	"github.com/viggy28/tider/internal/types"
@@ -35,14 +36,28 @@ API key for the chosen provider must be set in the environment
 			return fmt.Errorf("exactly one of --url or --file is required")
 		}
 
-		p, err := llm.New(llm.Config{Provider: intakeProvider, Model: intakeModel})
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		provider, model, maxTokens := cfg.ForTask("intake")
+		// Flags override config when set explicitly.
+		if intakeProvider != "" {
+			provider = intakeProvider
+		}
+		if intakeModel != "" {
+			model = intakeModel
+		}
+		if intakeMaxTokens > 0 {
+			maxTokens = intakeMaxTokens
+		}
+
+		p, err := llm.New(llm.Config{Provider: provider, Model: model})
 		if err != nil {
 			return err
 		}
 		i := intake.New(p)
-		if intakeMaxTokens > 0 {
-			i.MaxTokens = intakeMaxTokens
-		}
+		i.MaxTokens = maxTokens
 
 		ctx := context.Background()
 		var brief *types.Brief
@@ -67,7 +82,7 @@ API key for the chosen provider must be set in the environment
 func init() {
 	intakeCmd.Flags().StringVar(&intakeURL, "url", "", "URL to a blog post or GitHub repo")
 	intakeCmd.Flags().StringVar(&intakeFile, "file", "", "path to a markdown brief")
-	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "openai", "LLM provider: anthropic | openai")
-	intakeCmd.Flags().StringVar(&intakeModel, "model", "gpt-5", "LLM model name")
-	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget; 0 uses package default (8192).")
+	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "", "LLM provider: anthropic | openai (default from config)")
+	intakeCmd.Flags().StringVar(&intakeModel, "model", "", "LLM model name (default from config)")
+	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget (default from config)")
 }

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -20,6 +20,7 @@ func main() {
 	rootCmd.AddCommand(intakeCmd)
 	rootCmd.AddCommand(draftCmd)
 	rootCmd.AddCommand(regenCmd)
+	rootCmd.AddCommand(configCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/tider/regen.go
+++ b/cmd/tider/regen.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/viggy28/tider/config"
 	"github.com/viggy28/tider/draft"
 	"github.com/viggy28/tider/internal/llm"
 	"github.com/viggy28/tider/internal/types"
@@ -86,7 +87,8 @@ var regenBodyCmd = &cobra.Command{
 }
 
 // setupRegen loads the snapshot for the requested sub and constructs the
-// llm provider refs from --providers / --*-model flags.
+// llm provider refs from --providers / --*-model flags, falling back to
+// config when flags are unset.
 func setupRegen() (*types.Snapshot, []llm.ProviderRef, error) {
 	root, err := lastdraft.Default()
 	if err != nil {
@@ -96,7 +98,23 @@ func setupRegen() (*types.Snapshot, []llm.ProviderRef, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	refs, err := buildProviderRefs(regenProviders, regenAnthropic, regenOpenAI)
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+	providers := regenProviders
+	if providers == "" {
+		providers = cfg.Defaults.Providers
+	}
+	anthropicModel := regenAnthropic
+	openaiModel := regenOpenAI
+	if anthropicModel == "" {
+		anthropicModel = cfg.LLM.AnthropicModel
+	}
+	if openaiModel == "" {
+		openaiModel = cfg.LLM.OpenAIModel
+	}
+	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -143,9 +161,9 @@ func init() {
 		c.Flags().StringVar(&regenSub, "sub", "", "subreddit (the same one you ran `tider draft --sub` with)")
 		c.Flags().StringVar(&regenNote, "note", "", "guidance for the regeneration (e.g. \"more provocative\")")
 		c.Flags().StringVar(&regenRender, "render", "", "output format: json | markdown (default: markdown in TTY, json when piped)")
-		c.Flags().StringVar(&regenProviders, "providers", "openai,anthropic", "comma-separated providers (must include the providers in the saved bundle)")
-		c.Flags().StringVar(&regenAnthropic, "anthropic-model", "claude-sonnet-4-7", "Anthropic model to use")
-		c.Flags().StringVar(&regenOpenAI, "openai-model", "gpt-5", "OpenAI model to use")
+		c.Flags().StringVar(&regenProviders, "providers", "", "comma-separated providers (default from config)")
+		c.Flags().StringVar(&regenAnthropic, "anthropic-model", "", "Anthropic model to use (default from config)")
+		c.Flags().StringVar(&regenOpenAI, "openai-model", "", "OpenAI model to use (default from config)")
 	}
 	regenTitlesCmd.Flags().IntVar(&regenAngle, "angle", 0, "angle id (e.g. --angle=2)")
 	regenBodyCmd.Flags().StringVar(&regenVariant, "variant", "", "body variant id (e.g. --variant=2.1)")

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,182 @@
+// Package config loads ~/.tider/config.yaml and provides typed access to
+// the values. Missing config is fine — Default() returns hardcoded sane
+// defaults that match what the project's been using as flag defaults.
+//
+// Note: the original plan listed `viper` as the config library. Going
+// with yaml.v3 (already a dep from research/) instead — viper would pull
+// ~30 transitive deps for what amounts to "load one YAML file," which
+// runs counter to the project's minimal-deps stance (no SDKs, stdlib
+// HTTP, etc.). The package boundary here is what callers see, so a swap
+// to viper later is mechanical.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the full schema of ~/.tider/config.yaml. Every field is
+// optional — missing values fall back to Default().
+type Config struct {
+	LLM           LLMConfig      `yaml:"llm"`
+	Defaults      DefaultsConfig `yaml:"defaults"`
+	AuthorContext string         `yaml:"author_context"`
+}
+
+type LLMConfig struct {
+	// Single-provider defaults — used by commands that don't fan out
+	// (intake, eventually suggest/reply). The CLI's --provider / --model
+	// flags fall back to these.
+	Provider  string `yaml:"provider"`
+	Model     string `yaml:"model"`
+	MaxTokens int    `yaml:"max_tokens"`
+
+	// Per-provider model names — used by fan-out commands (draft, regen)
+	// where both providers run in parallel and each needs its own model.
+	AnthropicModel string `yaml:"anthropic_model"`
+	OpenAIModel    string `yaml:"openai_model"`
+
+	// Per-task overrides. Tasks may set their own provider/model/max_tokens
+	// to differ from the LLM-level defaults (e.g. intake uses cheap mini,
+	// draft uses reasoning model).
+	Tasks map[string]TaskConfig `yaml:"tasks"`
+}
+
+// TaskConfig is the per-task override block. Empty fields mean "use the
+// LLM-level default" — different tasks have different cost/quality
+// profiles (intake → cheap mini, draft → reasoning).
+type TaskConfig struct {
+	Provider  string `yaml:"provider,omitempty"`
+	Model     string `yaml:"model,omitempty"`
+	MaxTokens int    `yaml:"max_tokens,omitempty"`
+}
+
+type DefaultsConfig struct {
+	Render    string `yaml:"render,omitempty"`
+	Providers string `yaml:"providers,omitempty"`
+}
+
+// Default returns the fallback config: matches the hardcoded flag
+// defaults that have been baked into the CLI commands so far.
+func Default() *Config {
+	return &Config{
+		LLM: LLMConfig{
+			Provider:       "openai",
+			Model:          "gpt-5",
+			MaxTokens:      10000,
+			AnthropicModel: "claude-sonnet-4-7",
+			OpenAIModel:    "gpt-5",
+			Tasks: map[string]TaskConfig{
+				"intake": {Model: "gpt-4o-mini", MaxTokens: 8192},
+				"draft":  {MaxTokens: 10000},
+				"regen":  {MaxTokens: 4096},
+			},
+		},
+		Defaults: DefaultsConfig{
+			Render:    "",
+			Providers: "openai,anthropic",
+		},
+	}
+}
+
+// Path returns the canonical config path: ~/.tider/config.yaml.
+func Path() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".tider", "config.yaml"), nil
+}
+
+// Load reads ~/.tider/config.yaml and overlays it on Default(). A missing
+// file is not an error — defaults flow through.
+func Load() (*Config, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFrom(path)
+}
+
+// LoadFrom reads config from an explicit path. Useful for tests.
+func LoadFrom(path string) (*Config, error) {
+	cfg := Default()
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	// Ensure Tasks map is non-nil so callers can range over it safely.
+	if cfg.LLM.Tasks == nil {
+		cfg.LLM.Tasks = map[string]TaskConfig{}
+	}
+	return cfg, nil
+}
+
+// ForTask resolves provider/model/max_tokens for the named task, falling
+// back to LLM-level defaults when a per-task field is empty. Used by
+// single-provider commands (intake).
+func (c *Config) ForTask(task string) (provider, model string, maxTokens int) {
+	provider = c.LLM.Provider
+	model = c.LLM.Model
+	maxTokens = c.LLM.MaxTokens
+	if t, ok := c.LLM.Tasks[task]; ok {
+		if t.Provider != "" {
+			provider = t.Provider
+		}
+		if t.Model != "" {
+			model = t.Model
+		}
+		if t.MaxTokens > 0 {
+			maxTokens = t.MaxTokens
+		}
+	}
+	return
+}
+
+// FanOutModels returns the per-provider models and max-tokens budget for
+// commands that fan out across providers (draft, regen). Per-task
+// MaxTokens override applies; per-provider model names are LLM-level
+// (rare to want different per-provider models per task).
+func (c *Config) FanOutModels(task string) (anthropicModel, openaiModel string, maxTokens int) {
+	anthropicModel = c.LLM.AnthropicModel
+	openaiModel = c.LLM.OpenAIModel
+	maxTokens = c.LLM.MaxTokens
+	if t, ok := c.LLM.Tasks[task]; ok {
+		if t.MaxTokens > 0 {
+			maxTokens = t.MaxTokens
+		}
+	}
+	return
+}
+
+// Marshal returns the config as YAML bytes — used by `tider config show`.
+func (c *Config) Marshal() ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+// Save writes the config to its canonical path, creating the parent
+// directory if needed.
+func (c *Config) Save() error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir config: %w", err)
+	}
+	data, err := c.Marshal()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultMatchesShippedFlagDefaults(t *testing.T) {
+	c := Default()
+	if c.LLM.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", c.LLM.Provider)
+	}
+	if c.LLM.Model != "gpt-5" {
+		t.Errorf("model = %q, want gpt-5", c.LLM.Model)
+	}
+	if c.LLM.MaxTokens != 10000 {
+		t.Errorf("max_tokens = %d, want 10000", c.LLM.MaxTokens)
+	}
+	if c.Defaults.Providers != "openai,anthropic" {
+		t.Errorf("providers default = %q", c.Defaults.Providers)
+	}
+}
+
+func TestLoadFromMissingReturnsDefault(t *testing.T) {
+	c, err := LoadFrom(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.LLM.Provider != "openai" {
+		t.Errorf("missing config should fall back to default, got %q", c.LLM.Provider)
+	}
+}
+
+func TestLoadFromOverridesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yamlBody := `
+llm:
+  provider: anthropic
+  model: claude-sonnet-4-7
+  max_tokens: 12000
+  tasks:
+    intake:
+      model: claude-haiku-4-5
+      max_tokens: 4096
+defaults:
+  render: markdown
+author_context: |
+  Some custom voice.
+`
+	if err := os.WriteFile(path, []byte(yamlBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.LLM.Provider != "anthropic" {
+		t.Errorf("provider override missed: %q", c.LLM.Provider)
+	}
+	if c.LLM.Model != "claude-sonnet-4-7" {
+		t.Errorf("model override missed: %q", c.LLM.Model)
+	}
+	if c.LLM.MaxTokens != 12000 {
+		t.Errorf("max_tokens override missed: %d", c.LLM.MaxTokens)
+	}
+	intake := c.LLM.Tasks["intake"]
+	if intake.Model != "claude-haiku-4-5" {
+		t.Errorf("intake task override missed: %q", intake.Model)
+	}
+	if c.Defaults.Render != "markdown" {
+		t.Errorf("render default missed: %q", c.Defaults.Render)
+	}
+	if !strings.Contains(c.AuthorContext, "Some custom voice") {
+		t.Errorf("author_context missed: %q", c.AuthorContext)
+	}
+}
+
+func TestForTaskFallbackToLLMDefaults(t *testing.T) {
+	c := Default()
+	// "unknown" task isn't in the Tasks map → should return LLM-level defaults.
+	p, m, mt := c.ForTask("unknown")
+	if p != "openai" || m != "gpt-5" || mt != 10000 {
+		t.Errorf("fallback wrong: provider=%q model=%q mt=%d", p, m, mt)
+	}
+}
+
+func TestForTaskUsesTaskOverride(t *testing.T) {
+	c := Default()
+	p, m, mt := c.ForTask("intake")
+	// intake task overrides only Model and MaxTokens, so Provider falls back.
+	if p != "openai" || m != "gpt-4o-mini" || mt != 8192 {
+		t.Errorf("intake override wrong: provider=%q model=%q mt=%d", p, m, mt)
+	}
+}
+
+func TestFanOutModels(t *testing.T) {
+	c := Default()
+	am, om, mt := c.FanOutModels("draft")
+	if am != "claude-sonnet-4-7" {
+		t.Errorf("anthropic model = %q", am)
+	}
+	if om != "gpt-5" {
+		t.Errorf("openai model = %q", om)
+	}
+	if mt != 10000 {
+		t.Errorf("max_tokens = %d, want 10000", mt)
+	}
+
+	// regen has different max_tokens
+	_, _, mt = c.FanOutModels("regen")
+	if mt != 4096 {
+		t.Errorf("regen max_tokens = %d, want 4096", mt)
+	}
+
+	// unknown task → LLM-level max_tokens
+	_, _, mt = c.FanOutModels("unknown")
+	if mt != 10000 {
+		t.Errorf("unknown task max_tokens = %d", mt)
+	}
+}
+
+func TestForTaskPartialOverride(t *testing.T) {
+	// If a task only overrides Model, Provider/MaxTokens should fall back.
+	c := Default()
+	c.LLM.Tasks["partial"] = TaskConfig{Model: "claude-haiku-4-5"}
+	p, m, mt := c.ForTask("partial")
+	if p != "openai" {
+		t.Errorf("partial: provider should fall back to llm-level, got %q", p)
+	}
+	if m != "claude-haiku-4-5" {
+		t.Errorf("partial: model override missed, got %q", m)
+	}
+	if mt != 10000 {
+		t.Errorf("partial: max_tokens should fall back, got %d", mt)
+	}
+}
+
+func TestMarshalRoundTrip(t *testing.T) {
+	c := Default()
+	c.AuthorContext = "I built X. I write like this."
+	data, err := c.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "openai") {
+		t.Errorf("marshal output missing provider: %s", data)
+	}
+	if !strings.Contains(string(data), "I built X") {
+		t.Errorf("marshal output missing author_context: %s", data)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.AuthorContext != c.AuthorContext {
+		t.Errorf("round trip lost author_context: %q", loaded.AuthorContext)
+	}
+}
+
+func TestLoadFromTasksMapNeverNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	// Config without a tasks map at all.
+	if err := os.WriteFile(path, []byte("llm:\n  provider: openai\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.LLM.Tasks == nil {
+		t.Errorf("Tasks should never be nil after Load")
+	}
+	// Range is safe.
+	for k := range c.LLM.Tasks {
+		_ = k
+	}
+}

--- a/draft/draft.go
+++ b/draft/draft.go
@@ -25,6 +25,12 @@ type Options struct {
 	TitlesPerAngle int
 	BodiesPerAngle int
 	MaxTokens      int
+	// AuthorContext is the user's voice/background — what they've built,
+	// what experiences inform their take, what tone they want drafts in.
+	// Empty means generic developer-tone; loaded from ~/.tider/config.yaml's
+	// author_context field. Flows into the draft prompt so generated copy
+	// references real lived experience.
+	AuthorContext string
 }
 
 // Default is the spec's "2 angles × 3 titles × 2 bodies" — ~12 artifacts.
@@ -76,6 +82,7 @@ func RenderPrompt(brief types.Brief, research types.Research, opts Options) (str
 		AngleCount     int
 		TitlesPerAngle int
 		BodiesPerAngle int
+		AuthorContext  string
 	}{
 		SubName:        research.Sub.Name,
 		Subscribers:    research.Sub.Subscribers,
@@ -90,6 +97,7 @@ func RenderPrompt(brief types.Brief, research types.Research, opts Options) (str
 		AngleCount:     opts.AngleCount,
 		TitlesPerAngle: opts.TitlesPerAngle,
 		BodiesPerAngle: opts.BodiesPerAngle,
+		AuthorContext:  opts.AuthorContext,
 	})
 	if err != nil {
 		return "", fmt.Errorf("render draft prompt: %w", err)

--- a/draft/draft_test.go
+++ b/draft/draft_test.go
@@ -133,6 +133,34 @@ func TestRenderPromptIncludesContextAndCounts(t *testing.T) {
 	}
 }
 
+func TestRenderPromptIncludesAuthorContextWhenSet(t *testing.T) {
+	opts := Default()
+	opts.AuthorContext = "Five years at Cloudflare leading the Postgres team. Currently building Streambed."
+	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(prompt, "Who you're writing as") {
+		t.Error("author context section heading missing")
+	}
+	if !strings.Contains(prompt, "Five years at Cloudflare") {
+		t.Error("author context body not embedded")
+	}
+	if !strings.Contains(prompt, "ground them in this background") {
+		t.Error("author context guidance to LLM missing")
+	}
+}
+
+func TestRenderPromptOmitsAuthorContextWhenEmpty(t *testing.T) {
+	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(prompt, "Who you're writing as") {
+		t.Errorf("author context section should not render when AuthorContext empty")
+	}
+}
+
 func TestRenderPromptRejectsZeroCounts(t *testing.T) {
 	_, err := RenderPrompt(sampleBrief(), sampleResearch(), Options{AngleCount: 0, TitlesPerAngle: 3, BodiesPerAngle: 2})
 	if err == nil {

--- a/prompts/draft.tmpl
+++ b/prompts/draft.tmpl
@@ -1,4 +1,12 @@
 You are drafting Reddit posts for a specific subreddit. You write FROM the user's perspective; you never post anything yourself. The user reviews drafts, picks one, and posts manually.
+{{- if .AuthorContext }}
+
+# Who you're writing as
+
+{{.AuthorContext}}
+
+When you reference experience, lessons, or opinions in the body copy, ground them in this background — not generic developer-tone "I built a thing" prose. Drafts should sound like *this person* talking to peers, with the credibility their actual track record carries. Don't invent specific events or numbers that aren't in the brief or the source material; the background here is for *voice*, not factual padding.
+{{- end }}
 
 # Subreddit: r/{{.SubName}}
 


### PR DESCRIPTION
## Summary

Eliminates the daily flag burden. After a one-time \`tider config init\`:

\`\`\`
tider intake --url=https://github.com/viggy28/streambed
tider draft --brief=brief.json --sub=databases
tider regen titles --sub=databases --angle=2 --note="punchier"
\`\`\`

…each pulls provider/model/max-tokens from \`~/.tider/config.yaml\`. No \`--provider\`, no \`--openai-model\`, no \`--max-tokens\`. Flags still work and override config when set explicitly.

## Schema

\`\`\`yaml
llm:
  provider: openai          # single-provider default (intake)
  model: gpt-5
  max_tokens: 10000
  anthropic_model: claude-sonnet-4-7   # fan-out (draft, regen)
  openai_model: gpt-5
  tasks:
    intake:  { model: gpt-4o-mini, max_tokens: 8192 }
    draft:   { max_tokens: 10000 }
    regen:   { max_tokens: 4096 }
defaults:
  providers: openai,anthropic           # fan-out provider list
  render: ""
author_context: |
  ...multi-line bio...
\`\`\`

## The underrated win: \`author_context\`

Drafts have been generic-developer-tone — "I built a small tool" — because the prompt had no grounding for the user's voice. With \`author_context\` set, prompts/draft.tmpl now includes a "Who you're writing as" section. The LLM is explicitly guided to ground references in the background **without inventing facts not in the brief**. \`tider config init\` seeds it with the Streambed bio from plan.md as a real starting example to refine.

## CLI

- \`tider config show\` — print effective config (defaults + any overrides)
- \`tider config init\` — scaffold ~/.tider/config.yaml with defaults + seed author_context (\`--force\` to overwrite)

## Implementation note worth flagging

Went with \`yaml.v3\` (already a dep) instead of \`viper\` despite the original plan listing viper. Viper would pull ~30 transitive deps for "load one YAML file," counter to the project's minimal-deps stance (no SDKs, stdlib HTTP, etc.). The package boundary is what callers see, so a swap to viper later is mechanical.

## Test plan

- [x] config: load/default/round-trip, \`ForTask\` (single-provider) and \`FanOutModels\` (draft/regen) resolution with full and partial overrides, never-nil Tasks map post-load.
- [x] draft: \`AuthorContext\` renders into prompt under "Who you're writing as" header when set, omitted entirely when empty.
- [x] All prior packages still pass.
- [x] Smoke: \`tider config init && tider config show\` round-trips correctly with the seed author_context preserved verbatim.

## Out of scope (deferred)

- Combined \`tider draft --url=...\` workflow (skip the brief.json file dance) — separate small PR.
- Default sub list as a config field — useful when running the same Brief across multiple subs (Streambed launch case), but no immediate signal that single-sub-at-a-time is the bottleneck.
- Sessions (\`~/.tider/projects/{project}/sessions/...\`) — bigger refactor, lastdraft already serves the immediate need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)