### PR TITLE
cmd/tider: auto-load .env from cwd and ~/.tider/.env

### DIFF
--- a/cmd/tider/dotenv.go
+++ b/cmd/tider/dotenv.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// loadDotenv reads a .env file at path (if it exists) and sets each
+// KEY=value pair as an environment variable, but only if the variable
+// isn't already set. Explicit `export KEY=value` lines are supported but
+// the `export` keyword is optional; surrounding double or single quotes
+// on values are stripped; lines starting with # and blank lines are
+// ignored.
+//
+// Real env (passed by the parent shell) always wins over .env. A missing
+// file is not an error — returns nil so call sites can opportunistically
+// load without checking.
+//
+// Why we ship this: `source .env` in shells doesn't export plain
+// `KEY=value` lines to subprocesses, which silently breaks the binary.
+// Auto-loading at startup matches the convention used by most CLI tools
+// that read API keys (rails, node apps, etc.).
+func loadDotenv(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue // malformed (no key, or no =) — skip silently
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		val = stripQuotes(val)
+
+		// Don't override real env that the user already exported. Their
+		// explicit choice wins over a stale .env value.
+		if _, present := os.LookupEnv(key); present {
+			continue
+		}
+		if err := os.Setenv(key, val); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	return scanner.Err()
+}
+
+func stripQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	first, last := s[0], s[len(s)-1]
+	if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// autoloadEnv applies loadDotenv to the conventional locations: the
+// current working directory's .env first (highest priority after real
+// env), then ~/.tider/.env as a fallback for users who keep keys in a
+// per-tool-global file. cwd wins because the skip-if-already-set logic
+// in loadDotenv leaves earlier sets in place.
+func autoloadEnv() {
+	// Errors here are intentionally swallowed — a malformed .env shouldn't
+	// block the user from running the tool. They'll see "API_KEY not set"
+	// from the provider constructor instead, which is a clearer signal.
+	_ = loadDotenv(".env")
+	if home, err := os.UserHomeDir(); err == nil {
+		_ = loadDotenv(filepath.Join(home, ".tider", ".env"))
+	}
+}

--- a/cmd/tider/dotenv_test.go
+++ b/cmd/tider/dotenv_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeEnv is a small helper that writes content to <dir>/.env and
+// returns the path.
+func writeEnv(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadDotenvBasic(t *testing.T) {
+	t.Setenv("TIDER_TEST_BASIC", "")
+	os.Unsetenv("TIDER_TEST_BASIC")
+	path := writeEnv(t, t.TempDir(), "TIDER_TEST_BASIC=hello\n")
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_BASIC"); got != "hello" {
+		t.Errorf("got %q, want hello", got)
+	}
+}
+
+func TestLoadDotenvWithExport(t *testing.T) {
+	os.Unsetenv("TIDER_TEST_EXPORT")
+	path := writeEnv(t, t.TempDir(), "export TIDER_TEST_EXPORT=world\n")
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_EXPORT"); got != "world" {
+		t.Errorf("got %q, want world", got)
+	}
+}
+
+func TestLoadDotenvStripsQuotes(t *testing.T) {
+	os.Unsetenv("TIDER_TEST_DQ")
+	os.Unsetenv("TIDER_TEST_SQ")
+	os.Unsetenv("TIDER_TEST_NOQ")
+	body := `TIDER_TEST_DQ="double quoted"
+TIDER_TEST_SQ='single quoted'
+TIDER_TEST_NOQ=plain
+`
+	path := writeEnv(t, t.TempDir(), body)
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		"TIDER_TEST_DQ":  "double quoted",
+		"TIDER_TEST_SQ":  "single quoted",
+		"TIDER_TEST_NOQ": "plain",
+	}
+	for k, want := range cases {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestLoadDotenvIgnoresCommentsAndBlanks(t *testing.T) {
+	os.Unsetenv("TIDER_TEST_AFTER_COMMENT")
+	body := `
+# This is a comment
+   # Indented comment
+
+TIDER_TEST_AFTER_COMMENT=ok
+
+`
+	path := writeEnv(t, t.TempDir(), body)
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_AFTER_COMMENT"); got != "ok" {
+		t.Errorf("got %q, want ok", got)
+	}
+}
+
+func TestLoadDotenvDoesNotOverrideExistingEnv(t *testing.T) {
+	t.Setenv("TIDER_TEST_EXISTING", "from-shell")
+	path := writeEnv(t, t.TempDir(), "TIDER_TEST_EXISTING=from-dotenv\n")
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_EXISTING"); got != "from-shell" {
+		t.Errorf("real env should win: got %q, want from-shell", got)
+	}
+}
+
+func TestLoadDotenvMissingFileIsOK(t *testing.T) {
+	if err := loadDotenv(filepath.Join(t.TempDir(), "does-not-exist.env")); err != nil {
+		t.Errorf("missing file should not error, got %v", err)
+	}
+}
+
+func TestLoadDotenvMalformedLinesSkipped(t *testing.T) {
+	os.Unsetenv("TIDER_TEST_GOOD")
+	body := `
+no_equals_sign_here
+=no_key_either
+TIDER_TEST_GOOD=yes
+`
+	path := writeEnv(t, t.TempDir(), body)
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_GOOD"); got != "yes" {
+		t.Errorf("good line after malformed lines lost: got %q", got)
+	}
+}
+
+func TestLoadDotenvTrimsKeyAndValueWhitespace(t *testing.T) {
+	os.Unsetenv("TIDER_TEST_SPACES")
+	path := writeEnv(t, t.TempDir(), "  TIDER_TEST_SPACES   =   trimmed   \n")
+	if err := loadDotenv(path); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("TIDER_TEST_SPACES"); got != "trimmed" {
+		t.Errorf("got %q, want trimmed", got)
+	}
+}
+
+func TestStripQuotes(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`"hello"`, "hello"},
+		{`'hello'`, "hello"},
+		{`hello`, "hello"},
+		{`"unclosed`, `"unclosed`},
+		{`unclosed"`, `unclosed"`},
+		{``, ``},
+		{`"`, `"`},
+		{`""`, ``},
+	}
+	for _, c := range cases {
+		if got := stripQuotes(c.in); got != c.want {
+			t.Errorf("stripQuotes(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -16,6 +16,11 @@ post manually. No auth, no posting, no commenting — by design.`,
 }
 
 func main() {
+	// Auto-load .env from cwd and ~/.tider/.env so users don't have to
+	// `source .env` (and don't have to remember `export` or `set -a`).
+	// Real env always wins.
+	autoloadEnv()
+
 	rootCmd.AddCommand(researchCmd)
 	rootCmd.AddCommand(intakeCmd)
 	rootCmd.AddCommand(draftCmd)


### PR DESCRIPTION
## Why
\`source .env\` in shells doesn't export plain \`KEY=value\` lines to subprocesses, so users hit "OPENAI_API_KEY not set" even after sourcing. Earlier guidance to use \`set -a\` or add \`export\` works but is friction the binary should absorb.

## What
On startup, read \`.env\` from cwd and \`~/.tider/.env\`. cwd wins; real env wins over both. Supports:
- \`KEY=value\`
- \`export KEY=value\`
- \`KEY="quoted value"\` and \`KEY='single-quoted'\`
- \`# comments\` and blank lines

~50-line parser, no \`godotenv\` dep — same minimalism stance as the rest of the project. Malformed \`.env\` errors are swallowed so a busted file doesn't block the tool; users see the provider's "missing key" or 401 directly, which is a clearer signal than "could not parse line 7."

## Test plan

**Unit tests** — 9 cases pass:
- [x] Basic \`KEY=value\` sets the env var
- [x] \`export KEY=value\` prefix supported
- [x] Double-quoted values stripped
- [x] Single-quoted values stripped
- [x] Plain (unquoted) values pass through
- [x] Comment lines (\`#\`) and blank lines ignored
- [x] Real env (set by parent shell) is NOT overridden by .env
- [x] Missing file is not an error
- [x] Malformed lines (no \`=\`, no key) skipped without losing later good lines
- [x] Surrounding whitespace on key and value is trimmed

**Smoke** — reproduces the user's reported failure mode in a clean shell:
\`\`\`
$ env -i HOME=/tmp PATH=$PATH ./tider intake --url=https://example.com
Error: llm extract: openai 401 invalid_request_error: Incorrect API key...
\`\`\`
The 401 from OpenAI confirms the key was loaded from \`.env\` and sent. Previously this would have errored at \`NewOpenAI\` with "OPENAI_API_KEY not set" before any HTTP call.

## Out of scope (deferred)
- Hierarchical search up the directory tree (like git looking for .git). Add later if anyone wants to run \`tider\` from a subdirectory of their project.
- Variable interpolation (\`KEY=\${OTHER}\`) — godotenv supports it but we don't need it for API keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)