### PR TITLE
research: sharpen human insight reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ insight step can be rerun without another Reddit fetch. Use `--refresh`
 to force a new Reddit fetch, or `--raw` to print the raw bundle without
 LLM-generated insights.
 
-By default, `research` prints a concise human report focused on pain-point
-clusters, repeated asks, opportunity signals, community language, confidence,
-and 3-5 evidence posts. Use `--render=json` for raw + insights JSON, or
-`--render=insights-json` for only the structured insight report.
+By default, `research` prints a concise human report focused on one takeaway,
+the strongest pain points, narrower support friction, repeated asks,
+opportunity areas, community language, confidence, and 3-5 evidence posts.
+Use `--render=json` for raw + insights JSON, or `--render=insights-json` for
+only the structured insight report.
 The insight step uses the configured `research` LLM task, which defaults to
 `gpt-5` with a larger completion budget for reasoning-model headroom.
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -201,20 +201,29 @@ type PainPointCluster struct {
 	Evidence   []ResearchEvidence `json:"evidence"`
 }
 
+type SpecificFriction struct {
+	Name       string             `json:"name"`
+	Summary    string             `json:"summary"`
+	Confidence string             `json:"confidence"` // "medium" | "low"
+	Evidence   []ResearchEvidence `json:"evidence"`
+}
+
 // ResearchInsights is the human-oriented output of `tider research`: factual
 // pain-point clusters, repeated asks, opportunity signals, and language found
 // in recent subreddit posts.
 type ResearchInsights struct {
-	Subreddit    string             `json:"subreddit"`
-	PainPoints   []PainPointCluster `json:"pain_points"`
-	RepeatedAsks []string           `json:"repeated_asks"`
-	Opportunity  []string           `json:"opportunity"`
-	Language     []string           `json:"language"`
-	Evidence     []ResearchEvidence `json:"evidence"`
-	Limitations  []string           `json:"limitations,omitempty"`
-	InputTokens  int                `json:"input_tokens,omitempty"`
-	OutputTokens int                `json:"output_tokens,omitempty"`
-	Generated    time.Time          `json:"generated"`
+	Subreddit        string             `json:"subreddit"`
+	Takeaway         string             `json:"takeaway,omitempty"`
+	PainPoints       []PainPointCluster `json:"pain_points"`
+	SpecificFriction []SpecificFriction `json:"specific_friction,omitempty"`
+	RepeatedAsks     []string           `json:"repeated_asks"`
+	Opportunity      []string           `json:"opportunity"`
+	Language         []string           `json:"language"`
+	Evidence         []ResearchEvidence `json:"evidence"`
+	Limitations      []string           `json:"limitations,omitempty"`
+	InputTokens      int                `json:"input_tokens,omitempty"`
+	OutputTokens     int                `json:"output_tokens,omitempty"`
+	Generated        time.Time          `json:"generated"`
 }
 
 // ResearchReport pairs the raw Reddit bundle with the synthesized insight

--- a/prompts/research_insights.tmpl
+++ b/prompts/research_insights.tmpl
@@ -2,6 +2,12 @@ You analyze recent Reddit posts to produce a concise, factual pain-point researc
 
 Your job is clustering and compression, not prediction. Do not invent facts. Do not extrapolate beyond the supplied posts. Do not add advice about posting, promotion, subreddit etiquette, flairs, or audience segments. If the evidence is thin, say so in `limitations` and use "low" confidence.
 
+Separate broad pain from one-off support friction:
+- `pain_points` are broad, recurring, or generalizable problems. They need repeated evidence or one clearly broad thread with meaningful comment activity.
+- `specific_friction` is for narrow implementation problems, plugin/theme conflicts, bug reports, edge-case setup questions, migration questions, or single-thread support tickets. Do not promote these to `pain_points` unless multiple posts support the same underlying problem.
+- `repeated_asks` are questions people ask. Do not turn a question into a pain point unless the supplied posts show the underlying pain.
+- `opportunity` should name factual opportunity areas, not product specs or advice. Prefer "fewer-screen analytics workflows" over "build a consolidated analytics dashboard with X, Y, Z". Every opportunity must be directly supported by a `pain_points` or `specific_friction` item you returned.
+
 # Subreddit
 
 r/{{.SubName}}
@@ -39,11 +45,28 @@ Return one JSON object with exactly these fields:
 
 {
   "subreddit": "{{.SubName}}",
+  "takeaway": "one short synthesis sentence naming the strongest signal and any important caveat",
   "pain_points": [
     {
       "name": "short factual cluster name",
-      "summary": "1-2 sentences describing only what the posts support",
+      "summary": "one short sentence describing only what the posts support",
       "confidence": "high" | "medium" | "low",
+      "evidence": [
+        {
+          "title": "exact post title",
+          "score": 0,
+          "comments": 0,
+          "source": "top_week" | "top_month" | "hot",
+          "permalink": "post permalink"
+        }
+      ]
+    }
+  ],
+  "specific_friction": [
+    {
+      "name": "short factual issue name",
+      "summary": "one short sentence describing the narrow support issue",
+      "confidence": "medium" | "low",
       "evidence": [
         {
           "title": "exact post title",
@@ -79,10 +102,14 @@ Return one JSON object with exactly these fields:
 }
 
 Constraints:
-- Return 3-5 pain-point clusters if evidence supports them; fewer is fine.
+- Return at most 3 pain-point clusters. Fewer is better when signal is thin.
+- Return at most 4 specific friction items.
 - Use 3-5 evidence posts total in top-level `evidence`.
 - Each pain point may cite 1-2 evidence posts.
-- Keep repeated_asks to 3-6 items.
-- Keep opportunity to 2-5 factual signals.
-- Keep language to 5-12 terms or phrases.
+- Keep repeated_asks to 3-4 items.
+- Repeated asks must be semantically distinct; merge near-duplicates.
+- Keep opportunity to 2-3 factual signals.
+- Do not include opportunity areas that are not represented in the evidence posts you selected.
+- Keep language to 5-8 terms or phrases.
+- Keep all summaries short. No paragraph-style prose.
 - Every evidence item must come from the supplied posts exactly.

--- a/research/insights.go
+++ b/research/insights.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -90,6 +91,7 @@ func GenerateInsights(ctx context.Context, p llm.Provider, model string, r types
 	insights.OutputTokens = resp.OutputTokens
 	insights.Generated = time.Now().UTC()
 	trimInsights(&insights)
+	filterUnsupportedOpportunity(&insights)
 	fillTopLevelEvidence(&insights)
 	return &insights, nil
 }
@@ -135,17 +137,20 @@ func selectPromptPosts(r types.Research, limit int) []insightPromptPost {
 }
 
 func trimInsights(i *types.ResearchInsights) {
-	if len(i.PainPoints) > 5 {
-		i.PainPoints = i.PainPoints[:5]
+	if len(i.PainPoints) > 3 {
+		i.PainPoints = i.PainPoints[:3]
 	}
-	if len(i.RepeatedAsks) > 6 {
-		i.RepeatedAsks = i.RepeatedAsks[:6]
+	if len(i.SpecificFriction) > 4 {
+		i.SpecificFriction = i.SpecificFriction[:4]
 	}
-	if len(i.Opportunity) > 5 {
-		i.Opportunity = i.Opportunity[:5]
+	if len(i.RepeatedAsks) > 4 {
+		i.RepeatedAsks = i.RepeatedAsks[:4]
 	}
-	if len(i.Language) > 12 {
-		i.Language = i.Language[:12]
+	if len(i.Opportunity) > 3 {
+		i.Opportunity = i.Opportunity[:3]
+	}
+	if len(i.Language) > 8 {
+		i.Language = i.Language[:8]
 	}
 	if len(i.Evidence) > 5 {
 		i.Evidence = i.Evidence[:5]
@@ -155,6 +160,56 @@ func trimInsights(i *types.ResearchInsights) {
 			i.PainPoints[pi].Evidence = i.PainPoints[pi].Evidence[:2]
 		}
 	}
+	for fi := range i.SpecificFriction {
+		if len(i.SpecificFriction[fi].Evidence) > 1 {
+			i.SpecificFriction[fi].Evidence = i.SpecificFriction[fi].Evidence[:1]
+		}
+	}
+}
+
+var wordRE = regexp.MustCompile(`[A-Za-z][A-Za-z0-9-]{2,}`)
+
+var opportunityStopWords = map[string]bool{
+	"and": true, "are": true, "but": true, "can": true, "for": true, "from": true,
+	"has": true, "into": true, "not": true, "that": true, "the": true, "their": true,
+	"this": true, "with": true, "within": true, "without": true, "workflow": true,
+	"workflows": true, "woocommerce": true, "woo": true,
+}
+
+func filterUnsupportedOpportunity(i *types.ResearchInsights) {
+	if len(i.Opportunity) == 0 {
+		return
+	}
+	supported := map[string]bool{}
+	add := func(s string) {
+		for _, w := range wordRE.FindAllString(strings.ToLower(s), -1) {
+			if !opportunityStopWords[w] {
+				supported[w] = true
+			}
+		}
+	}
+	for _, p := range i.PainPoints {
+		add(p.Name)
+		add(p.Summary)
+	}
+	for _, f := range i.SpecificFriction {
+		add(f.Name)
+		add(f.Summary)
+	}
+	var out []string
+	for _, note := range i.Opportunity {
+		keep := false
+		for _, w := range wordRE.FindAllString(strings.ToLower(note), -1) {
+			if supported[w] {
+				keep = true
+				break
+			}
+		}
+		if keep {
+			out = append(out, note)
+		}
+	}
+	i.Opportunity = out
 }
 
 func fillTopLevelEvidence(i *types.ResearchInsights) {
@@ -164,6 +219,19 @@ func fillTopLevelEvidence(i *types.ResearchInsights) {
 	seen := map[string]bool{}
 	for _, p := range i.PainPoints {
 		for _, e := range p.Evidence {
+			key := e.Title + "|" + e.Permalink
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			i.Evidence = append(i.Evidence, e)
+			if len(i.Evidence) >= 5 {
+				return
+			}
+		}
+	}
+	for _, f := range i.SpecificFriction {
+		for _, e := range f.Evidence {
 			key := e.Title + "|" + e.Permalink
 			if seen[key] {
 				continue

--- a/research/insights_test.go
+++ b/research/insights_test.go
@@ -68,6 +68,7 @@ func sampleInsightResearch() types.Research {
 
 const cannedInsightsJSON = `{
   "subreddit": "woocommerce",
+  "takeaway": "The strongest signal is store-operator friction around WooCommerce performance workflows, while several other issues are narrower support cases.",
   "pain_points": [
     {
       "name": "Checkout changes and conversion friction",
@@ -78,8 +79,18 @@ const cannedInsightsJSON = `{
       ]
     }
   ],
-  "repeated_asks": ["What changes actually helped a store?"],
-  "opportunity": ["Practical diagnostics around checkout and product data show up as concrete needs."],
+  "specific_friction": [
+    {
+      "name": "Theme/plugin checkout compatibility",
+      "summary": "A theme and deposit plugin interaction can lose checkout metadata during AJAX cart flows.",
+      "confidence": "low",
+      "evidence": [
+        {"title": "Plugin conflict after checkout update", "score": 7, "comments": 9, "source": "top_month", "permalink": "/r/woocommerce/comments/c/example/"}
+      ]
+    }
+  ],
+  "repeated_asks": ["What changes actually helped a store?", "How can checkout plugin conflicts be diagnosed?"],
+  "opportunity": ["Fewer-screen performance workflows and clearer checkout diagnostics show up as useful opportunity areas."],
   "language": ["checkout", "store", "structured product data"],
   "evidence": [
     {"title": "What is one change that helped your WooCommerce store?", "score": 14, "comments": 17, "source": "top_week", "permalink": "/r/woocommerce/comments/a/example/"},
@@ -98,6 +109,8 @@ func TestRenderInsightsPromptIsEvidenceGrounded(t *testing.T) {
 		"Do not invent facts",
 		"Do not extrapolate",
 		"Do not add advice about posting",
+		"specific_friction",
+		"Do not turn a question into a pain point",
 		"What is one change that helped your WooCommerce store?",
 		"Plugin conflict after checkout update",
 	} {
@@ -137,6 +150,12 @@ func TestGenerateInsightsParsesAndRecordsTokens(t *testing.T) {
 	if len(insights.PainPoints) != 1 {
 		t.Fatalf("pain_points len = %d", len(insights.PainPoints))
 	}
+	if insights.Takeaway == "" {
+		t.Error("takeaway not parsed")
+	}
+	if len(insights.SpecificFriction) != 1 {
+		t.Fatalf("specific_friction len = %d", len(insights.SpecificFriction))
+	}
 	if insights.InputTokens != 11 || insights.OutputTokens != 22 {
 		t.Errorf("tokens = in=%d out=%d", insights.InputTokens, insights.OutputTokens)
 	}
@@ -167,9 +186,12 @@ func TestRenderMarkdownIsConcise(t *testing.T) {
 	md := RenderMarkdown(insights)
 	for _, want := range []string{
 		"# r/woocommerce Research",
-		"## Pain Point Clusters",
+		"## Takeaway",
+		"## Strongest Pain Points",
 		"Checkout changes and conversion friction",
 		"medium confidence",
+		"## Specific Friction Seen",
+		"Theme/plugin checkout compatibility",
 		"## Evidence Posts",
 	} {
 		if !strings.Contains(md, want) {
@@ -178,5 +200,85 @@ func TestRenderMarkdownIsConcise(t *testing.T) {
 	}
 	if strings.Contains(md, "Body excerpt") {
 		t.Errorf("markdown should not include raw body excerpts")
+	}
+}
+
+func TestGenerateInsightsTrimsForHumanDigestibility(t *testing.T) {
+	var payload types.ResearchInsights
+	payload.Subreddit = "woocommerce"
+	for i := 0; i < 5; i++ {
+		payload.PainPoints = append(payload.PainPoints, types.PainPointCluster{Name: "pain"})
+	}
+	for i := 0; i < 6; i++ {
+		payload.SpecificFriction = append(payload.SpecificFriction, types.SpecificFriction{Name: "friction"})
+	}
+	for i := 0; i < 10; i++ {
+		payload.RepeatedAsks = append(payload.RepeatedAsks, "ask")
+		payload.Opportunity = append(payload.Opportunity, "pain opportunity")
+		payload.Language = append(payload.Language, "term")
+		payload.Evidence = append(payload.Evidence, types.ResearchEvidence{Title: "evidence"})
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &fakeInsightProvider{response: string(raw)}
+	insights, err := GenerateInsights(context.Background(), p, "gpt-5", sampleInsightResearch(), 1234)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(insights.PainPoints) != 3 {
+		t.Errorf("pain points len = %d", len(insights.PainPoints))
+	}
+	if len(insights.SpecificFriction) != 4 {
+		t.Errorf("specific friction len = %d", len(insights.SpecificFriction))
+	}
+	if len(insights.RepeatedAsks) != 4 {
+		t.Errorf("repeated asks len = %d", len(insights.RepeatedAsks))
+	}
+	if len(insights.Opportunity) != 3 {
+		t.Errorf("opportunity len = %d", len(insights.Opportunity))
+	}
+	if len(insights.Language) != 8 {
+		t.Errorf("language len = %d", len(insights.Language))
+	}
+	if len(insights.Evidence) != 5 {
+		t.Errorf("evidence len = %d", len(insights.Evidence))
+	}
+}
+
+func TestGenerateInsightsFiltersUnsupportedOpportunity(t *testing.T) {
+	payload := types.ResearchInsights{
+		Subreddit: "woocommerce",
+		PainPoints: []types.PainPointCluster{{
+			Name:    "Fragmented analytics workflows",
+			Summary: "Owners juggle multiple screens for performance reporting.",
+		}},
+		SpecificFriction: []types.SpecificFriction{{
+			Name:    "Theme plugin checkout compatibility",
+			Summary: "AJAX cart flows can drop deposit metadata.",
+		}},
+		Opportunity: []string{
+			"Fewer-screen analytics workflows inside Woo admin",
+			"Restaurant online ordering after GloriaFood",
+			"Checkout compatibility diagnostics for AJAX cart flows",
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &fakeInsightProvider{response: string(raw)}
+	insights, err := GenerateInsights(context.Background(), p, "gpt-5", sampleInsightResearch(), 1234)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(insights.Opportunity) != 2 {
+		t.Fatalf("opportunity len = %d: %+v", len(insights.Opportunity), insights.Opportunity)
+	}
+	for _, note := range insights.Opportunity {
+		if strings.Contains(note, "Restaurant") {
+			t.Fatalf("unsupported opportunity survived: %+v", insights.Opportunity)
+		}
 	}
 }

--- a/research/render.go
+++ b/research/render.go
@@ -13,8 +13,13 @@ func RenderMarkdown(i *types.ResearchInsights) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "# r/%s Research\n\n", i.Subreddit)
 
+	if i.Takeaway != "" {
+		sb.WriteString("## Takeaway\n\n")
+		fmt.Fprintf(&sb, "%s\n\n", i.Takeaway)
+	}
+
 	if len(i.PainPoints) > 0 {
-		sb.WriteString("## Pain Point Clusters\n\n")
+		sb.WriteString("## Strongest Pain Points\n\n")
 		for n, p := range i.PainPoints {
 			confidence := p.Confidence
 			if confidence == "" {
@@ -28,6 +33,22 @@ func RenderMarkdown(i *types.ResearchInsights) string {
 		}
 	}
 
+	if len(i.SpecificFriction) > 0 {
+		sb.WriteString("## Specific Friction Seen\n\n")
+		for _, f := range i.SpecificFriction {
+			confidence := f.Confidence
+			if confidence == "" {
+				confidence = "unknown"
+			}
+			fmt.Fprintf(&sb, "- **%s** (%s confidence)", f.Name, confidence)
+			if f.Summary != "" {
+				fmt.Fprintf(&sb, ": %s", f.Summary)
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
 	if len(i.RepeatedAsks) > 0 {
 		sb.WriteString("## Repeated Asks\n\n")
 		for _, ask := range i.RepeatedAsks {
@@ -37,7 +58,7 @@ func RenderMarkdown(i *types.ResearchInsights) string {
 	}
 
 	if len(i.Opportunity) > 0 {
-		sb.WriteString("## Opportunity Signals\n\n")
+		sb.WriteString("## Opportunity Areas\n\n")
 		for _, note := range i.Opportunity {
 			fmt.Fprintf(&sb, "- %s\n", note)
 		}


### PR DESCRIPTION
## Summary
- add a top-level research takeaway for the strongest signal
- split broad pain points from narrower specific support friction
- cap pain points, asks, opportunity areas, language, and evidence for more concise terminal output
- adjust the research insight prompt away from product-spec opportunities and one-off issue promotion
- update tests and README for the sharper report shape

## Verification
- go test ./...
- go vet ./...
- go build -o tider ./cmd/tider
- git diff --check