### PR TITLE
intake: add markdown render with TTY-aware default

### DIFF
--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -19,6 +20,7 @@ var (
 	intakeProvider  string
 	intakeModel     string
 	intakeMaxTokens int
+	intakeRender    string
 )
 
 var intakeCmd = &cobra.Command{
@@ -70,11 +72,23 @@ API key for the chosen provider must be set in the environment
 		if err != nil {
 			return err
 		}
-		out, err := json.MarshalIndent(brief, "", "  ")
-		if err != nil {
-			return err
+
+		switch resolveRender(intakeRender) {
+		case "markdown":
+			md := intake.RenderMarkdown(brief)
+			if isTerminal(os.Stdout) {
+				md = renderTerminal(md)
+			}
+			fmt.Print(md)
+		case "json":
+			out, err := json.MarshalIndent(brief, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+		default:
+			return fmt.Errorf("unknown --render value: %s (use json or markdown)", intakeRender)
 		}
-		fmt.Println(string(out))
 		return nil
 	},
 }
@@ -85,4 +99,5 @@ func init() {
 	intakeCmd.Flags().StringVar(&intakeProvider, "provider", "", "LLM provider: anthropic | openai (default from config)")
 	intakeCmd.Flags().StringVar(&intakeModel, "model", "", "LLM model name (default from config)")
 	intakeCmd.Flags().IntVar(&intakeMaxTokens, "max-tokens", 0, "LLM completion budget (default from config)")
+	intakeCmd.Flags().StringVar(&intakeRender, "render", "", "output format: json | markdown (default: markdown in TTY, json when piped)")
 }

--- a/intake/render.go
+++ b/intake/render.go
@@ -1,0 +1,60 @@
+package intake
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// RenderMarkdown turns a Brief into a scannable human report. raw_content
+// is intentionally omitted — it's verbose and meant for machine consumption
+// (it round-trips through brief.json into draft). For the markdown view,
+// we want what a human cares about: title, summary, audience, the things
+// the LLM actually surfaced as Brief-shape signal.
+func RenderMarkdown(b *types.Brief) string {
+	if b == nil {
+		return ""
+	}
+	var sb strings.Builder
+
+	title := b.Title
+	if title == "" {
+		title = "(untitled brief)"
+	}
+	fmt.Fprintf(&sb, "# %s\n\n", title)
+
+	if b.Summary != "" {
+		fmt.Fprintf(&sb, "%s\n\n", b.Summary)
+	}
+	if b.Audience != "" {
+		fmt.Fprintf(&sb, "**Audience:** %s\n\n", b.Audience)
+	}
+
+	if len(b.Highlights) > 0 {
+		sb.WriteString("## Highlights\n\n")
+		for _, h := range b.Highlights {
+			fmt.Fprintf(&sb, "- %s\n", h)
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(b.Links) > 0 {
+		sb.WriteString("## Links\n\n")
+		for _, l := range b.Links {
+			fmt.Fprintf(&sb, "- %s\n", l)
+		}
+		sb.WriteString("\n")
+	}
+
+	if b.Source.Mode != "" || b.Source.Value != "" {
+		sb.WriteString("---\n\n")
+		if b.Source.Value != "" {
+			fmt.Fprintf(&sb, "*Source: %s — %s*\n", b.Source.Mode, b.Source.Value)
+		} else {
+			fmt.Fprintf(&sb, "*Source: %s*\n", b.Source.Mode)
+		}
+	}
+
+	return sb.String()
+}

--- a/intake/render_test.go
+++ b/intake/render_test.go
@@ -1,0 +1,94 @@
+package intake
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+func TestRenderMarkdownFullBrief(t *testing.T) {
+	b := &types.Brief{
+		Source:  types.BriefSource{Mode: "url", Value: "https://github.com/viggy28/kova"},
+		Title:   "Kova — Build Plan",
+		Summary: "Etsy listing video tool for handmade sellers.",
+		Highlights: []string{
+			"Two-stage MVP",
+			"1080x1080 MP4 under 100MB",
+		},
+		Audience:   "Solo Etsy sellers who need listing videos.",
+		Links:      []string{"https://github.com/viggy28/kova"},
+		RawContent: "# Kova\n\nthousands of bytes here that we should NOT render in markdown",
+	}
+
+	md := RenderMarkdown(b)
+
+	wantSubstrings := []string{
+		"# Kova — Build Plan",                               // h1
+		"Etsy listing video tool for handmade sellers.",     // summary
+		"**Audience:** Solo Etsy sellers",                   // audience bold
+		"## Highlights",                                     // section
+		"- Two-stage MVP",                                   // list item
+		"- 1080x1080 MP4 under 100MB",                       // list item
+		"## Links",                                          // section
+		"- https://github.com/viggy28/kova",                 // link item
+		"---",                                               // separator before footer
+		"*Source: url — https://github.com/viggy28/kova*",   // source footer
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(md, s) {
+			t.Errorf("rendered markdown missing %q\n--- output ---\n%s", s, md)
+		}
+	}
+
+	// raw_content must NOT leak into markdown; it's too long to be useful here.
+	if strings.Contains(md, "thousands of bytes here") {
+		t.Error("raw_content leaked into markdown render")
+	}
+}
+
+func TestRenderMarkdownOmitsEmptySections(t *testing.T) {
+	b := &types.Brief{
+		Title: "Bare brief",
+	}
+	md := RenderMarkdown(b)
+
+	if !strings.Contains(md, "# Bare brief") {
+		t.Error("title missing")
+	}
+	for _, s := range []string{"## Highlights", "## Links", "**Audience:**", "---"} {
+		if strings.Contains(md, s) {
+			t.Errorf("empty-field section should be omitted but found %q", s)
+		}
+	}
+}
+
+func TestRenderMarkdownHandlesMissingTitle(t *testing.T) {
+	b := &types.Brief{
+		Summary: "Has a summary but no title",
+	}
+	md := RenderMarkdown(b)
+	if !strings.Contains(md, "# (untitled brief)") {
+		t.Errorf("expected fallback title, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Has a summary but no title") {
+		t.Error("summary lost")
+	}
+}
+
+func TestRenderMarkdownNilSafe(t *testing.T) {
+	if got := RenderMarkdown(nil); got != "" {
+		t.Errorf("nil brief should render empty, got %q", got)
+	}
+}
+
+func TestRenderMarkdownFileSourceFooter(t *testing.T) {
+	b := &types.Brief{
+		Title:  "From a local file",
+		Source: types.BriefSource{Mode: "file", Value: "/tmp/notes.md"},
+	}
+	md := RenderMarkdown(b)
+	if !strings.Contains(md, "*Source: file — /tmp/notes.md*") {
+		t.Errorf("file source footer missing or wrong:\n%s", md)
+	}
+}


### PR DESCRIPTION
\`tider intake\` previously printed JSON unconditionally. Catches it up to the same smart-render pattern \`draft\` and \`regen\` use.

## What

- New \`intake/render.go\`: \`RenderMarkdown(*types.Brief)\` produces a scannable view with title, summary, audience, highlights, links, and a source footer. \`raw_content\` is intentionally omitted (verbose, meant for downstream JSON consumption).
- \`cmd/tider/intake.go\`: \`--render=json|markdown\` flag with TTY-aware default. Empty default → markdown when stdout is a terminal, json when piped/redirected. ANSI styling via the existing \`renderTerminal\` helper.

The JSON path is unchanged — \`tider intake --url=... > brief.json\` continues to produce the canonical Brief JSON that \`tider draft --brief=...\` consumes.

## Why this shape

- **Default markdown in TTY**: spot-check intakes are common; the previous default forced you to read raw JSON or pipe to a parser.
- **Default JSON when piped**: the canonical workflow is \`tider intake > brief.json && tider draft --brief=brief.json --sub=...\`. That stays one step.
- **\`raw_content\` omitted from markdown**: full source corpus is too long to scan, and the value is in the LLM-extracted fields (title, summary, highlights, audience). Available in JSON for any caller that needs it.

Mirrors the pattern already shipped for \`draft\` and \`regen\` (PR #9). \`research\` already had it (PR #14).

## Test plan

5 new render tests, all pass:

- Full Brief: title as h1, summary, audience bold, highlights/links lists, source footer with mode + value, **raw_content not leaked**.
- Bare brief (only title): no empty section headers (no orphan \`## Highlights\` or \`---\`).
- Missing title: falls back to \`# (untitled brief)\` rather than emitting a blank h1.
- Nil input: returns empty string rather than panicking.
- File-mode source: footer reads \`*Source: file — /tmp/notes.md*\`.

All other packages still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)