### PR TITLE
context: add reusable context bank

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,36 @@ The insight step uses the configured `research` LLM task, which defaults to
 
 ---
 
+## Context bank
+
+Reusable project and positioning context lives in:
+
+```
+~/.tider/contexts/
+  kova.md
+  streambed.md
+  profile.md
+```
+
+Use it for durable notes you expect to reuse across thread engagement and
+drafting workflows. Context files are plain Markdown so they can hold product
+positioning, current audience, constraints, and "do not say" guidance.
+
+Commands:
+
+```bash
+tider context import kova ./kova.md
+tider context list
+tider context show kova
+tider context edit kova
+```
+
+`tider context show` also accepts direct file paths for ad hoc context review.
+`tider context edit` opens `$EDITOR` on the saved context file, creating it if
+needed.
+
+---
+
 ## Session layout
 
 ```

--- a/cmd/tider/context.go
+++ b/cmd/tider/context.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/contextbank"
+)
+
+var (
+	contextDir         string
+	contextImportForce bool
+)
+
+var contextCmd = &cobra.Command{
+	Use:   "context",
+	Short: "Manage reusable drafting context files",
+	Long: `Manage reusable project/context notes stored under ~/.tider/contexts.
+
+Examples:
+  tider context import kova ./kova.md
+  tider context list
+  tider context show kova
+  tider context edit kova`,
+}
+
+var contextListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List saved contexts",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := resolveContextDir()
+		if err != nil {
+			return err
+		}
+		entries, err := contextbank.List(dir)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			fmt.Println(e.ID)
+		}
+		return nil
+	},
+}
+
+var contextShowCmd = &cobra.Command{
+	Use:   "show <id-or-path>",
+	Short: "Print a saved or ad hoc context",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := resolveContextDir()
+		if err != nil {
+			return err
+		}
+		entry, err := contextbank.Load(dir, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Print(entry.Body)
+		return nil
+	},
+}
+
+var contextImportCmd = &cobra.Command{
+	Use:   "import <id> <path>",
+	Short: "Import a markdown file into the context bank",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir, err := resolveContextDir()
+		if err != nil {
+			return err
+		}
+		entry, err := contextbank.Import(dir, args[0], args[1], contextImportForce)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "imported %s -> %s\n", entry.ID, entry.Path)
+		return nil
+	},
+}
+
+var contextEditCmd = &cobra.Command{
+	Use:   "edit <id>",
+	Short: "Open a context in $EDITOR",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			return errors.New("EDITOR not set")
+		}
+		dir, err := resolveContextDir()
+		if err != nil {
+			return err
+		}
+		path, err := contextbank.Ensure(dir, args[0])
+		if err != nil {
+			return err
+		}
+		c := exec.Command(editor, path)
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("run editor: %w", err)
+		}
+		return nil
+	},
+}
+
+func resolveContextDir() (string, error) {
+	if contextDir != "" {
+		return contextDir, nil
+	}
+	return contextbank.DefaultDir()
+}
+
+func init() {
+	contextCmd.PersistentFlags().StringVar(&contextDir, "dir", "", "context bank directory (default ~/.tider/contexts)")
+	contextImportCmd.Flags().BoolVar(&contextImportForce, "force", false, "overwrite an existing context")
+	contextCmd.AddCommand(contextListCmd)
+	contextCmd.AddCommand(contextShowCmd)
+	contextCmd.AddCommand(contextImportCmd)
+	contextCmd.AddCommand(contextEditCmd)
+}

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -26,6 +26,7 @@ func main() {
 	rootCmd.AddCommand(draftCmd)
 	rootCmd.AddCommand(regenCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(contextCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/contextbank/contextbank.go
+++ b/contextbank/contextbank.go
@@ -1,0 +1,168 @@
+// Package contextbank stores reusable project/context notes for drafting.
+package contextbank
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var idRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+// Entry is one saved context document.
+type Entry struct {
+	ID   string
+	Path string
+	Body string
+}
+
+// DefaultDir returns the canonical context-bank directory.
+func DefaultDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".tider", "contexts"), nil
+}
+
+// ValidateID checks whether id is safe for use as a context-bank filename.
+func ValidateID(id string) error {
+	if !idRE.MatchString(id) {
+		return fmt.Errorf("invalid context id %q: use letters, numbers, dashes, or underscores", id)
+	}
+	return nil
+}
+
+// PathFor returns dir/<id>.md after validating id.
+func PathFor(dir, id string) (string, error) {
+	if err := ValidateID(id); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, id+".md"), nil
+}
+
+// List returns all markdown context entries in dir, sorted by id. Missing
+// context directories are treated as empty.
+func List(dir string) ([]Entry, error) {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read contexts: %w", err)
+	}
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".md")
+		if ValidateID(id) != nil {
+			continue
+		}
+		out = append(out, Entry{ID: id, Path: filepath.Join(dir, e.Name())})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// Load resolves ref as either a context id or a filesystem path and reads it.
+// Path refs are useful for ad hoc contexts; id refs come from the bank.
+func Load(dir, ref string) (*Entry, error) {
+	path, id, err := resolveRef(dir, ref)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("context %q not found", ref)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read context %q: %w", ref, err)
+	}
+	return &Entry{ID: id, Path: path, Body: string(data)}, nil
+}
+
+// Import copies sourcePath into dir/<id>.md. Existing entries are overwritten
+// only when force is true.
+func Import(dir, id, sourcePath string, force bool) (*Entry, error) {
+	dest, err := PathFor(dir, id)
+	if err != nil {
+		return nil, err
+	}
+	if !force {
+		if _, err := os.Stat(dest); err == nil {
+			return nil, fmt.Errorf("context %q already exists; use --force to overwrite", id)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("stat context %q: %w", id, err)
+		}
+	}
+	in, err := os.Open(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("open source context: %w", err)
+	}
+	defer in.Close()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir contexts: %w", err)
+	}
+	tmp := dest + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("create context: %w", err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return nil, fmt.Errorf("copy context: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return nil, fmt.Errorf("close context: %w", err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return nil, fmt.Errorf("rename context: %w", err)
+	}
+	entry, err := Load(dir, id)
+	if err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// Ensure returns the bank path for id, creating dir and an empty file when the
+// entry does not exist. It is used by `tider context edit`.
+func Ensure(dir, id string) (string, error) {
+	path, err := PathFor(dir, id)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir contexts: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("ensure context: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close context: %w", err)
+	}
+	return path, nil
+}
+
+func resolveRef(dir, ref string) (path, id string, err error) {
+	if looksLikePath(ref) {
+		return ref, strings.TrimSuffix(filepath.Base(ref), filepath.Ext(ref)), nil
+	}
+	path, err = PathFor(dir, ref)
+	if err != nil {
+		return "", "", err
+	}
+	return path, ref, nil
+}
+
+func looksLikePath(ref string) bool {
+	return strings.ContainsRune(ref, os.PathSeparator) || strings.HasPrefix(ref, ".") || filepath.Ext(ref) != ""
+}

--- a/contextbank/contextbank_test.go
+++ b/contextbank/contextbank_test.go
@@ -1,0 +1,141 @@
+package contextbank
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateID(t *testing.T) {
+	for _, id := range []string{"kova", "streambed", "my-project_1"} {
+		if err := ValidateID(id); err != nil {
+			t.Errorf("ValidateID(%q) unexpected error: %v", id, err)
+		}
+	}
+	for _, id := range []string{"", "../secret", "bad/name", "-starts-dash", strings.Repeat("a", 65)} {
+		if err := ValidateID(id); err == nil {
+			t.Errorf("ValidateID(%q) expected error", id)
+		}
+	}
+}
+
+func TestListSortedMarkdownOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "streambed.md"), "streambed")
+	writeFile(t, filepath.Join(dir, "kova.md"), "kova")
+	writeFile(t, filepath.Join(dir, "notes.txt"), "ignore")
+	if err := os.Mkdir(filepath.Join(dir, "folder.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := List(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("entries len = %d: %+v", len(entries), entries)
+	}
+	if entries[0].ID != "kova" || entries[1].ID != "streambed" {
+		t.Fatalf("entries not sorted/filtered: %+v", entries)
+	}
+}
+
+func TestListMissingDirIsEmpty(t *testing.T) {
+	entries, err := List(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty list, got %+v", entries)
+	}
+}
+
+func TestImportAndLoadByID(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(t.TempDir(), "kova-source.md")
+	writeFile(t, source, "# Kova\n\nContext body.")
+
+	entry, err := Import(dir, "kova", source, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ID != "kova" {
+		t.Errorf("id = %q", entry.ID)
+	}
+	if !strings.Contains(entry.Body, "Context body") {
+		t.Errorf("body = %q", entry.Body)
+	}
+
+	loaded, err := Load(dir, "kova")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Path != filepath.Join(dir, "kova.md") {
+		t.Errorf("path = %q", loaded.Path)
+	}
+}
+
+func TestImportRefusesOverwriteUnlessForced(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(t.TempDir(), "first.md")
+	second := filepath.Join(t.TempDir(), "second.md")
+	writeFile(t, first, "first")
+	writeFile(t, second, "second")
+
+	if _, err := Import(dir, "kova", first, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(dir, "kova", second, false); err == nil {
+		t.Fatal("expected overwrite error")
+	}
+	entry, err := Import(dir, "kova", second, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(entry.Body) != "second" {
+		t.Errorf("body = %q", entry.Body)
+	}
+}
+
+func TestLoadPathRef(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(t.TempDir(), "adhoc.md")
+	writeFile(t, source, "ad hoc")
+
+	entry, err := Load(dir, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ID != "adhoc" {
+		t.Errorf("id = %q", entry.ID)
+	}
+	if strings.TrimSpace(entry.Body) != "ad hoc" {
+		t.Errorf("body = %q", entry.Body)
+	}
+}
+
+func TestEnsureCreatesEmptyContext(t *testing.T) {
+	dir := t.TempDir()
+	path, err := Ensure(dir, "kova")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join(dir, "kova.md") {
+		t.Errorf("path = %q", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty file, got %q", data)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a contextbank package for durable Markdown context entries under ~/.tider/contexts
- add tider context list/show/import/edit commands
- support direct path refs for ad hoc context review via context show
- document the context bank workflow in README

## Verification
- go test ./...
- go vet ./...
- go build -o tider ./cmd/tider
- git diff --check
- smoke tested context list/import/show and invalid id handling with a temp --dir