### PR TITLE
reply: angle-based variants + flair + voice/lens rules

### DIFF
--- a/SPEC_REPLY_REFINEMENT.md
+++ b/SPEC_REPLY_REFINEMENT.md
@@ -1,0 +1,629 @@
+# Spec: `tider reply` quality refinement
+
+## Status
+
+Draft spec. This refines the already implemented `tider reply` command without changing the core read-only invariant: Tider drafts replies, persists session artifacts, and never posts to Reddit.
+
+## Problem
+
+The current reply output is structurally useful but not sharp enough for real Reddit engagement.
+
+Observed example: a Shopify thread where the OP is a solo store owner burned out by Instagram, TikTok, Facebook, Pinterest, captions, comments, trends, and filming content. With `--context=kova --context=personal`, Tider produced a long operating plan:
+
+- pick one source channel
+- batch content
+- use Meta Business Suite
+- reuse clips across TikTok/Pinterest
+- use caption templates
+- respond for 15 minutes/day
+- run small paid tests
+- track funnel metrics
+- hire a part-time editor
+
+Most of that advice is plausible, but the result reads like a generic marketing consultant checklist. It repeats what the thread already contains, especially "pick one platform" and "repurpose content." It also produced a `detailed` variant that was longer rather than more differentiated.
+
+The strongest context-specific insight from Kova was weaker than it should have been:
+
+> Do not solve content burnout by becoming a full-time creator. Build a repeatable way to capture real product proof: scale, texture, function, packing, and process footage.
+
+That is the kind of angle Tider should surface.
+
+## Goals
+
+1. Make `tider reply` produce comments a Reddit user would realistically post.
+2. Prefer differentiated angles over longer versions of the same advice.
+3. Use project context as a lens, not as a pitch.
+4. Use personal context only when it makes the reply more credible or human.
+5. Engage the existing thread when comments reveal a useful counterpoint.
+6. Keep default replies concise unless the OP explicitly asks for a step-by-step plan.
+7. Prevent unsupported first-person claims such as "I ran into the same wall."
+
+## Non-goals
+
+- No Reddit write actions.
+- No automatic posting.
+- No project pitching by default.
+- No forcing personal anecdotes into every reply.
+- No hardcoded one-off behavior for only `r/shopify`.
+- No removal of session persistence.
+- No change to review-mode inspection in this spec.
+- No solving context-bank editing UX here, except where context semantics affect reply quality.
+
+## Current command shape
+
+`tider reply` remains the command:
+
+```text
+tider reply --url=<reddit-thread-url> --context=kova --context=personal
+```
+
+The current trailing positional `comment` seen in usage examples is not part of the preferred UX. The refined vocabulary is:
+
+- `tider post` for drafting a standalone Reddit submission
+- `tider reply` for drafting a reply inside an existing Reddit thread
+
+No `draft comment` phrase should appear in user-facing product copy.
+
+## Core design shift
+
+Replace the default `detailed` variant with angle-based variants.
+
+### Old variant model
+
+```text
+best
+short
+detailed
+question-first
+```
+
+The problem: `detailed` is a length variant. It often creates a longer checklist without adding a new reason to post.
+
+### New variant model
+
+```text
+best
+short
+thread-aware
+personal-story, if supported
+question-first, if needed
+detailed, only if the OP explicitly asks for a plan, diagnosis, technical steps, or multi-part answer
+```
+
+The model does not have to output every variant. Three strong variants are better than four padded ones.
+
+## Variant definitions
+
+### `best`
+
+The recommended reply. It should be the comment the user is most likely to post.
+
+Properties:
+
+- concise
+- specific
+- directly useful to the OP
+- grounded in OP + top comments + supplied context
+- usually 120-220 words for business/community subs
+- can be shorter if the answer is obvious
+
+For the Shopify burnout example, `best` should focus on one sharp frame:
+
+> Build a repeatable proof-capture loop, not a bigger content calendar.
+
+### `short`
+
+The shortest viable reply.
+
+Properties:
+
+- one paragraph or a few bullets
+- 40-90 words in most non-technical threads
+- no setup, no throat-clearing
+- preserves the core advice from `best`
+
+### `thread-aware`
+
+Reacts to something important already present in comments.
+
+This is the replacement for most `detailed` output in Reddit-style business/trade/community subs.
+
+Purpose:
+
+- add a missing nuance
+- resolve tension between top comments
+- push back on advice that is directionally right but incomplete
+- avoid repeating the same consensus comment
+
+For the Shopify burnout example, the useful counter-comment was that batching can fail because it still requires creative energy on demand. A good `thread-aware` variant should engage that:
+
+```text
+I agree with the "pick one platform" advice, but I would be careful with generic batching. Batching only works if the task is capture, not creativity.
+
+Instead of sitting down to invent content, keep a repeatable proof-shot list: product in hand for scale, close-up texture, quick use/demo, packing an order, and one process clip. Film those whenever you already have the product out. Then on busy weeks you are assembling from a small clip library, not trying to be creative from zero.
+
+That is the difference between a content calendar and content inventory.
+```
+
+### `personal-story`
+
+Uses a personal anecdote from `author_context` or supplied contexts only when it clearly fits.
+
+Purpose:
+
+- make the reply feel more human
+- establish why the user understands the pain
+- avoid sounding like a generic consultant
+
+Rules:
+
+- Do not invent lived experience.
+- Do not use family details unless the supplied context contains them.
+- Do not mention private family context unless it is genuinely relevant and the user explicitly supplied that context.
+- Prefer light phrasing over oversharing.
+
+For the Kova/personal context, the mom story is available:
+
+> Kova was inspired by watching the user's mom struggle with a one-person Etsy/Shopify handmade shop.
+
+The reply should not default to "my mom..." every time. Better default phrasing:
+
+```text
+I have seen this up close with a one-person handmade shop: the useful content usually was not polished. It was simple proof that the product was real: scale, texture, packing, and process.
+```
+
+Use "my mom" only if the context explicitly allows personal/family framing or the user requests a personal version.
+
+### `question-first`
+
+Use only when more information is required before useful advice is possible.
+
+Good uses:
+
+- OP asks a broad question but omits product/category/audience/platform performance
+- OP asks for diagnosis but gives no data
+- the safest reply is to ask for one missing fact
+
+Bad uses:
+
+- OP is venting and already has enough context for a useful lightweight answer
+- the question is a disguised invitation to write a mini-consulting plan
+
+### `detailed`
+
+Not a default variant.
+
+Use only when the OP explicitly asks for:
+
+- step-by-step plan
+- technical troubleshooting
+- implementation details
+- multi-part critique
+- code/config/database/API diagnosis
+- structured store review
+
+If produced, `detailed` must still be concise for the subreddit. It should not be a 10-step playbook unless the OP asked for one.
+
+## Subreddit-aware behavior
+
+The prompt should infer thread/subreddit style and choose variants accordingly.
+
+### Signals available to the drafter
+
+The drafter prompt should classify thread style from three signals on the OP, all of which are already fetched and stored in `thread.json`:
+
+- **Subreddit name** — already passed through to the drafter prompt as `Subreddit: r/{{.Subreddit}}`.
+- **Flair** — currently fetched and stored in `thread.json` (e.g. `"flair": "Marketing"`) and passed to the *mode classifier*, but **not threaded into the drafter prompt today**. This needs fixing as part of this spec: the drafter often has to disambiguate similar subs (`r/Entrepreneur` with flair `Technical Question` vs `Marketing` vs `Personal`) and flair is the fastest signal for that.
+- **OP body** — already in the prompt.
+
+Flair must be added to the drafter template inputs so the model can use it for both category inference and tone calibration. When flair is empty or absent, the drafter falls back to subreddit + body.
+
+### Business, trade, marketing, ecommerce, founder, community subs
+
+Examples:
+
+- `r/shopify`
+- `r/EtsySellers`
+- `r/ecommerce`
+- `r/Entrepreneur`
+- `r/marketing`
+
+Default behavior:
+
+- produce `best`
+- produce `short`
+- prefer `thread-aware`
+- produce `personal-story` only if supported and relevant
+- skip `detailed` unless OP explicitly asks for a plan
+
+Target tone:
+
+- practical peer advice
+- one useful frame
+- fewer tools and metrics unless directly asked
+- avoid consultant voice
+
+### Technical/troubleshooting subs
+
+Examples:
+
+- `r/golang`
+- `r/PostgreSQL`
+- `r/kubernetes`
+- `r/webdev`
+- `r/sysadmin`
+
+Default behavior:
+
+- `detailed` may be useful
+- answer with concrete steps, tradeoffs, commands, configs, or diagnostics
+- `thread-aware` is still useful when top comments reveal a misconception
+- avoid personal-story unless credibility matters and is concise
+
+### Review/feedback posts
+
+Handled by review mode, not normal reply mode.
+
+Default behavior:
+
+- inspect the linked site/shop/listing
+- produce structured review observations
+- no generic reply if inspection fails
+- do not trigger review mode from comments
+
+This spec does not change review-mode implementation.
+
+## Context semantics
+
+### `author_context`
+
+`author_context` in `~/.tider/config.yaml` should be stable voice/background, not active project material.
+
+Recommended shape:
+
+```yaml
+author_context: |
+  Vignesh writes concise, direct, practical replies. He is a founder and engineering leader.
+  Use this only for tone and judgment. Do not mention projects, credentials, employers,
+  family stories, or personal background unless directly relevant to the thread and supplied
+  context explicitly allows it.
+```
+
+`author_context` should not say "currently building Streambed" if `--context=kova` might be passed in the same command. Active project context belongs in the context bank.
+
+### Context bank files
+
+Context bank files are reusable project/background material:
+
+```text
+~/.tider/contexts/kova.md
+~/.tider/contexts/streambed.md
+~/.tider/contexts/personal.md
+```
+
+Use:
+
+- `--context=kova` when the reply should use Kova as a lens
+- `--context=streambed` for database/CDC/data infra threads
+- `--context=personal` only when personal background is relevant
+
+### Collision rule
+
+If `author_context` and `--context` disagree about the user's current project, `--context` wins for subject matter and `author_context` remains voice-only.
+
+Example:
+
+- config says Streambed
+- command passes `--context=kova`
+
+The reply must not mention Streambed unless the Reddit thread is about Streambed-like work.
+
+### Mom story rule
+
+The mom story is valuable, but should be optional.
+
+Recommended split:
+
+- `kova.md`: product thesis and audience
+- `personal.md`: broad personal/professional background
+- optional `kova-origin.md`: personal origin story, including the mom/shop anecdote
+
+If the mom story remains in `personal.md`, the prompt must treat it as origin/background, not default reply content.
+
+Use it when:
+
+- OP is a solo handmade seller
+- OP is struggling with one-person shop operations
+- authenticity or trust is central
+- the user wants a warmer/personal reply
+
+Avoid it when:
+
+- the thread is technical
+- the thread is not about handmade/small-store pain
+- it would make the reply about the user instead of OP
+- the reply already works without personal framing
+
+## Prompt rules
+
+The reply prompt should add or strengthen these rules.
+
+### Use context as a lens
+
+Context should shape the insight, not become the topic.
+
+For Kova:
+
+- good: "buyers need clear proof that the product is real"
+- good: "capture product-in-hand, texture, function, process"
+- bad: "I am building Kova"
+- bad: "Kova can solve this"
+- bad: turning every Shopify thread into Etsy listing video advice
+
+### Prefer one differentiated point
+
+A good Reddit reply often wins by saying one useful thing clearly.
+
+Avoid:
+
+- full operating manuals by default
+- generic tool lists
+- repeating every good comment in the thread
+- adding ads/SEO/funnel metrics unless the OP asked
+
+### Respect top comments
+
+The drafter should inspect top comments as context and ask:
+
+1. What advice has already been repeated?
+2. What counterpoint or nuance is missing?
+3. Can we build on the best comment instead of duplicating it?
+
+For the Shopify example:
+
+- repeated: pick one platform, repurpose content
+- useful counterpoint: batching still requires creative energy
+- sharper reply: capture inventory, not content calendar
+
+### Ban unsupported first-person claims
+
+Never write:
+
+```text
+I ran into the same wall.
+What fixed it for me was...
+When I ran my store...
+```
+
+unless the supplied context explicitly supports that exact experience.
+
+Allowed:
+
+```text
+I have seen this up close with a one-person handmade shop...
+```
+
+only if the context includes that story and the thread fits.
+
+### Word-count guidance
+
+Default caps for non-technical reply mode:
+
+- `best`: 120-220 words
+- `short`: 40-90 words
+- `thread-aware`: 90-180 words
+- `personal-story`: 90-180 words
+- `question-first`: 30-80 words
+- `detailed`: skip unless needed; if included, 250-400 words max unless OP explicitly asked for more
+
+Technical/troubleshooting threads may exceed these caps when concrete detail is necessary.
+
+## Output rendering
+
+Current renderer sections:
+
+```text
+Best Pick
+Alternatives
+```
+
+This can stay, but labels should become meaningful:
+
+- `Short`
+- `Thread-Aware`
+- `Personal Story`
+- `Question First`
+- `Detailed`
+
+`Detailed` should not appear unless generated.
+
+Alternative reasoning should describe the angle, not the length:
+
+Good:
+
+```text
+Engages the batching pushback in the comments and reframes the work as capture inventory.
+```
+
+Bad:
+
+```text
+Provides a step-by-step operating model with concrete tools.
+```
+
+## Ideal output for the Shopify example
+
+Given:
+
+```text
+tider reply --url=<shopify marketing burnout thread> --context=kova --context=personal
+```
+
+The recommended `best` reply should resemble:
+
+```text
+I would make the content system smaller than "be active on every platform."
+
+For a solo store, the hard part is not just scheduling posts. It is having repeatable raw material that proves the product is real and worth buying. I would pick one source channel, then build a simple shot list you can reuse every time: product in hand for scale, texture close-up, quick use/demo, packing an order, and one process/maker clip.
+
+That gives you enough footage to repurpose into reels, pins, product-page clips, and posts without inventing new ideas every day.
+
+Also, do not over-polish it. If the product is clear, garage/process footage can work because buyers are often looking for trust: is this real, does it look like the photos, who is behind it?
+
+So I would optimize for a repeatable proof-capture loop, not a bigger content calendar.
+```
+
+The `thread-aware` variant should resemble:
+
+```text
+I agree with the "pick one platform" advice, but I would be careful with generic batching. Batching only works if the task is capture, not creativity.
+
+Instead of sitting down to invent content, keep a repeatable proof-shot list: product in hand for scale, close-up texture, quick use/demo, packing an order, and one process clip. Film those whenever you already have the product out. Then on busy weeks you are assembling from a small clip library, not trying to be creative from zero.
+
+That is the difference between a content calendar and content inventory.
+```
+
+The `personal-story` variant, if produced, should resemble:
+
+```text
+I have seen this up close with a one-person handmade shop: the content burden gets heavy fast, but the useful clips usually were not polished. They were simple proof that the product was real: product in hand for scale, texture, packing, and process.
+
+I would not try to run four separate content calendars. I would build one small capture loop: film the same five proof shots whenever the product is already out, then reuse those clips across whichever channel is actually bringing buyers.
+
+That keeps the work closer to running the shop instead of becoming a full-time creator.
+```
+
+## Implementation plan
+
+### 1. Update reply prompt
+
+Files:
+
+```text
+prompts/reply.tmpl
+reply/drafter.go
+```
+
+Changes to `prompts/reply.tmpl`:
+
+- replace the variant list with the new angle-based model
+- make `detailed` conditional
+- add subreddit-aware guidance
+- reference `{{.Flair}}` alongside `{{.Subreddit}}` in the thread header (rendered conditionally so empty flair doesn't print "Flair: ")
+- add thread-aware instructions based on top comments
+- add personal-story rules
+- add stronger first-person claim ban
+- add word-count guidance
+- clarify `author_context` vs context-bank roles
+
+Changes to `reply/drafter.go`:
+
+- add `Flair string` to the anonymous struct passed to `replyTmpl.Execute` in `renderReplyPrompt`
+- populate it from `input.Thread.Flair` (the field already exists on `types.Thread`)
+
+This is the gap noted in *Signals available to the drafter*: the data is already on the type, just not threaded through to the drafter template.
+
+### 2. Update tests
+
+Files:
+
+```text
+reply/drafter_test.go
+reply/render_test.go
+```
+
+Changes:
+
+- update happy-path fake response to include `thread-aware`
+- add prompt-render test assertions for:
+  - `thread-aware`
+  - `personal-story`
+  - `detailed` conditionality
+  - unsupported first-person claim ban
+  - context-as-lens guidance
+  - `Flair: <value>` line appears in the rendered prompt when `Thread.Flair` is non-empty, and is omitted otherwise
+- ensure renderer title-cases labels like `thread-aware` and `personal-story`
+
+### 3. Update type comments
+
+File:
+
+```text
+internal/types/types.go
+```
+
+Change the `ReplyDraft.Label` comment from:
+
+```go
+// "best" | "short" | "detailed" | "question-first"
+```
+
+to:
+
+```go
+// Common labels: "best", "short", "thread-aware", "personal-story",
+// "question-first", "detailed".
+```
+
+The data model does not need a schema change because IDs and labels are already strings.
+
+### 4. Manual verification
+
+Run:
+
+```text
+go test ./...
+```
+
+Then re-run a known thread:
+
+```text
+./tider reply --url=https://www.reddit.com/r/shopify/comments/1sz012f/struggling_on_marketing_my_shopify_store/ --context=kova --context=personal
+```
+
+Expected:
+
+- no generic 10-step `Detailed` default
+- `Best Pick` is concise and Kova-shaped
+- `Thread-Aware` engages the batching/creative-energy counterpoint
+- `Personal Story` appears only if the model can use the one-person handmade shop context naturally
+- no "I ran into the same wall" unless directly supported
+- no mention of Kova by name
+- no mention of Streambed
+
+## Acceptance criteria
+
+1. `tider reply` still returns valid JSON internally and markdown externally.
+2. Existing session artifacts continue to be written:
+   - `thread.json`
+   - `contexts.json`
+   - `mode.json`
+   - `draft-input.json`
+   - `drafts.json`
+   - `output.md`
+3. The default output for non-technical business/community threads no longer includes a long `Detailed` variant unless OP asked for a plan.
+4. At least one generated variant explicitly engages a high-signal comment or repeated thread pattern when such a pattern exists.
+5. Personal anecdotes are optional and grounded.
+6. `author_context` is treated as voice/background, not a competing project context.
+7. Context-bank project material influences advice without naming or pitching the project by default.
+8. The Shopify marketing-burnout example produces a sharper reply centered on repeatable product-proof capture.
+
+## Future work
+
+- Add a `--style=concise|balanced|expanded` flag only if manual usage shows the default is too restrictive.
+- Add session-based regeneration for a specific angle:
+
+  ```text
+  tider reply regen --session=<path> --angle=thread-aware
+  ```
+
+- Add lightweight subreddit profiles if prompt-only subreddit awareness is insufficient.
+- Add context metadata later if prose conventions become unreliable:
+
+  ```yaml
+  allow_naming: false
+  allow_personal_story: true
+  primary_lens: product trust
+  ```
+
+  Do not add this until there is clear evidence prose conventions are failing.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -294,9 +294,14 @@ type LoadedReplyContext struct {
 }
 
 // ReplyDraft is one variant produced by the reply drafter.
+//
+// Common labels: "best", "short", "thread-aware", "personal-story",
+// "question-first", "detailed". Not exhaustive — labels are free-form
+// strings on the wire so the prompt can evolve without a schema change.
+// The renderer title-cases hyphenated labels for display.
 type ReplyDraft struct {
 	ID        string `json:"id"`
-	Label     string `json:"label"` // "best" | "short" | "detailed" | "question-first"
+	Label     string `json:"label"`
 	Text      string `json:"text"`
 	Reasoning string `json:"reasoning,omitempty"`
 }

--- a/prompts/reply.tmpl
+++ b/prompts/reply.tmpl
@@ -3,6 +3,9 @@ You are drafting a Reddit reply for the user. The user reviews the drafts you pr
 # Thread
 
 Subreddit: r/{{.Subreddit}}
+{{- if .Flair }}
+Flair: {{.Flair}}
+{{- end }}
 Title: {{.Title}}
 {{- if .Body }}
 
@@ -24,7 +27,7 @@ Body:
 
 {{.AuthorContext}}
 
-When you reference experience, ground it in this background — not generic developer-tone "I built a thing" prose. Don't invent specific events or numbers that aren't in the context; the background is for *voice*, not factual padding.
+This block is for **voice and judgment only** — tone, communication style, what kinds of frames the user tends to use. It is not a list of facts to drop into the reply. Do **not** name employers, projects, credentials, family members, or specific past experiences from this block unless the supplied Context section explicitly invites that material. If the AuthorContext mentions an active project, treat it as background, never as the topic.
 {{- end }}
 {{- if .Contexts }}
 
@@ -36,19 +39,36 @@ When you reference experience, ground it in this background — not generic deve
 {{.Body}}
 {{- end }}
 
-Use this context as background only. **Do not name or pitch the project** unless the context body explicitly says naming is allowed in this thread (look for phrases like "in-thread naming: ok"). The OP didn't ask about your project — they asked about their thing. Lead with their problem, not yours.
+Use context as a **lens, not a topic**. The thesis or worldview from this material should shape the angle of your advice — not become the subject. Concrete rules:
+
+- **Do not name or pitch the project** unless the context body explicitly says naming is allowed in this thread (look for phrases like "in-thread naming: ok"). The OP didn't ask about your project.
+- **Reuse the insight, not the artifact.** If the context says "buyers need trust signals: scale, texture, function, process," use that frame to advise OP. Do not turn every thread into the project's domain (e.g. don't pivot a Shopify burnout thread into Etsy listing-video advice).
+- **Personal stories from context are opt-in.** If a context body contains a first-degree connection (you, family, close colleague) directly relevant to OP's situation, you may surface it lightly. Default phrasing: "I have seen this up close with..." Use named-relative framing ("my mom...") only when the context explicitly permits it or the thread strongly fits.
+- **Multiple contexts may disagree.** If `--context=kova` and `author_context` describe different active projects, the supplied context wins for subject matter; AuthorContext stays voice-only.
 {{- end }}
 
-# Task
+# Sub-category inference
 
-Draft 3-4 reply variants:
+Classify this thread from the Subreddit name, Flair (if present), and OP's body. Use the inferred category to pick variants and tone.
 
-- "best" — your recommended reply: concise, actionable, helpful peer advice. The thing you'd actually want them to post.
-- "short" — the shortest viable version (sometimes a single sentence is the right reply). Skip if the thread genuinely needs detail.
-- "detailed" — a more thorough technical/contextual response. Skip if there's not enough substance to justify length.
-- "question-first" — leads with a question to clarify before advising. Use only if OP needs to give more info before any answer is useful.
+- **Business / trade / marketing / ecommerce / founder / community** — practical peer voice, one useful frame, fewer tools and metrics, avoid consultant voice. Variants: `best`, `short`, prefer `thread-aware`, `personal-story` if supported. Skip `detailed` unless OP explicitly asked for a plan.
+- **Technical / troubleshooting / engineering** — concrete steps, tradeoffs, code/config/diagnostics. Variants: `best`, `short`, `thread-aware` when comments reveal a misconception, `detailed` when the thread genuinely warrants depth.
+- **Creative / hobbyist / lifestyle** — warm peer voice, lightweight, often shorter. Variants: `best`, `short`; `thread-aware` if comments diverge. Skip `detailed` almost always.
 
-You don't have to produce all four. Three solid variants beat four padded ones. Set `pick_id` to your recommended choice — usually "best", but pick another id if a different variant fits the thread better (e.g. some threads truly need "question-first").
+If the sub doesn't clearly fit, default to business/trade behavior (concise, single frame, skip `detailed`).
+
+# Task — variants
+
+Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if a different angle better fits the thread (e.g. `question-first` when OP omitted critical detail).
+
+- **`best`** — your recommended reply: one sharp frame, specific, peer voice. Grounded in OP + top comments + supplied context. Usually 120-220 words for non-technical subs; can be shorter when the answer is obvious.
+- **`short`** — the shortest viable reply (40-90 words). One paragraph or a few bullets. No setup, no throat-clearing. Skip if `best` is already short.
+- **`thread-aware`** — engages something specific in the existing comments: a missing nuance, tension between top comments, advice that's directionally right but incomplete, or a counterpoint everyone walked past. **Do not duplicate the consensus.** If the comments contain a sharp counter-argument that contradicts your `best` advice, this is the variant where you address it explicitly. Skip if comments add nothing meaningful. 90-180 words.
+- **`personal-story`** — *optional*. Generate ONLY if a supplied context body contains a first-degree personal connection (you, family, close colleague) directly matching OP's situation. The `reasoning` field must name the connection (e.g. "uses one-person handmade shop story from personal.md"). Skip otherwise — do not invent. 90-180 words.
+- **`question-first`** — *optional*. Generate only when OP genuinely needs to give more info before any answer is useful (e.g. broad question with no product/category/data). Skip when OP is venting or has enough context for a lightweight answer. 30-80 words.
+- **`detailed`** — *conditional*. Generate ONLY if the OP explicitly asked for a step-by-step plan, technical troubleshooting, multi-part critique, code/config/database/API diagnosis, or structured review. The `reasoning` field must quote the literal OP phrase that warranted depth (e.g. "OP asked: 'walk me through the steps'"). If you cannot quote OP requesting depth, **do not generate this variant.** Reformatting `best` with section headers does NOT count as detailed. 250-400 words max even when included.
+
+Word counts are guidance, not hard limits — fit the thread.
 
 # Anti-tells (mandatory)
 
@@ -60,17 +80,27 @@ Never:
 - Give generic advice ("improve your SEO", "run ads", "post more", "engage with your audience") unless the thread or context directly supports it
 - Echo the OP's question back at them as filler
 - "Let me know if you have any questions!" closes
+- **Fabricate first-person experience.** "I ran into the same wall", "What fixed it for me was...", "When I ran my store..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
+- **Reformat `best` as `detailed`.** Numbered 1-N section headers covering the same ground as `best` is not depth, it's padding.
+- **Repeat the consensus.** If three top comments already say "pick one platform," do not lead with "pick one platform." Build on it or push back on it.
 
 Always:
 - Write as a peer giving practical advice
 - Cite only things visible in the thread or supplied context
 - Be specific. "Have you tried X with config Y" beats "consider tools"
-- Match the sub's tone (technical sub → technical voice; trade sub → practical voice)
-- Sound like the person described in "Who you're writing as" if that section is present
+- Match the inferred sub category's tone
+- Sound like the person described in "Who you're writing as" if that section is present — voice only, not biographical claims
+
+# Reasoning field — describe the angle, not the length
+
+The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is.
+
+Good: "Engages the batching pushback in the comments and reframes the work as capture inventory."
+Bad: "Provides a step-by-step operating model with concrete tools."
 
 # Output
 
-Return a single JSON object exactly matching this shape, no other fields:
+Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-6 entries depending on what fits.
 
 {
   "drafts": [
@@ -78,7 +108,7 @@ Return a single JSON object exactly matching this shape, no other fields:
       "id": "best",
       "label": "best",
       "text": "...the actual reddit comment text the user would post, no preamble like 'Here is my draft:'...",
-      "reasoning": "one short sentence on why this approach fits the thread"
+      "reasoning": "one short sentence on the angle"
     },
     {
       "id": "short",
@@ -87,16 +117,10 @@ Return a single JSON object exactly matching this shape, no other fields:
       "reasoning": "..."
     },
     {
-      "id": "detailed",
-      "label": "detailed",
+      "id": "thread-aware",
+      "label": "thread-aware",
       "text": "...",
-      "reasoning": "..."
-    },
-    {
-      "id": "question-first",
-      "label": "question-first",
-      "text": "...",
-      "reasoning": "..."
+      "reasoning": "name the comment or pattern this engages"
     }
   ],
   "pick_id": "best"

--- a/reply/drafter.go
+++ b/reply/drafter.go
@@ -103,6 +103,7 @@ func renderReplyPrompt(input *DraftInput) (string, error) {
 	var buf bytes.Buffer
 	err := replyTmpl.Execute(&buf, struct {
 		Subreddit     string
+		Flair         string
 		Title         string
 		Body          string
 		Comments      []types.Comment
@@ -110,6 +111,7 @@ func renderReplyPrompt(input *DraftInput) (string, error) {
 		Contexts      []types.LoadedReplyContext
 	}{
 		Subreddit:     input.Thread.Subreddit,
+		Flair:         input.Thread.Flair,
 		Title:         input.Thread.Title,
 		Body:          input.Thread.Body,
 		Comments:      input.Thread.Comments,

--- a/reply/drafter_test.go
+++ b/reply/drafter_test.go
@@ -13,6 +13,7 @@ func sampleDraftInput() *DraftInput {
 	return &DraftInput{
 		Thread: &types.Thread{
 			Subreddit: "shopify",
+			Flair:     "Marketing",
 			Title:     "best plugins for performance?",
 			Body:      "Looking for plugin recs to speed up the cart.",
 			URL:       "https://www.reddit.com/r/shopify/comments/abc/best/",
@@ -26,10 +27,9 @@ func sampleDraftInput() *DraftInput {
 
 const goodDrafterResp = `{
   "drafts": [
-    {"id":"best","label":"best","text":"Best draft text.","reasoning":"concise + actionable"},
-    {"id":"short","label":"short","text":"Short text.","reasoning":"shortest viable"},
-    {"id":"detailed","label":"detailed","text":"Detailed text.","reasoning":"more depth"},
-    {"id":"question-first","label":"question-first","text":"What kind of cart?","reasoning":"need more info"}
+    {"id":"best","label":"best","text":"Best draft text.","reasoning":"one sharp frame for solo store owner"},
+    {"id":"short","label":"short","text":"Short text.","reasoning":"shortest viable answer"},
+    {"id":"thread-aware","label":"thread-aware","text":"Engaging the batching pushback.","reasoning":"top comment's batching critique deserves a response"}
   ],
   "pick_id": "best"
 }`
@@ -43,8 +43,17 @@ func TestGenerateReplyHappyPath(t *testing.T) {
 	if bundle.Subreddit != "shopify" || bundle.Mode != types.ReplyModeReply {
 		t.Errorf("bundle metadata: %+v", bundle)
 	}
-	if len(bundle.Drafts) != 4 {
-		t.Errorf("drafts len = %d", len(bundle.Drafts))
+	if len(bundle.Drafts) != 3 {
+		t.Errorf("drafts len = %d (expected 3 for new variant model)", len(bundle.Drafts))
+	}
+	gotLabels := map[string]bool{}
+	for _, d := range bundle.Drafts {
+		gotLabels[d.Label] = true
+	}
+	for _, want := range []string{"best", "short", "thread-aware"} {
+		if !gotLabels[want] {
+			t.Errorf("missing variant %q in bundle", want)
+		}
 	}
 	if bundle.PickID != "best" {
 		t.Errorf("pick = %q", bundle.PickID)
@@ -115,22 +124,77 @@ func TestRenderReplyPromptIncludesContextAndAuthor(t *testing.T) {
 	}
 	checks := []string{
 		"r/shopify",
+		"Flair: Marketing",                   // flair threaded through (new)
 		"best plugins for performance?",
 		"Looking for plugin recs",
-		"alice", "Try X", // top comment leaked in
+		"alice", "Try X",                     // top comment leaked in
 		"Who you're writing as",
 		"Five years running Postgres",
+		"voice and judgment only",            // author_context redefined as voice-only
 		"Context (project material",
 		"From bank (kova)",
 		"From path",
 		"kova body content",
 		"notes body",
 		"Do not name or pitch the project",
+		"lens, not a topic",                  // context-as-lens guidance
+		"Sub-category inference",             // abstract category guidance, not named-sub list
+		"thread-aware",                       // new variant slot
+		"personal-story",                     // new variant slot
+		"Fabricate first-person experience",  // explicit ban on fake autobiography
+		"Repeat the consensus",               // engage-don't-duplicate rule
 		"Anti-tells",
 	}
 	for _, s := range checks {
 		if !strings.Contains(prompt, s) {
 			t.Errorf("prompt missing %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+}
+
+// Flair is conditional: it must appear in the rendered prompt only when
+// Thread.Flair is non-empty. Empty flair should not produce a stray
+// "Flair: " line.
+func TestRenderReplyPromptOmitsFlairLineWhenEmpty(t *testing.T) {
+	input := sampleDraftInput()
+	input.Thread.Flair = ""
+
+	prompt, err := RenderReplyPrompt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(prompt, "Flair:") {
+		t.Errorf("empty Flair should not render a Flair: line\n--- prompt ---\n%s", prompt)
+	}
+	// Subreddit line still renders.
+	if !strings.Contains(prompt, "Subreddit: r/shopify") {
+		t.Error("Subreddit line should still render even when flair is empty")
+	}
+}
+
+// The new prompt forbids hardcoded named-subreddit category lookups.
+// Sub-category inference comes from Subreddit + Flair + body, described
+// abstractly. Catching the regression of a "named subs" list slipping
+// back in: assert that example sub names from the spec body do NOT
+// appear in the rendered prompt.
+func TestRenderReplyPromptDoesNotEnumerateNamedSubs(t *testing.T) {
+	input := sampleDraftInput()
+	prompt, err := RenderReplyPrompt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bannedExamples := []string{
+		"r/EtsySellers",
+		"r/ecommerce",
+		"r/Entrepreneur",
+		"r/marketing",
+		"r/PostgreSQL",
+		"r/kubernetes",
+		"r/sysadmin",
+	}
+	for _, b := range bannedExamples {
+		if strings.Contains(prompt, b) {
+			t.Errorf("prompt should not enumerate named subs (%q found) — sub-category inference must come from category descriptions", b)
 		}
 	}
 }

--- a/reply/render.go
+++ b/reply/render.go
@@ -73,12 +73,30 @@ func alternatives(drafts []types.ReplyDraft, pickID string) []types.ReplyDraft {
 	return out
 }
 
-// titleCaseLabel turns "question-first" → "Question-First", "short" →
-// "Short", etc. Cobra-style title casing for short tokens. Avoids
-// strings.Title (deprecated) and the cases package dep.
+// displayLabel maps known variant ids to their spec-mandated display
+// form (SPEC_REPLY_REFINEMENT.md, "Output rendering"). Hyphen retention
+// is intentional and per-label: "thread-aware" reads as a compound
+// modifier and keeps its hyphen; "personal-story" and "question-first"
+// read as noun phrases and use spaces.
+var displayLabel = map[string]string{
+	"best":           "Best",
+	"short":          "Short",
+	"thread-aware":   "Thread-Aware",
+	"personal-story": "Personal Story",
+	"question-first": "Question First",
+	"detailed":       "Detailed",
+}
+
+// titleCaseLabel returns the display form of a draft label. Known labels
+// from the spec use the explicit map above; unknown labels fall back to
+// kebab-to-title-case-with-hyphens so future variant names render
+// reasonably without a code change.
 func titleCaseLabel(s string) string {
 	if s == "" {
 		return ""
+	}
+	if d, ok := displayLabel[s]; ok {
+		return d
 	}
 	parts := strings.Split(s, "-")
 	for i, p := range parts {

--- a/reply/render_test.go
+++ b/reply/render_test.go
@@ -49,9 +49,9 @@ func TestRenderMarkdownBestPickLeads(t *testing.T) {
 		"### Short",
 		"*shortest viable*",                    // alt reasoning as italic
 		"Short text.",
-		"### Thread-Aware",                     // new variant, hyphenated label title-cased
-		"### Personal-Story",                   // new variant, hyphenated label title-cased
-		"### Question-First",                   // hyphenated label title-cased
+		"### Thread-Aware",                     // compound modifier — hyphen retained per spec
+		"### Personal Story",                   // noun phrase — space, not hyphen, per spec
+		"### Question First",                   // noun phrase — space, not hyphen, per spec
 		"What's your stack?",
 	}
 	for _, c := range checks {
@@ -90,7 +90,7 @@ func TestRenderMarkdownPickIDNotInDrafts(t *testing.T) {
 	if !strings.Contains(md, "## Alternatives") {
 		t.Error("Alternatives should still render")
 	}
-	for _, want := range []string{"### Best", "### Short", "### Thread-Aware", "### Personal-Story", "### Question-First"} {
+	for _, want := range []string{"### Best", "### Short", "### Thread-Aware", "### Personal Story", "### Question First"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("alternative %q should still render", want)
 		}
@@ -105,11 +105,15 @@ func TestRenderMarkdownNilBundle(t *testing.T) {
 
 func TestTitleCaseLabel(t *testing.T) {
 	cases := []struct{ in, want string }{
+		// Spec-mandated display forms (SPEC_REPLY_REFINEMENT.md "Output rendering").
 		{"best", "Best"},
 		{"short", "Short"},
-		{"thread-aware", "Thread-Aware"},
-		{"personal-story", "Personal-Story"},
-		{"question-first", "Question-First"},
+		{"thread-aware", "Thread-Aware"},   // hyphen retained — compound modifier
+		{"personal-story", "Personal Story"}, // space — noun phrase
+		{"question-first", "Question First"}, // space — noun phrase
+		{"detailed", "Detailed"},
+		// Unknown labels fall back to kebab→title-case-with-hyphens so future
+		// variant names render reasonably without a code change.
 		{"long-multi-part", "Long-Multi-Part"},
 		{"", ""},
 		{"a", "A"},

--- a/reply/render_test.go
+++ b/reply/render_test.go
@@ -16,7 +16,8 @@ func sampleBundle() *types.ReplyBundle {
 		Drafts: []types.ReplyDraft{
 			{ID: "best", Label: "best", Text: "Best reply text here.", Reasoning: "concise + fits sub"},
 			{ID: "short", Label: "short", Text: "Short text.", Reasoning: "shortest viable"},
-			{ID: "detailed", Label: "detailed", Text: "Detailed text with more depth.", Reasoning: "for thorough threads"},
+			{ID: "thread-aware", Label: "thread-aware", Text: "Engages the batching pushback.", Reasoning: "top comment counterpoint"},
+			{ID: "personal-story", Label: "personal-story", Text: "Story-shaped reply.", Reasoning: "uses one-person handmade shop story from personal.md"},
 			{ID: "question-first", Label: "question-first", Text: "What's your stack?", Reasoning: "need more info"},
 		},
 		PickID:    "best",
@@ -48,7 +49,8 @@ func TestRenderMarkdownBestPickLeads(t *testing.T) {
 		"### Short",
 		"*shortest viable*",                    // alt reasoning as italic
 		"Short text.",
-		"### Detailed",
+		"### Thread-Aware",                     // new variant, hyphenated label title-cased
+		"### Personal-Story",                   // new variant, hyphenated label title-cased
 		"### Question-First",                   // hyphenated label title-cased
 		"What's your stack?",
 	}
@@ -88,7 +90,7 @@ func TestRenderMarkdownPickIDNotInDrafts(t *testing.T) {
 	if !strings.Contains(md, "## Alternatives") {
 		t.Error("Alternatives should still render")
 	}
-	for _, want := range []string{"### Best", "### Short", "### Detailed", "### Question-First"} {
+	for _, want := range []string{"### Best", "### Short", "### Thread-Aware", "### Personal-Story", "### Question-First"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("alternative %q should still render", want)
 		}
@@ -105,6 +107,8 @@ func TestTitleCaseLabel(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"best", "Best"},
 		{"short", "Short"},
+		{"thread-aware", "Thread-Aware"},
+		{"personal-story", "Personal-Story"},
 		{"question-first", "Question-First"},
 		{"long-multi-part", "Long-Multi-Part"},
 		{"", ""},


### PR DESCRIPTION
## Summary

Implements `SPEC_REPLY_REFINEMENT.md` (committed in this PR as the design doc).

- Replaces length-based variants (best/short/detailed/question-first) with angle-based ones (best/short/thread-aware/personal-story/question-first/detailed). Detailed becomes conditional — must quote OP requesting depth; reformatting `best` with section headers does not count.
- Threads `Thread.Flair` through to the drafter prompt — was already fetched and saved in `thread.json` and passed to the mode classifier, but dropped before the drafter rendered. Now appears as a conditional `Flair: <value>` line.
- Tightens context rules: `author_context` is voice-only (no naming employers/projects/family unless context invites it); supplied contexts are a lens, not a topic; personal stories from context are opt-in with the connection named in the reasoning field.
- Bans unsupported first-person claims ("I ran into the same wall" → forbidden), repeating the consensus, and reformatting `best` as `detailed`.
- Sub-category inference uses Subreddit + Flair + body to pick variants and tone via three abstract categories. No named-sub list to maintain.

## Test plan

- [x] `go test ./...` green
- [x] `TestRenderReplyPromptIncludesContextAndAuthor` asserts Flair line, voice-only language, lens guidance, new variant slots, first-person ban, consensus-repeat ban
- [x] `TestRenderReplyPromptOmitsFlairLineWhenEmpty` confirms no stray `Flair:` when empty
- [x] `TestRenderReplyPromptDoesNotEnumerateNamedSubs` regression-guards against named-sub lists creeping back into the template
- [x] `TestRenderMarkdown*` covers Thread-Aware / Personal-Story title-casing
- [ ] Manual: rerun the Shopify thread we used as the regression target and verify (a) no generic 10-step Detailed by default, (b) Thread-Aware engages the augustcero batching pushback, (c) no fake "I ran into the same wall"

🤖 Generated with [Claude Code](https://claude.com/claude-code)