### PR TITLE
reply: Firecrawl visual review pipeline

### DIFF
--- a/SPEC_REVIEW_VISUAL_FIRECRAWL.md
+++ b/SPEC_REVIEW_VISUAL_FIRECRAWL.md
@@ -1,0 +1,766 @@
+# Spec: Firecrawl visual store/shop review for `tider reply`
+
+## Status
+
+Draft spec. This defines how `tider reply` should handle Reddit threads where the OP asks for feedback, criticism, or review of a concrete ecommerce site, Shopify store, Etsy shop, product listing, or similar public page.
+
+Core decision: if a thread is classified as review mode, Tider must perform visual inspection. A text-only scrape is not enough for a store/shop review.
+
+## Problem
+
+Current review mode can classify a website-review thread correctly and fetch the target page, but it may silently fall back to HTML-only inspection when `FIRECRAWL_API_KEY` is not set.
+
+That produces plausible but incomplete feedback:
+
+- title/meta review
+- heading/copy review
+- category/pricing/CTA observations based on text
+- open questions about images or product gallery
+
+The user-facing output still looks like a review, but it has not inspected:
+
+- homepage visual hierarchy
+- above-the-fold composition
+- product photography
+- trust signals visible in the design
+- image quality and consistency
+- whether product scale, texture, material, or function are clear
+- whether the site feels real, handmade, generic, AI-ish, or dropshipped
+- mobile layout risks
+
+For ecommerce and store-review posts, visual evidence is often the highest-signal part of the review. A text-only review is a partial review and should not be presented as complete.
+
+## Product position
+
+Review mode has a stronger contract than normal reply mode:
+
+```text
+review = OP asks for feedback on a concrete site/shop/listing/resource.
+review requires target inspection + visual analysis before drafting.
+```
+
+If Tider cannot visually inspect the target, it should fail clearly and preserve the session. It should not silently downgrade to text-only review.
+
+## Goals
+
+1. Use Firecrawl as the required capture provider for review-mode site/shop/listing inspection.
+2. Capture and persist a full-page screenshot for every review-mode target.
+3. Discover and optionally persist relevant product/page images.
+4. Run a visual analysis step over the screenshot and selected images.
+5. Merge visual findings with text findings before drafting.
+6. Make review output honest about what was inspected.
+7. Make failure modes explicit and recoverable.
+8. Use Kova/project context as a lens for visual feedback without naming or pitching the project by default.
+
+## Non-goals
+
+- No Reddit posting.
+- No `--text-only` flag for review mode.
+- No silent fallback from Firecrawl to HTML-only review.
+- No broad crawling of the whole store in v1.
+- No checkout flow testing.
+- No performance audit, Lighthouse score, SEO crawl, or accessibility audit in v1.
+- No claim that the review covered pages or images Tider did not inspect.
+- No image generation or image editing.
+- No Kova pitch unless context explicitly allows naming.
+
+## Trigger behavior
+
+Mode detection remains OP-only.
+
+Inputs:
+
+- subreddit
+- title
+- flair
+- OP body/selftext
+- OP outbound URL
+- URLs in OP body
+
+Do not use comments to trigger review mode. A comment saying "can you review my shop too?" must not flip the thread into review mode.
+
+If mode is `reply`, do not inspect external links.
+
+If mode is `review`, visual inspection is required.
+
+## CLI behavior
+
+Command shape remains:
+
+```text
+tider reply --url=<reddit-thread-url> --context=personal
+```
+
+No additional flag should be required to analyze images. The user's intent comes from the Reddit post asking for review/feedback.
+
+`--text-only` is intentionally not added in v1. There is no degraded text-only review mode — Firecrawl visual is required when mode is `review`.
+
+`--mode=reply` IS in v1 as a recoverable escape hatch. Use it when:
+
+- the classifier mistakes a discussion thread for a review request
+- you don't want to spend the Firecrawl + vision budget on a thread that doesn't warrant it
+- `FIRECRAWL_API_KEY` isn't set and you want to draft an ordinary reply anyway
+
+```text
+tider reply --url=<reddit-thread-url> --mode=reply
+```
+
+`--mode=reply` short-circuits the OP-only mode classifier and runs the normal reply pipeline. It does not produce a degraded review.
+
+## Required environment
+
+Review mode requires:
+
+```text
+FIRECRAWL_API_KEY
+```
+
+Review visual analysis also requires a vision-capable LLM provider/model configured for a new task:
+
+```yaml
+tasks:
+  review_visual:
+    provider: openai
+    model: <vision-capable-model>
+    max_tokens: 4096
+```
+
+The exact model should be configurable and should not be hardcoded into the review pipeline. If `tasks.review_visual` is missing, fall back to `tasks.reply` only if that configured model supports image inputs. Otherwise fail clearly.
+
+## Pipeline
+
+Review mode should run:
+
+```text
+[Reddit thread]
+      |
+      v
+[OP-only mode detection]
+      |
+      v
+[Target URL extraction]
+      |
+      v
+[Firecrawl target capture]
+      |
+      v
+[Persist screenshot + selected images]
+      |
+      v
+[Text extraction notes]
+      |
+      v
+[Visual analysis notes]
+      |
+      v
+[Merged review notes]
+      |
+      v
+[Reply drafting]
+      |
+      v
+[Rendered output + session artifacts]
+```
+
+### Step 1: Target extraction
+
+Target URL candidates:
+
+1. OP outbound URL for link posts
+2. markdown links in OP body
+3. raw URLs in OP body
+4. mode-classifier `target_urls`
+
+Skip:
+
+- Reddit URLs
+- image-only URLs posted as examples unless the OP explicitly asks for image feedback
+- bare hostnames without protocol in v1
+
+If multiple candidates exist, choose the first candidate that looks like a shop/site/listing. Persist alternatives in `target.json`.
+
+### Step 2: Firecrawl capture
+
+Firecrawl is required for review mode.
+
+If `FIRECRAWL_API_KEY` is missing:
+
+```text
+Error: review mode requires visual site inspection, but FIRECRAWL_API_KEY is not set.
+Set FIRECRAWL_API_KEY and rerun. Session preserved at <session path>.
+```
+
+Firecrawl should request, at minimum:
+
+- markdown or equivalent clean text
+- full-page screenshot
+- links
+- image references, if available
+- enough metadata to preserve source URL and status
+
+The current Firecrawl-backed `Inspection` shape already contains:
+
+```go
+Markdown
+ScreenshotURL
+ScreenshotPath
+ImageURLs
+Title
+MetaDescription
+Headings
+Snippets
+```
+
+For this spec, review mode must require `ScreenshotURL` and a locally persisted `ScreenshotPath`.
+
+If Firecrawl returns no screenshot:
+
+```text
+Error: review mode requires a screenshot, but Firecrawl did not return one.
+Session preserved at <session path>.
+```
+
+If screenshot download fails:
+
+```text
+Error: review mode could not persist the Firecrawl screenshot.
+Session preserved at <session path>.
+```
+
+Do not continue to draft a review without a screenshot.
+
+### Step 3: Image selection
+
+Screenshot is mandatory. Additional image URLs are optional but useful.
+
+Select up to 8 page images for visual analysis.
+
+Selection priority:
+
+1. product images
+2. hero images
+3. collection/category images
+4. process/maker images
+5. trust imagery: packaging, certificates, team, workshop, store, materials
+
+Filter out likely low-signal images:
+
+- logos
+- favicons
+- SVG icons
+- payment badges
+- social icons
+- tracking pixels
+- tiny images
+- repeated decorative backgrounds
+
+Implementation can start with simple heuristics:
+
+- reject URLs containing `logo`, `favicon`, `icon`, `sprite`, `payment`, `badge`, `tracking`, `pixel`
+- reject non-image extensions unless Firecrawl explicitly identifies them as images
+- cap by URL count
+- dedupe by normalized URL
+
+If no image URLs survive, proceed with screenshot-only analysis and record a limitation:
+
+```text
+No separate product image URLs were available; visual review is based on the captured page screenshot.
+```
+
+### Step 4: Persist visual inputs
+
+Session layout should include:
+
+```text
+~/.tider/sessions/replies/{date}-{subreddit}-{post_id}/
+  target.json
+  inspection.json
+  screenshots/
+    homepage.png
+  images/
+    image-001.jpg
+    image-002.png
+  visual-input.json
+  visual-notes.json
+  review-notes.json
+  draft-input.json
+  drafts.json
+  output.md
+```
+
+`images/` is optional in v1 if the vision provider can consume remote image URLs reliably. Prefer local persistence for reproducibility when practical.
+
+`visual-input.json` should record exactly what was sent to the visual analyzer:
+
+```json
+{
+  "target_url": "https://example.com/",
+  "screenshot_path": ".../screenshots/homepage.png",
+  "screenshot_source_url": "https://...",
+  "image_refs": [
+    {
+      "url": "https://example.com/product.jpg",
+      "local_path": ".../images/image-001.jpg",
+      "alt": "optional if available",
+      "reason": "product image candidate"
+    }
+  ],
+  "page_title": "...",
+  "context_ids": ["personal", "kova"],
+  "generated": "..."
+}
+```
+
+### Step 5: Visual analysis
+
+Add a new visual analysis step before review-note drafting.
+
+Suggested package/file:
+
+```text
+reply/visual.go
+prompts/review_visual.tmpl
+```
+
+The visual analyzer should receive:
+
+- full-page screenshot
+- selected product/page images, if available
+- target URL
+- page title/meta/headings/snippets for grounding
+- context-bank material, if supplied
+
+It should return strict JSON.
+
+Proposed type:
+
+```go
+type VisualReviewNotes struct {
+    TargetURL    string              `json:"target_url"`
+    ShopType     string              `json:"shop_type"`             // handmade|boutique|dropship|b2b_industrial|saas|services|portfolio|unclear
+    Summary      string              `json:"summary"`
+    Observations []VisualObservation `json:"observations"`
+    KovaSignals  []string            `json:"kova_signals,omitempty"` // populated only when ShopType ∈ {handmade, boutique}
+    Questions    []string            `json:"questions,omitempty"`
+    Limitations  []string            `json:"limitations,omitempty"`
+    Generated    time.Time           `json:"generated"`
+}
+
+type VisualObservation struct {
+    Area           string `json:"area"`            // above_fold, product_images, trust, navigation, pricing_cta, mobile_risk
+    Finding        string `json:"finding"`
+    Evidence       string `json:"evidence"`
+    Severity       string `json:"severity"`        // high, medium, low
+    Recommendation string `json:"recommendation"`
+}
+```
+
+The prompt should ask for observations in these areas:
+
+- above-the-fold clarity
+- product or offer clarity
+- visual hierarchy
+- CTA visibility
+- product image quality
+- product scale/material/texture/function visibility
+- trust/authenticity signals
+- pricing or quote-path visibility
+- category navigation visibility
+- mobile readability risks visible in the screenshot
+- brand consistency
+- generic/dropship/AI-looking risk when visually supported
+
+It must not infer:
+
+- checkout behavior
+- inventory depth
+- prices not visible
+- conversion rates
+- mobile behavior not visible from the screenshot
+- internal page quality unless those pages were inspected
+
+### Kova lens
+
+When Kova context is present, use it as a lens for visual feedback:
+
+- Does the page show real product proof?
+- Are scale, texture, material, function, and process visible?
+- Would a buyer trust that the product is real and accurately represented?
+- Is a short product/process video an obvious missing trust signal?
+
+Do not mention Kova by name unless context explicitly allows naming.
+
+#### Shop-type classification gates `kova_signals`
+
+Not every store-review thread is Kova-relevant. r/shopify spans dropshippers, B2B equipment suppliers, SaaS, services, and agencies — the Kova thesis (handmade trust) only applies to a subset.
+
+The visual analyzer must classify the inspected page and only populate `kova_signals` when the classification is Kova-adjacent:
+
+```
+shop_type ∈ {
+  handmade,           // ← kova_signals applies
+  boutique,           // ← kova_signals applies  
+  dropship,           // kova_signals empty
+  b2b_industrial,     // kova_signals empty
+  saas,               // kova_signals empty
+  services,           // kova_signals empty
+  portfolio,          // kova_signals empty
+  unclear,            // kova_signals empty
+}
+```
+
+The classification itself is recorded in `VisualReviewNotes.ShopType` so downstream rendering can show it.
+
+Without this gate, recommending "show your maker process" to a B2B industrial supplier or SaaS landing page produces dubious output. Acceptance criterion 9 (PND Industrial Suppliers) is explicitly the regression target.
+
+Good:
+
+```text
+Your product images should prove scale and material faster. A short real product/process clip would probably build more trust than another generic banner.
+```
+
+Bad:
+
+```text
+Use Kova to make listing videos.
+```
+
+## Merged review notes
+
+Keep text and visual notes separate in artifacts, then merge into the review drafter input.
+
+Artifacts:
+
+- `review-notes.json`: text/content/structure observations
+- `visual-notes.json`: screenshot/image observations
+- `draft-input.json`: includes both
+
+Suggested `ReviewDraftInput` extension:
+
+```go
+type ReviewDraftInput struct {
+    Thread        *types.Thread
+    Mode          *types.ReplyModeResult
+    Notes         *types.ReviewNotes
+    VisualNotes   *types.VisualReviewNotes
+    Contexts      []types.LoadedReplyContext
+}
+```
+
+The final drafter should prioritize high-confidence visual findings over generic text findings. If the visual notes say the CTA is visible but text notes say CTA is unclear, the drafter should phrase the issue carefully:
+
+```text
+The CTA exists, but visually it does not dominate the first screen.
+```
+
+## Review draft variants
+
+Review mode should use review-specific variants, not the normal reply variants.
+
+Recommended:
+
+```text
+best
+short
+structured-review
+question-first, only if critical information is missing
+```
+
+### `best`
+
+The comment the user should probably post.
+
+Shape:
+
+- acknowledge one or two strengths
+- give 2-4 concrete fixes
+- include at least one visual observation when available
+- avoid sounding like an agency audit
+- usually 150-300 words
+
+### `short`
+
+The shortest useful review.
+
+Shape:
+
+- one strength
+- one or two highest-leverage fixes
+- 60-130 words
+
+### `structured-review`
+
+Use when OP explicitly asks for critique/review and the findings justify structure.
+
+Shape:
+
+```text
+What works:
+- ...
+
+What I would fix:
+- ...
+
+Biggest priority:
+- ...
+```
+
+Avoid huge audits. Keep it postable as a Reddit comment.
+
+### `question-first`
+
+Only if the review cannot be usefully completed without one or two facts, such as:
+
+- quote-only vs fixed pricing
+- intended customer segment
+- whether the linked page is a placeholder
+
+Do not use `question-first` as an excuse to avoid giving visible-page feedback.
+
+## Output rendering
+
+Rendered markdown should make inspection depth obvious before the draft:
+
+```text
+Reply drafts for r/ecommerce
+
+Thread: Looking for Website Review/Criticism
+Mode: review
+Session: /Users/.../.tider/sessions/replies/...
+Inspection: Firecrawl visual
+Screenshot: saved
+Images analyzed: 4
+Limitations: homepage only; checkout not inspected
+```
+
+If visual inspection is not available, there should be no draft output because the command should fail before drafting.
+
+## Progress UX
+
+Review mode should print compact progress to stderr:
+
+```text
+session: ~/.tider/sessions/replies/2026-05-01-ecommerce-1t06474
+[1/8] fetching Reddit thread...
+[2/8] loading contexts: personal
+[3/8] classifying thread... review
+[4/8] inspecting target with Firecrawl...
+[5/8] saving screenshot and images...
+[6/8] analyzing screenshot and product images...
+[7/8] drafting review reply...
+[8/8] saved session artifacts
+done in 1m42s
+```
+
+Keep final drafts on stdout. Keep progress on stderr.
+
+## Failure behavior
+
+Review mode should fail before drafting when:
+
+- target URL is missing
+- `FIRECRAWL_API_KEY` is missing
+- Firecrawl request fails
+- Firecrawl returns no screenshot
+- screenshot cannot be persisted
+- vision-capable review model is not configured
+- visual analysis fails
+
+Each error should include the session path:
+
+```text
+Error: review mode requires visual inspection, but FIRECRAWL_API_KEY is not set.
+Session preserved at /Users/.../.tider/sessions/replies/...
+```
+
+Do not write `drafts.json` or `output.md` on failed review visual inspection. Earlier artifacts should remain.
+
+## Implementation plan
+
+### 1. Make Firecrawl mandatory for review mode
+
+File:
+
+```text
+cmd/tider/reply.go
+reply/inspect.go
+```
+
+Change review-mode path so it does not call HTML fallback. Either:
+
+- add `reply.InspectReviewTarget(...)` that requires Firecrawl, or
+- add a `RequireVisual bool` option to `Inspect`
+
+Preferred:
+
+```go
+inspection, err := reply.InspectReviewTarget(ctx, httpClient, targetURL)
+```
+
+`InspectHTML` can remain for tests or future non-review metadata extraction, but review mode should not use it.
+
+### 2. Require screenshot persistence
+
+File:
+
+```text
+cmd/tider/reply.go
+reply/firecrawl.go
+```
+
+Make screenshot download fatal in review mode. Persist the screenshot path into `inspection.json`.
+
+### 3. Select and persist image inputs
+
+New or existing files:
+
+```text
+reply/images.go
+reply/firecrawl.go
+```
+
+Implement:
+
+- image URL normalization
+- low-signal image filtering
+- cap selected images
+- optional image download into `images/`
+- `visual-input.json`
+
+### 4. Add visual LLM support
+
+Files:
+
+```text
+internal/llm/llm.go
+internal/llm/openai.go
+reply/visual.go
+prompts/review_visual.tmpl
+```
+
+The existing `llm.Request` needs to support image inputs. Keep the abstraction narrow:
+
+```go
+type ImageInput struct {
+    Path string // local path; preferred when set
+    URL  string // remote URL; fallback when Path is empty
+    MIME string // optional override; inferred from extension if empty
+}
+
+type Request struct {
+    Model     string
+    Messages  []Message
+    Images    []ImageInput
+    JSONMode  bool
+    MaxTokens int
+}
+```
+
+**v1 scope:**
+
+- OpenAI vision only. Anthropic vision is deferred to v1.5; the Anthropic provider should return a clear "model does not support image inputs" error if `Images` is non-empty.
+- Vision-capable model detection: hardcoded allowlist in `internal/llm/` (e.g. `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`). Easy to extend; we don't need a Provider.Capabilities() abstraction yet.
+- Local image persistence is deferred. v1 passes Firecrawl image URLs directly to OpenAI's `image_url` content blocks. The screenshot, however, IS persisted (we already do that) and IS sent base64-encoded since signed Firecrawl URLs may expire.
+
+Provider implementations that do not support images should return a clear error:
+
+```text
+provider anthropic/model x does not support image inputs for review_visual
+```
+
+### 5. Add visual notes type
+
+File:
+
+```text
+internal/types/types.go
+```
+
+Add `VisualReviewNotes`, `VisualObservation`, and `VisualReviewInput` types.
+
+### 6. Merge notes into review drafter
+
+Files:
+
+```text
+reply/review.go
+prompts/review_reply.tmpl
+```
+
+Update review drafting prompt to include:
+
+- text notes
+- visual notes
+- visual limitations
+- context-bank material
+- top-level OP request
+
+Prompt rule:
+
+```text
+Do not claim you reviewed visual elements unless they appear in visual_notes.
+```
+
+### 7. Update renderer
+
+File:
+
+```text
+reply/render.go
+```
+
+Add inspection metadata to `ReplyBundle` or pass a render context so output can show:
+
+- inspection source
+- screenshot saved/not saved
+- images analyzed count
+- limitations
+
+Avoid adding noisy raw paths to the final output unless useful. Session path is already printed.
+
+### 8. Tests
+
+Add or update tests:
+
+```text
+reply/firecrawl_test.go
+reply/inspect_test.go
+reply/visual_test.go
+reply/review_test.go
+cmd/tider/reply_test.go
+reply/render_test.go
+```
+
+Test cases:
+
+- review mode with missing `FIRECRAWL_API_KEY` fails before drafting
+- Firecrawl no screenshot fails before drafting
+- screenshot download failure fails before drafting
+- screenshot + no image URLs succeeds with screenshot-only limitation
+- image URL filtering removes logos/icons/payment badges
+- visual analyzer receives screenshot input
+- visual notes JSON parse errors fail clearly
+- review drafter receives both text and visual notes
+- renderer shows inspection depth
+- no `drafts.json` on failed visual inspection
+
+## Acceptance criteria
+
+1. A website-review Reddit post triggers `mode=review`.
+2. Review mode requires Firecrawl and fails if `FIRECRAWL_API_KEY` is missing.
+3. Review mode persists a full-page screenshot in the session.
+4. Review mode runs a visual analysis step before drafting.
+5. Review drafts include at least one visual observation when visual notes exist.
+6. Review drafts do not mention visual/layout/image feedback unless visual notes support it.
+7. Text-only HTML fallback is not used for review-mode drafting.
+8. The output header shows inspection depth and limitations.
+9. The PND Industrial Suppliers example would not produce a draft without Firecrawl visual inspection.
+10. With Firecrawl and visual analysis enabled, the PND example should critique visible page/product/CTA/category imagery, not only title/meta/headings.
+
+## Future work
+
+- Add optional second-page inspection for top nav/category/product pages.
+- Add mobile screenshot capture if Firecrawl supports viewport options cleanly.
+- Add visual diff/regeneration from saved session.
+- Add `--mode=reply` only if review false positives become common.
+- Add richer context metadata for Kova-style visual lenses if prose context becomes unreliable.

--- a/cmd/tider/reply.go
+++ b/cmd/tider/reply.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	replyURL       string
-	replyContexts  []string
-	replyRender    string
-	replyProvider  string
-	replyModel     string
-	replyMaxTokens int
+	replyURL          string
+	replyContexts     []string
+	replyRender       string
+	replyProvider     string
+	replyModel        string
+	replyMaxTokens    int
+	replyModeOverride string // --mode=reply forces reply mode (skips OP-only classifier)
 )
 
 var replyCmd = &cobra.Command{
@@ -115,17 +116,34 @@ API key for the chosen provider must be set in the environment
 			return err
 		}
 
-		// 7. Mode classifier — uses the cheaper model from tasks.reply_mode.
-		//    --provider propagates here so `--provider=anthropic` doesn't
-		//    silently still require OPENAI_API_KEY for the classifier call.
-		modeProvider, modeModel, modeMaxTokens := resolveProviderModel(cfg, "reply_mode", replyProvider, "", 0)
-		modeP, err := llm.New(llm.Config{Provider: modeProvider, Model: modeModel})
-		if err != nil {
-			return fmt.Errorf("mode classifier provider: %w", err)
-		}
-		modeResult, err := reply.DetectMode(ctx, modeP, modeModel, thread, modeMaxTokens)
-		if err != nil {
-			return err
+		// 7. Mode resolution. Either:
+		//    a) honor --mode=reply (recoverable escape hatch — see
+		//       SPEC_REVIEW_VISUAL_FIRECRAWL.md "CLI behavior") and skip
+		//       the classifier entirely; or
+		//    b) run the cheaper classifier from tasks.reply_mode.
+		//    --provider propagates so `--provider=anthropic` doesn't
+		//    silently still require OPENAI_API_KEY for the classifier.
+		var modeResult *types.ReplyModeResult
+		if replyModeOverride != "" {
+			switch replyModeOverride {
+			case "reply":
+				modeResult = &types.ReplyModeResult{
+					Mode:   types.ReplyModeReply,
+					Reason: "forced by --mode=reply (classifier skipped)",
+				}
+			default:
+				return fmt.Errorf("unsupported --mode=%q (only 'reply' is supported in v1)", replyModeOverride)
+			}
+		} else {
+			modeProvider, modeModel, modeMaxTokens := resolveProviderModel(cfg, "reply_mode", replyProvider, "", 0)
+			modeP, err := llm.New(llm.Config{Provider: modeProvider, Model: modeModel})
+			if err != nil {
+				return fmt.Errorf("mode classifier provider: %w", err)
+			}
+			modeResult, err = reply.DetectMode(ctx, modeP, modeModel, thread, modeMaxTokens)
+			if err != nil {
+				return err
+			}
 		}
 		if err := sess.SaveMode(modeResult); err != nil {
 			return err
@@ -160,7 +178,7 @@ API key for the chosen provider must be set in the environment
 
 		case types.ReplyModeReview:
 			if len(modeResult.TargetURLs) == 0 {
-				return errors.New("review request detected, but no shop/site URL was found in the original post — pass --context with notes you want to base the reply on, or wait for a thread that includes a target link")
+				return errors.New("review request detected, but no shop/site URL was found in the original post — pass --context with notes you want to base the reply on, rerun with --mode=reply for an ordinary reply, or wait for a thread that includes a target link")
 			}
 			// Save target.json before any potentially-failing step so the
 			// session preserves what we knew even if inspection fails.
@@ -172,42 +190,85 @@ API key for the chosen provider must be set in the environment
 				return err
 			}
 
-			// Inspect the target URL. Failure here preserves the session
-			// (target.json is written; nothing else past this point) — the
-			// spec's "do not generate generic review advice as a fallback"
-			// rule is honored by simply propagating the error.
-			//
-			// Backend dispatch (text-only HTML vs Firecrawl with screenshot
-			// + images) lives inside reply.Inspect, keyed off
-			// FIRECRAWL_API_KEY in env.
+			// Visual review pipeline (SPEC_REVIEW_VISUAL_FIRECRAWL.md):
+			//   1. Firecrawl required → InspectReviewTarget. Errors are
+			//      explicit and recoverable via --mode=reply.
+			//   2. Screenshot is mandatory — fail before drafting if it
+			//      can't be persisted (no degraded text-only review).
+			//   3. Visual analyzer (vision-capable model) consumes the
+			//      screenshot + selected product images.
+			//   4. Text-only review notes still run alongside; both flow
+			//      into the drafter.
 			httpClient := &http.Client{Timeout: 60 * time.Second}
-			inspection, err := reply.Inspect(ctx, httpClient, modeResult.TargetURLs[0])
+			inspection, err := reply.InspectReviewTarget(ctx, httpClient, modeResult.TargetURLs[0])
 			if err != nil {
-				return fmt.Errorf("inspection: %w (session preserved at %s)", err, sess.Path())
+				return fmt.Errorf("inspection: %w (session preserved at %s; rerun with --mode=reply to draft an ordinary reply)", err, sess.Path())
 			}
 
-			// If Firecrawl returned a screenshot URL, download it into
-			// the session's screenshots/ dir so it persists after
-			// Firecrawl's hosted URL eventually expires. Failure here is
-			// non-fatal — the URL is still in inspection.json.
-			if inspection.ScreenshotURL != "" {
-				screenshotDir := filepath.Join(sess.Path(), "screenshots")
-				localPath, derr := reply.DownloadScreenshot(ctx, httpClient, inspection.ScreenshotURL, screenshotDir)
-				if derr != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to download screenshot: %v\n", derr)
-				} else {
-					inspection.ScreenshotPath = localPath
-				}
+			screenshotDir := filepath.Join(sess.Path(), "screenshots")
+			localPath, err := reply.DownloadScreenshot(ctx, httpClient, inspection.ScreenshotURL, screenshotDir)
+			if err != nil {
+				return fmt.Errorf("review mode could not persist Firecrawl screenshot: %w (session preserved at %s)", err, sess.Path())
 			}
+			inspection.ScreenshotPath = localPath
 
 			if err := sess.WriteJSON("inspection.json", inspection); err != nil {
 				return err
 			}
 
-			// Build review notes — uses the cheaper classifier model
-			// since this is structured-summary work, not creative writing.
-			// --provider propagates so the user's provider choice covers
-			// every call in the pipeline.
+			// Visual analyzer. Resolve review_visual via config; OpenAI-
+			// only in v1 per spec. Gate with llm.SupportsVision so the
+			// failure mode is "your configured model is not vision-
+			// capable" rather than a provider-level cryptic error.
+			visualProvider, visualModel, visualMaxTokens := resolveProviderModel(cfg, "review_visual", replyProvider, "", 0)
+			if !llm.SupportsVision(visualProvider, visualModel) {
+				return fmt.Errorf("review mode requires a vision-capable model for tasks.review_visual; %s/%s is not on the supported list (try gpt-4o); session preserved at %s", visualProvider, visualModel, sess.Path())
+			}
+			visualP, err := llm.New(llm.Config{Provider: visualProvider, Model: visualModel})
+			if err != nil {
+				return fmt.Errorf("visual analyzer provider: %w", err)
+			}
+			selectedImages := reply.SelectImagesForAnalysis(inspection.ImageURLs, inspection.ScreenshotURL)
+			visualInput := &reply.VisualInput{
+				Inspection: inspection,
+				Contexts:   contexts,
+				ImageURLs:  selectedImages,
+			}
+			// Persist visual-input.json BEFORE the LLM call so a failed
+			// analysis still leaves the input footprint for debugging.
+			contextIDs := make([]string, 0, len(contexts))
+			for _, c := range contexts {
+				if c.ID != "" {
+					contextIDs = append(contextIDs, c.ID)
+				}
+			}
+			imageRefs := make([]types.VisualImageRef, 0, len(selectedImages))
+			for _, u := range selectedImages {
+				imageRefs = append(imageRefs, types.VisualImageRef{URL: u, Reason: "product image candidate"})
+			}
+			if err := sess.WriteJSON("visual-input.json", types.VisualInputRecord{
+				TargetURL:           inspection.URL,
+				ScreenshotPath:      inspection.ScreenshotPath,
+				ScreenshotSourceURL: inspection.ScreenshotURL,
+				ImageRefs:           imageRefs,
+				PageTitle:           inspection.Title,
+				ContextIDs:          contextIDs,
+				Generated:           time.Now().UTC(),
+			}); err != nil {
+				return err
+			}
+
+			visualNotes, err := reply.AnalyzeVisual(ctx, visualP, visualModel, visualInput, visualMaxTokens)
+			if err != nil {
+				return fmt.Errorf("visual analysis: %w (session preserved at %s)", err, sess.Path())
+			}
+			if err := sess.WriteJSON("visual-notes.json", visualNotes); err != nil {
+				return err
+			}
+
+			// Text-only review notes — still useful alongside visual
+			// because they cover headings/copy/meta which aren't really
+			// "visual" anyway. Uses the cheap classifier model.
 			notesProvider, notesModel, notesMaxTokens := resolveProviderModel(cfg, "reply_mode", replyProvider, "", 0)
 			notesP, err := llm.New(llm.Config{Provider: notesProvider, Model: notesModel})
 			if err != nil {
@@ -221,11 +282,12 @@ API key for the chosen provider must be set in the environment
 				return err
 			}
 
-			// Snapshot review-mode drafter input.
+			// Snapshot review-mode drafter input — both text and visual.
 			input := &reply.ReviewDraftInput{
 				Thread:        thread,
 				Mode:          modeResult,
 				Notes:         notes,
+				VisualNotes:   visualNotes,
 				Contexts:      contexts,
 				AuthorContext: cfg.AuthorContext,
 			}
@@ -235,6 +297,15 @@ API key for the chosen provider must be set in the environment
 			bundle, err = reply.GenerateReviewReply(ctx, draftP, draftModel, input, draftMaxTokens)
 			if err != nil {
 				return err
+			}
+			// Populate the InspectionSummary so the renderer shows what
+			// was inspected.
+			bundle.Inspection = &types.InspectionSummary{
+				Source:         inspection.Source,
+				ScreenshotPath: inspection.ScreenshotPath,
+				ImagesAnalyzed: len(selectedImages),
+				ShopType:       visualNotes.ShopType,
+				Limitations:    visualNotes.Limitations,
 			}
 
 		default:
@@ -317,4 +388,5 @@ func init() {
 	replyCmd.Flags().StringVar(&replyProvider, "provider", "", "LLM provider for every call in this command (default from config tasks.<task>)")
 	replyCmd.Flags().StringVar(&replyModel, "model", "", "LLM model for the drafter call (default from config tasks.reply)")
 	replyCmd.Flags().IntVar(&replyMaxTokens, "max-tokens", 0, "drafter completion budget (default from config tasks.reply)")
+	replyCmd.Flags().StringVar(&replyModeOverride, "mode", "", "force a mode, skipping the OP-only classifier. Currently supports 'reply' (use when the classifier mistakes a discussion for a review request, or when FIRECRAWL_API_KEY isn't set and you want to draft a normal reply anyway)")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,12 @@ func Default() *Config {
 				"regen":      {MaxTokens: 4096},
 				"reply_mode": {Model: "gpt-4o-mini", MaxTokens: 2048},
 				"reply":      {MaxTokens: 8192},
+				// review_visual is the screenshot+images analyzer for review
+				// mode (SPEC_REVIEW_VISUAL_FIRECRAWL.md). MUST be a vision-
+				// capable model — Anthropic vision is deferred to v1.5, so
+				// this is OpenAI-only in practice. llm.SupportsVision gates
+				// the choice at call time.
+				"review_visual": {Provider: "openai", Model: "gpt-4o", MaxTokens: 4096},
 			},
 		},
 		Defaults: DefaultsConfig{

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -86,6 +86,13 @@ func (a *Anthropic) Complete(ctx context.Context, req Request) (*Response, error
 	if req.MaxTokens <= 0 {
 		return nil, fmt.Errorf("anthropic: MaxTokens must be > 0")
 	}
+	if len(req.Images) > 0 {
+		// Anthropic vision support is deferred to v1.5 per
+		// SPEC_REVIEW_VISUAL_FIRECRAWL.md. Fail loudly so callers route
+		// vision-required tasks (review_visual) to OpenAI instead of
+		// silently dropping the screenshot.
+		return nil, fmt.Errorf("anthropic: image inputs not supported in this provider build (model %s); route vision tasks to openai", model)
+	}
 
 	body := anthropicRequest{
 		Model:       model,

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -288,6 +288,31 @@ func TestAnthropicUnknownRoleRejected(t *testing.T) {
 	}
 }
 
+// Vision support is intentionally not implemented for Anthropic in v1
+// (per SPEC_REVIEW_VISUAL_FIRECRAWL.md). The provider must error
+// loudly when Images is non-empty so vision-required tasks like
+// review_visual get routed to OpenAI instead of silently dropping the
+// screenshot.
+func TestAnthropicErrorsOnImageInputs(t *testing.T) {
+	a := newAnthropicTest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("Anthropic should NOT make an HTTP request when Images is non-empty")
+	}))
+	_, err := a.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleUser, Content: "describe this"}},
+		Images:    []ImageInput{{URL: "https://example.com/x.png"}},
+	})
+	if err == nil {
+		t.Fatal("expected error when Images is non-empty for Anthropic")
+	}
+	if !strings.Contains(err.Error(), "image inputs not supported") {
+		t.Errorf("expected unsupported-images error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "openai") {
+		t.Errorf("error should hint to route vision tasks to openai, got: %v", err)
+	}
+}
+
 func TestAnthropicName(t *testing.T) {
 	a := &Anthropic{}
 	if a.Name() != "anthropic" {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -16,6 +16,20 @@ type Message struct {
 	Content string `json:"content"`
 }
 
+// ImageInput is a vision-model input. Path is preferred — local files
+// are read and base64-encoded by the provider so the wire request is
+// self-contained even when the original signed URL has expired
+// (Firecrawl screenshot URLs are an example). URL is the fallback for
+// callers that only have a remote reference; OpenAI passes those
+// through as `image_url`. Set MIME to override the inferred type
+// (defaults to image/png for screenshots, image/jpeg for product
+// photos, derived from extension).
+type ImageInput struct {
+	Path string // local path; preferred when set
+	URL  string // remote URL; fallback when Path is empty
+	MIME string // optional override
+}
+
 type Request struct {
 	Model       string
 	Messages    []Message
@@ -25,6 +39,10 @@ type Request struct {
 	// implements this idiomatically: OpenAI uses native response_format,
 	// Anthropic uses a system-instruction nudge.
 	JSONMode bool
+	// Images attach to the last user-role message. Providers that don't
+	// support image inputs (Anthropic in v1) return a clear error when
+	// Images is non-empty.
+	Images []ImageInput
 }
 
 type Response struct {

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -3,11 +3,14 @@ package llm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -43,18 +46,55 @@ type openaiRequest struct {
 	ResponseFormat *openaiResponseFormat `json:"response_format,omitempty"`
 }
 
+// openaiMessage covers both shapes the API accepts: Content is a string
+// for plain text messages and a slice of content blocks for vision
+// requests. Marshaling picks whichever is non-nil.
 type openaiMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role         string
+	Text         string
+	ContentParts []openaiContentPart
+}
+
+type openaiContentPart struct {
+	Type     string             `json:"type"`
+	Text     string             `json:"text,omitempty"`
+	ImageURL *openaiImageURLRef `json:"image_url,omitempty"`
+}
+
+type openaiImageURLRef struct {
+	URL string `json:"url"`
+}
+
+func (m openaiMessage) MarshalJSON() ([]byte, error) {
+	type withText struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type withParts struct {
+		Role    string              `json:"role"`
+		Content []openaiContentPart `json:"content"`
+	}
+	if len(m.ContentParts) > 0 {
+		return json.Marshal(withParts{Role: m.Role, Content: m.ContentParts})
+	}
+	return json.Marshal(withText{Role: m.Role, Content: m.Text})
 }
 
 type openaiResponseFormat struct {
 	Type string `json:"type"`
 }
 
+// openaiResponseMessage is the response-side shape: completions always
+// return plain string content, regardless of whether the request used
+// multipart vision content blocks.
+type openaiResponseMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
 type openaiResponse struct {
 	Choices []struct {
-		Message openaiMessage `json:"message"`
+		Message openaiResponseMessage `json:"message"`
 	} `json:"choices"`
 	Usage struct {
 		PromptTokens     int `json:"prompt_tokens"`
@@ -90,10 +130,36 @@ func (o *OpenAI) Complete(ctx context.Context, req Request) (*Response, error) {
 	if req.JSONMode {
 		body.ResponseFormat = &openaiResponseFormat{Type: "json_object"}
 	}
-	for _, m := range req.Messages {
+	// Translate llm.Messages to openaiMessages. Images attach to the LAST
+	// user-role message — same convention OpenAI's reference docs use for
+	// vision requests.
+	lastUserIdx := -1
+	for i, m := range req.Messages {
+		if m.Role == RoleUser {
+			lastUserIdx = i
+		}
+	}
+	if len(req.Images) > 0 && lastUserIdx == -1 {
+		return nil, fmt.Errorf("openai: Images set but no user-role message to attach them to")
+	}
+	for i, m := range req.Messages {
 		switch m.Role {
-		case RoleSystem, RoleUser, RoleAssistant:
-			body.Messages = append(body.Messages, openaiMessage{Role: m.Role, Content: m.Content})
+		case RoleSystem, RoleAssistant:
+			body.Messages = append(body.Messages, openaiMessage{Role: m.Role, Text: m.Content})
+		case RoleUser:
+			if i == lastUserIdx && len(req.Images) > 0 {
+				parts := []openaiContentPart{{Type: "text", Text: m.Content}}
+				for _, img := range req.Images {
+					ref, err := openaiImageRef(img)
+					if err != nil {
+						return nil, fmt.Errorf("openai: image %d: %w", len(parts)-1, err)
+					}
+					parts = append(parts, openaiContentPart{Type: "image_url", ImageURL: ref})
+				}
+				body.Messages = append(body.Messages, openaiMessage{Role: m.Role, ContentParts: parts})
+			} else {
+				body.Messages = append(body.Messages, openaiMessage{Role: m.Role, Text: m.Content})
+			}
 		default:
 			return nil, fmt.Errorf("openai: unknown role %q", m.Role)
 		}
@@ -137,4 +203,46 @@ func (o *OpenAI) Complete(ctx context.Context, req Request) (*Response, error) {
 		InputTokens:  resp.Usage.PromptTokens,
 		OutputTokens: resp.Usage.CompletionTokens,
 	}, nil
+}
+
+// openaiImageRef turns an llm.ImageInput into the OpenAI `image_url`
+// payload. Local Path is preferred — the file is read and embedded as a
+// data URL so the wire request is self-contained even when the original
+// (signed) URL has expired. URL is the fallback for callers that only
+// have a remote reference.
+func openaiImageRef(img ImageInput) (*openaiImageURLRef, error) {
+	if img.Path != "" {
+		data, err := os.ReadFile(img.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read image %s: %w", img.Path, err)
+		}
+		mime := img.MIME
+		if mime == "" {
+			mime = guessImageMIME(img.Path)
+		}
+		dataURL := "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
+		return &openaiImageURLRef{URL: dataURL}, nil
+	}
+	if img.URL != "" {
+		return &openaiImageURLRef{URL: img.URL}, nil
+	}
+	return nil, fmt.Errorf("image has neither Path nor URL")
+}
+
+// guessImageMIME returns the image/* type based on a file extension.
+// Defaults to image/png when unrecognized — that's the safe default for
+// Firecrawl screenshots, which are PNG.
+func guessImageMIME(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	default:
+		return "image/png"
+	}
 }

--- a/internal/llm/vision.go
+++ b/internal/llm/vision.go
@@ -1,0 +1,39 @@
+package llm
+
+import "strings"
+
+// visionCapableOpenAIModels is a hardcoded allowlist of OpenAI models
+// known to accept image_url content blocks. Maintained by hand — when
+// OpenAI ships a new vision model, add it here. We intentionally avoid
+// a Provider.Capabilities() abstraction in v1; a static list is honest
+// about the maintenance cost and easy to audit.
+//
+// Match is a prefix check so model identifiers with date suffixes
+// (e.g. "gpt-4o-2024-11-20") still resolve.
+var visionCapableOpenAIModels = []string{
+	"gpt-4o",
+	"gpt-4o-mini",
+	"gpt-4-turbo",
+	"gpt-4-vision",
+	"gpt-5", // gpt-5 family supports vision per OpenAI docs
+}
+
+// SupportsVision reports whether the given (provider, model) pair can
+// accept image inputs. Anthropic returns false in v1 — vision support
+// for the Anthropic provider is deferred per
+// SPEC_REVIEW_VISUAL_FIRECRAWL.md.
+//
+// Callers should use this before constructing a Request with non-empty
+// Images, to fail fast with a clear error rather than triggering a
+// provider-level "model does not support image inputs" error mid-flow.
+func SupportsVision(provider, model string) bool {
+	if provider != "openai" {
+		return false
+	}
+	for _, m := range visionCapableOpenAIModels {
+		if strings.HasPrefix(model, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/llm/vision_test.go
+++ b/internal/llm/vision_test.go
@@ -1,0 +1,202 @@
+package llm
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSupportsVision(t *testing.T) {
+	cases := []struct {
+		desc     string
+		provider string
+		model    string
+		want     bool
+	}{
+		{"openai gpt-4o", "openai", "gpt-4o", true},
+		{"openai gpt-4o dated suffix", "openai", "gpt-4o-2024-11-20", true},
+		{"openai gpt-4o-mini", "openai", "gpt-4o-mini", true},
+		{"openai gpt-4-turbo", "openai", "gpt-4-turbo", true},
+		{"openai gpt-5", "openai", "gpt-5", true},
+		{"openai gpt-3.5", "openai", "gpt-3.5-turbo", false},
+		{"anthropic claude-opus-4-7", "anthropic", "claude-opus-4-7", false},
+		{"unknown provider", "perplexity", "anything", false},
+		{"empty model", "openai", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			if got := SupportsVision(c.provider, c.model); got != c.want {
+				t.Errorf("SupportsVision(%q, %q) = %v, want %v", c.provider, c.model, got, c.want)
+			}
+		})
+	}
+}
+
+// Vision request smoke test: the OpenAI provider should send the user
+// message as a content-parts array containing one text part and one
+// image_url part when Request.Images is non-empty. The image_url URL
+// should be a data: URL when Path is set (so the request is
+// self-contained even if the original signed URL has expired).
+func TestOpenAIVisionRequestShape(t *testing.T) {
+	tmp := t.TempDir()
+	imgPath := filepath.Join(tmp, "shot.png")
+	imgBytes := []byte{0x89, 'P', 'N', 'G', 0x00, 0x01, 0x02} // arbitrary bytes; not a real PNG, but read+encoded faithfully
+	if err := os.WriteFile(imgPath, imgBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	o.Model = "gpt-4o"
+
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 1024,
+		Messages: []Message{
+			{Role: RoleUser, Content: "what's in this image?"},
+		},
+		Images: []ImageInput{{Path: imgPath}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, ok := cap.body["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("messages = %#v", cap.body["messages"])
+	}
+	user := msgs[0].(map[string]any)
+	if user["role"] != "user" {
+		t.Fatalf("role = %v", user["role"])
+	}
+	parts, ok := user["content"].([]any)
+	if !ok {
+		t.Fatalf("expected content to be array (vision request), got %#v", user["content"])
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 content parts (text + image), got %d", len(parts))
+	}
+
+	textPart := parts[0].(map[string]any)
+	if textPart["type"] != "text" || textPart["text"] != "what's in this image?" {
+		t.Errorf("text part: %+v", textPart)
+	}
+
+	imgPart := parts[1].(map[string]any)
+	if imgPart["type"] != "image_url" {
+		t.Errorf("image part type: %v", imgPart["type"])
+	}
+	imgRef, ok := imgPart["image_url"].(map[string]any)
+	if !ok {
+		t.Fatalf("image_url shape: %#v", imgPart["image_url"])
+	}
+	url, _ := imgRef["url"].(string)
+	wantPrefix := "data:image/png;base64,"
+	if !strings.HasPrefix(url, wantPrefix) {
+		t.Fatalf("expected data URL with PNG MIME, got: %q", url)
+	}
+	encoded := strings.TrimPrefix(url, wantPrefix)
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode base64: %v", err)
+	}
+	if string(decoded) != string(imgBytes) {
+		t.Errorf("decoded bytes don't match original image bytes")
+	}
+}
+
+// When Path is empty and only URL is set, OpenAI should pass the URL
+// straight through (no base64 encoding, no file read). That's the
+// fallback path for callers that only have a remote reference.
+func TestOpenAIVisionRequestPassesThroughURL(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+	o.Model = "gpt-4o"
+
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 1024,
+		Messages:  []Message{{Role: RoleUser, Content: "describe"}},
+		Images:    []ImageInput{{URL: "https://example.com/photo.jpg"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := cap.body["messages"].([]any)
+	parts := msgs[0].(map[string]any)["content"].([]any)
+	imgRef := parts[1].(map[string]any)["image_url"].(map[string]any)
+	if imgRef["url"] != "https://example.com/photo.jpg" {
+		t.Errorf("expected URL passthrough, got %v", imgRef["url"])
+	}
+}
+
+// Plain text (no images) keeps the legacy `content: <string>` shape so
+// the body is identical to pre-vision builds for non-vision tasks. This
+// catches accidental shape regression that might confuse JSON-mode
+// parsers or token counters downstream.
+func TestOpenAIPlainTextStillUsesStringContent(t *testing.T) {
+	cap, h := captureHandler(t, 200, openaiSuccess)
+	o := newOpenAITest(t, h)
+
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := cap.body["messages"].([]any)
+	user := msgs[0].(map[string]any)
+	content := user["content"]
+	if _, isStr := content.(string); !isStr {
+		t.Errorf("plain text request should keep content as string, got %T: %#v", content, content)
+	}
+}
+
+// When Images is set but no user-role message exists, the provider
+// should fail loudly rather than silently dropping the images.
+func TestOpenAIVisionWithoutUserMessageErrors(t *testing.T) {
+	o := newOpenAITest(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+	}))
+	_, err := o.Complete(context.Background(), Request{
+		MaxTokens: 100,
+		Messages:  []Message{{Role: RoleSystem, Content: "be terse"}},
+		Images:    []ImageInput{{URL: "https://example.com/x.png"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "no user-role message") {
+		t.Errorf("expected user-message error, got %v", err)
+	}
+}
+
+// guessImageMIME unit test — small but worth pinning since the dataURL
+// prefix correctness depends on it.
+func TestGuessImageMIME(t *testing.T) {
+	cases := []struct{ path, want string }{
+		{"shot.png", "image/png"},
+		{"photo.jpg", "image/jpeg"},
+		{"photo.JPEG", "image/jpeg"},
+		{"img.webp", "image/webp"},
+		{"banner.gif", "image/gif"},
+		{"unknown.bin", "image/png"}, // safe default for screenshots
+		{"noext", "image/png"},
+	}
+	for _, c := range cases {
+		if got := guessImageMIME(c.path); got != c.want {
+			t.Errorf("guessImageMIME(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+// pin httptest import for symmetry with other test files
+var _ = httptest.NewServer
+
+// pin json import for symmetry — vision tests rely on json decoding via
+// the captureHandler helper; making the dep explicit so removing
+// captureHandler in future doesn't surprise this file.
+var _ = json.Unmarshal

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -308,14 +308,16 @@ type ReplyDraft struct {
 
 // ReplyBundle holds the variants a single reply-drafting call produced
 // plus the pick the LLM recommends. Same shape regardless of mode
-// (reply vs review).
+// (reply vs review). Inspection is populated only in review mode and
+// drives the inspection-depth header in the rendered output.
 type ReplyBundle struct {
-	ThreadURL string       `json:"thread_url"`
-	Subreddit string       `json:"subreddit"`
-	Mode      ReplyMode    `json:"mode"`
-	Drafts    []ReplyDraft `json:"drafts"`
-	PickID    string       `json:"pick_id,omitempty"`
-	Generated time.Time    `json:"generated"`
+	ThreadURL  string             `json:"thread_url"`
+	Subreddit  string             `json:"subreddit"`
+	Mode       ReplyMode          `json:"mode"`
+	Drafts     []ReplyDraft       `json:"drafts"`
+	PickID     string             `json:"pick_id,omitempty"`
+	Inspection *InspectionSummary `json:"inspection,omitempty"`
+	Generated  time.Time          `json:"generated"`
 }
 
 // Inspection is the structured signal we extract from a review target's
@@ -368,4 +370,70 @@ type ReviewNotes struct {
 	Suggestions   []string  `json:"suggestions,omitempty"`
 	OpenQuestions []string  `json:"open_questions,omitempty"`
 	Generated     time.Time `json:"generated"`
+}
+
+// VisualReviewNotes is the LLM's analysis of the captured screenshot
+// (and optionally selected product/page images). Sits alongside
+// ReviewNotes — text and visual observations are kept in separate
+// artifacts so the review drafter can quote each one specifically and
+// the user can audit which findings came from where.
+//
+// ShopType is the analyzer's classification of the inspected page; it
+// gates the KovaSignals slot. KovaSignals is populated only when
+// ShopType is "handmade" or "boutique" (where the Kova thesis applies).
+// For B2B / SaaS / dropship / services / portfolio / unclear pages,
+// KovaSignals stays empty so the drafter doesn't recommend "show your
+// maker process" to an industrial supplier.
+type VisualReviewNotes struct {
+	TargetURL    string              `json:"target_url"`
+	ShopType     string              `json:"shop_type"` // handmade|boutique|dropship|b2b_industrial|saas|services|portfolio|unclear
+	Summary      string              `json:"summary"`
+	Observations []VisualObservation `json:"observations"`
+	KovaSignals  []string            `json:"kova_signals,omitempty"`
+	Questions    []string            `json:"questions,omitempty"`
+	Limitations  []string            `json:"limitations,omitempty"`
+	Generated    time.Time           `json:"generated"`
+}
+
+// VisualObservation is one finding from the visual analyzer. Each
+// observation must cite visible evidence so the drafter can quote it
+// directly without re-inspecting the page.
+type VisualObservation struct {
+	Area           string `json:"area"` // above_fold|product_images|trust|navigation|pricing_cta|mobile_risk|brand|generic_risk
+	Finding        string `json:"finding"`
+	Evidence       string `json:"evidence"`
+	Severity       string `json:"severity"` // high|medium|low
+	Recommendation string `json:"recommendation"`
+}
+
+// VisualInputRecord is what gets persisted to visual-input.json — the
+// exact materials sent to the visual analyzer. Saved alongside
+// visual-notes.json so a session can be replayed without re-fetching.
+type VisualInputRecord struct {
+	TargetURL           string                `json:"target_url"`
+	ScreenshotPath      string                `json:"screenshot_path"`
+	ScreenshotSourceURL string                `json:"screenshot_source_url,omitempty"`
+	ImageRefs           []VisualImageRef      `json:"image_refs,omitempty"`
+	PageTitle           string                `json:"page_title,omitempty"`
+	ContextIDs          []string              `json:"context_ids,omitempty"`
+	Generated           time.Time             `json:"generated"`
+}
+
+type VisualImageRef struct {
+	URL       string `json:"url"`
+	LocalPath string `json:"local_path,omitempty"`
+	Alt       string `json:"alt,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// InspectionSummary is a small render-time payload describing what was
+// inspected for a review. Populated only in review mode; reply mode
+// ignores it. Surfaces in the rendered output so users can see the
+// inspection depth before reading the draft.
+type InspectionSummary struct {
+	Source         string   `json:"source"`              // "firecrawl" — HTML inspection isn't valid for review-mode rendering
+	ScreenshotPath string   `json:"screenshot_path,omitempty"`
+	ImagesAnalyzed int      `json:"images_analyzed"`
+	ShopType       string   `json:"shop_type,omitempty"`
+	Limitations    []string `json:"limitations,omitempty"`
 }

--- a/prompts/review.tmpl
+++ b/prompts/review.tmpl
@@ -1,6 +1,6 @@
 You are drafting a Reddit reply for the user. The OP asked for review/feedback/critique of a specific resource (a shop, website, listing, portfolio). The user reviews the drafts and posts the chosen one manually. You never post anything yourself.
 
-Your reply must be GROUNDED in the inspection-derived review notes below. Do not invent observations not supported by the notes. Do not give generic advice ("improve your SEO", "run ads", "post on TikTok") that the notes don't justify.
+Your reply must be GROUNDED in the review notes below. The notes have two layers — TEXT notes (extracted from the page's markdown/headings/copy) and VISUAL notes (analyzed from the captured screenshot and product images). Quote specific findings; do not invent observations the notes don't support. Do not give generic advice ("improve your SEO", "run ads", "post on TikTok") that the notes don't justify.
 
 # Thread
 
@@ -14,7 +14,7 @@ Body:
 ---
 {{- end }}
 
-# Review notes (your evidence base)
+# Text review notes (extracted-content evidence)
 
 Target URL: {{.TargetURL}}
 {{- if .Strengths }}
@@ -46,13 +46,51 @@ Target URL: {{.TargetURL}}
 {{- end }}
 {{- end }}
 
+{{- if .VisualNotes }}
+
+# Visual review notes (screenshot + image evidence)
+
+ShopType: {{.VisualNotes.ShopType}}
+{{- if .VisualNotes.Summary }}
+Summary: {{.VisualNotes.Summary}}
+{{- end }}
+{{- if .VisualNotes.Observations }}
+
+## Observations (each cites visible evidence)
+{{- range .VisualNotes.Observations }}
+- [{{.Severity}}] {{.Area}}: {{.Finding}} (evidence: {{.Evidence}}; rec: {{.Recommendation}})
+{{- end }}
+{{- end }}
+{{- if .VisualNotes.KovaSignals }}
+
+## Kova signals (visible trust gaps in product proof)
+{{- range .VisualNotes.KovaSignals }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- if .VisualNotes.Questions }}
+
+## Visual questions (open from screenshot)
+{{- range .VisualNotes.Questions }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- if .VisualNotes.Limitations }}
+
+## Visual inspection limitations
+{{- range .VisualNotes.Limitations }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- if .AuthorContext }}
 
 # Who you're writing as
 
 {{.AuthorContext}}
 
-When you reference experience or perspective, ground it in this background — not generic developer-tone "I built a thing" prose. Don't invent specific events not in the context.
+This block is for **voice and judgment only** — tone, communication style. It is not a list of facts to drop into the reply. Do not name employers, projects, credentials, or family members from this block unless the supplied Context section explicitly invites that material.
 {{- end }}
 {{- if .Contexts }}
 
@@ -64,52 +102,65 @@ When you reference experience or perspective, ground it in this background — n
 {{.Body}}
 {{- end }}
 
-Use as background only. **Do not name or pitch the project** unless the context body explicitly says naming is allowed (look for "in-thread naming: ok"). The OP wants help with their thing, not a pitch for yours.
+Use context as a **lens, not a topic**. The thesis or worldview from this material should shape the angle of your feedback — not become the subject. Do **not** name or pitch the project unless the context body explicitly says naming is allowed.
 {{- end }}
 
-# Task
+# Task — variants
 
-Draft 3-4 reply variants of constructive review:
+Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if the thread genuinely fits one (e.g. `question-first` when the open questions in the notes block any useful advice).
 
-- "best" — your recommended reply: specific, balanced (acknowledges at least one strength + names concrete improvement areas), references the actual page content
-- "short" — the shortest viable version that still gives one specific suggestion the OP can act on
-- "detailed" — a thorough breakdown organized by area (e.g., positioning, content, layout) — only if the notes have enough material to justify length
-- "question-first" — leads with the most important open question from the notes before advising
+- **`best`** — your recommended reply: acknowledge one or two strengths, give 2-4 concrete fixes, include at least one visual observation when visual notes exist. Avoid sounding like an agency audit. Usually 150-300 words.
+- **`short`** — shortest useful review: one strength, one or two highest-leverage fixes. 60-130 words.
+- **`structured-review`** — *use only when OP explicitly asked for critique/review and the findings justify structure.* Format: "What works:" / "What I would fix:" / "Biggest priority:" lists. Keep it postable as a Reddit comment, not an audit. Skip if the findings are sparse.
+- **`question-first`** — *only* if the review cannot be usefully completed without one or two facts (e.g. quote-only vs fixed pricing, intended customer, whether the linked page is a placeholder). Do NOT use this as an excuse to avoid giving visible-page feedback. 30-80 words.
 
-Set `pick_id` to your recommended choice. "best" is usually right; pick another if the notes lean heavily toward needing clarification ("question-first") or have very little material ("short").
+# Hard rules — visual feedback grounding
+
+- Do NOT mention visual / layout / image / screenshot feedback unless the Visual review notes section above contains a corresponding observation. If there are no visual notes, do not write "your hero section..." or "your product photos...".
+- When you draw on a visual observation, paraphrase the specific finding — don't generalize. "Your first three product shots are top-down crops with no scale reference" beats "your photos could be better."
+- If `ShopType` is `b2b_industrial`, `saas`, `services`, `portfolio`, or `unclear`, do not recommend "show your maker process" or "add a making-of clip" — that's Kova-thesis advice and only applies when ShopType is `handmade` or `boutique`.
+- When `KovaSignals` is non-empty, those are the highest-leverage visual gaps for this thread; lead with one of them in `best`.
 
 # Anti-tells (mandatory)
 
 Never:
 - Generic advice not grounded in the notes ("improve your SEO", "run ads", "post more")
-- Made-up specifics ("your photos look great" if photos aren't in the notes)
+- Made-up specifics ("your photos look great" if no visual notes back this up)
 - "Great question!" / "Thanks for sharing!" / "Hey r/{{.Subreddit}}!" openers
 - Project sales pitches (unless context allows naming)
 - "I built a tool" framing
 - Rocket 🚀, fire 🔥, sparkles ✨, marketing emojis
 - Sycophantic praise without substance
+- **Fabricate first-person experience.** "I ran the same kind of shop", "What worked for me was..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
+- **Reformat `best` as `structured-review`.** Adding "What works:" / "What I would fix:" headers around the same content is not depth, it's padding.
 
 Always:
-- Cite specific text from the inspection — quote a heading, reference the meta description, point at what the page does or doesn't say
+- Cite specific evidence — quote a heading, reference the meta description, paraphrase a visual observation
 - Be a constructive peer, not a consultant pitching a service
-- If the notes flag open questions, surface 1-2 in the body so the OP knows what additional info would unlock better feedback
-- Keep critique kind but specific. "The h1 reads 'Welcome to my shop' — leading with what you make would let buyers know they're in the right place" beats "your h1 needs work"
+- If the notes flag open questions and they're load-bearing, surface 1-2 so OP knows what would unlock better feedback
+- Keep critique kind but specific
+
+# Reasoning field — describe the angle, not the length
+
+The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is.
+
+Good: "Leads with the highest-severity visual finding (no scale reference) and ties it to the thread's stated goal."
+Bad: "Provides a thorough multi-section review with structured headers."
 
 # Output
 
-Return a single JSON object exactly matching this shape, no other fields:
+Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-4 entries depending on what fits.
 
 {
   "drafts": [
     {
       "id": "best",
       "label": "best",
-      "text": "...the actual reddit reply text the user would post, grounded in specific inspection observations...",
-      "reasoning": "one short sentence on why this approach fits the thread"
+      "text": "...the actual reddit reply text the user would post, grounded in specific notes observations...",
+      "reasoning": "one short sentence on the angle"
     },
     {"id": "short", "label": "short", "text": "...", "reasoning": "..."},
-    {"id": "detailed", "label": "detailed", "text": "...", "reasoning": "..."},
-    {"id": "question-first", "label": "question-first", "text": "...", "reasoning": "..."}
+    {"id": "structured-review", "label": "structured-review", "text": "...", "reasoning": "..."}
   ],
   "pick_id": "best"
 }

--- a/prompts/review_visual.tmpl
+++ b/prompts/review_visual.tmpl
@@ -1,0 +1,101 @@
+You are analyzing a website screenshot to produce structured visual review notes. Another LLM call will use these notes to draft a Reddit comment that gives the page owner concrete, specific feedback.
+
+You are looking at:
+
+- a full-page screenshot of the captured page (attached as image)
+{{- if .ImageURLs }}
+- {{len .ImageURLs}} additional product/page image(s) extracted from the page (attached separately)
+{{- end }}
+
+# Target page
+
+URL: {{.TargetURL}}
+{{- if .Title }}
+Page title: {{.Title}}
+{{- end }}
+{{- if .MetaDescription }}
+Meta description: {{.MetaDescription}}
+{{- end }}
+{{- if .Headings }}
+
+## Headings (from the markdown extraction, for grounding)
+{{- range .Headings }}
+- (h{{.Level}}) {{.Text}}
+{{- end }}
+{{- end }}
+{{- if .Contexts }}
+
+# Context (project material — background only, do NOT pitch)
+{{- range .Contexts }}
+
+## From {{.Source}}{{if .ID}} ({{.ID}}){{end}}
+
+{{.Body}}
+{{- end }}
+{{- end }}
+
+# Task
+
+Step 1 — Classify the shop/page type into ONE of:
+
+- `handmade` — solo or small-team artisan/handmade goods (Etsy-shaped, ceramic, textile, jewelry, woodworking, art prints, etc.)
+- `boutique` — small curated brand, often single-product or small catalog, owner-operated, lifestyle/fashion/beauty
+- `dropship` — generic catalog with many SKUs, stock photos, no maker/origin signals, AliExpress-shaped
+- `b2b_industrial` — wholesale/equipment/industrial supplier, business buyers, quote-driven, technical specs
+- `saas` — software product, sign-up funnel, feature/pricing pages
+- `services` — agency/consultancy/freelancer offering services, not products
+- `portfolio` — personal site, work showcase, no commerce
+- `unclear` — when the screenshot doesn't give you enough to choose
+
+Step 2 — Produce visual observations across these areas (skip any that don't apply):
+
+- `above_fold` — clarity in the first viewport: what is this site, who is it for, what action can I take?
+- `product_images` — quality, consistency, scale clarity, lighting, background, hero shots
+- `trust` — authenticity signals: real-product proof, packaging, maker/process visibility, reviews/testimonials visible, badges
+- `navigation` — header structure, category clarity, can I find what I'm looking for in 2 clicks
+- `pricing_cta` — visible price or quote path, primary CTA prominence, friction in the buy/contact action
+- `mobile_risk` — visible-from-screenshot risks for mobile: tiny text, dense layout, off-canvas content, image-heavy hero
+- `brand` — color/typography/voice consistency across visible sections
+- `generic_risk` — does this page look stock/AI-generated/dropship/templated? Cite the specific visual features that triggered the read.
+
+Each observation MUST cite specific visible evidence (e.g. "the hero section uses three different button styles for the primary CTA" — not "CTAs are inconsistent"). If you can't cite evidence, don't include the observation.
+
+Step 3 — KovaSignals (gated by ShopType).
+
+Populate `kova_signals` ONLY if `shop_type` is `handmade` or `boutique`. The Kova thesis: handmade buyers need to *trust the product is real* — that means visible proof of scale, texture, material, function, packing, and process. KovaSignals capture observations specifically about that proof:
+
+- "no in-hand or scale shot in the first 2 product images"
+- "texture is invisible at the photo crops shown"
+- "no process/maker clip; site reads as dropship-flavored despite handmade copy"
+- "packing/order shots could double as trust signals"
+
+For any other ShopType (dropship, b2b_industrial, saas, services, portfolio, unclear), `kova_signals` MUST be an empty array `[]`. Do NOT recommend "show your maker process" to a B2B equipment supplier or SaaS landing page — the Kova thesis doesn't apply.
+
+# Hard rules
+
+- Do NOT name the project or pitch it. Even if context mentions "Kova", never write the word in your output.
+- Do NOT infer behavior you can't see: checkout flow, page speed, mobile rendering not in the screenshot, conversion rates, inventory, prices not visible.
+- Do NOT fabricate observations. If the screenshot is partial or low-quality, list that in `limitations`.
+- Severity: `high` for observations that materially hurt trust or conversion; `medium` for clear-but-fixable issues; `low` for polish-level notes.
+- Recommendations should be one specific actionable change, not "improve your branding".
+
+# Output
+
+Return a single JSON object exactly matching this shape, no other fields:
+
+{
+  "shop_type": "handmade",
+  "summary": "one-sentence read of the page overall",
+  "observations": [
+    {
+      "area": "above_fold",
+      "finding": "specific visible issue",
+      "evidence": "what in the screenshot supports this",
+      "severity": "high|medium|low",
+      "recommendation": "one specific actionable change"
+    }
+  ],
+  "kova_signals": ["..."],
+  "questions": ["things you'd ask the owner that the screenshot can't answer"],
+  "limitations": ["e.g. screenshot only covers homepage; mobile not inspected"]
+}

--- a/reply/images.go
+++ b/reply/images.go
@@ -1,0 +1,91 @@
+package reply
+
+import (
+	"net/url"
+	"strings"
+)
+
+// MaxImagesForAnalysis caps how many product/page images we attach to
+// the visual analyzer prompt. The screenshot is always attached
+// separately; this is the cap on the additional images. 8 keeps cost
+// bounded while leaving room for the most informative product shots
+// most ecommerce homepages surface above the fold.
+const MaxImagesForAnalysis = 8
+
+// imageNoiseFragments are URL substrings that mark an image as low-
+// signal for visual review: logos, icons, payment badges, sprites,
+// social glyphs, tracking pixels. Filtered case-insensitively.
+//
+// Conservative on purpose — false negatives cost a few extra tokens at
+// the visual analyzer; false positives drop a real product image.
+var imageNoiseFragments = []string{
+	"logo",
+	"favicon",
+	"sprite",
+	"icon-",
+	"/icons/",
+	"payment",
+	"badge",
+	"tracking",
+	"pixel",
+	"google-analytics",
+	"facebook.com/tr",
+}
+
+// SelectImagesForAnalysis filters Firecrawl's extracted image URL list
+// to the set of likely product/page images worth sending to the visual
+// analyzer. Returns up to MaxImagesForAnalysis URLs, deduped
+// case-insensitively, body-order preserved (Firecrawl emits images in
+// roughly DOM order, which correlates with above-the-fold).
+//
+// Filters:
+//   - reject URLs containing any imageNoiseFragments substring
+//   - reject non-http(s) schemes (data: URIs, relative paths)
+//   - reject the screenshot URL itself if it appears in the list
+//   - dedupe case-insensitively
+func SelectImagesForAnalysis(rawURLs []string, screenshotURL string) []string {
+	if len(rawURLs) == 0 {
+		return nil
+	}
+	screenshotLower := strings.ToLower(strings.TrimSpace(screenshotURL))
+	seen := map[string]bool{}
+	var out []string
+	for _, raw := range rawURLs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			continue
+		}
+		lower := strings.ToLower(raw)
+		if lower == screenshotLower {
+			continue
+		}
+		if isLowSignalImageURL(lower) {
+			continue
+		}
+		if seen[lower] {
+			continue
+		}
+		seen[lower] = true
+		out = append(out, raw)
+		if len(out) >= MaxImagesForAnalysis {
+			break
+		}
+	}
+	return out
+}
+
+func isLowSignalImageURL(lowerURL string) bool {
+	for _, frag := range imageNoiseFragments {
+		if strings.Contains(lowerURL, frag) {
+			return true
+		}
+	}
+	return false
+}

--- a/reply/images_test.go
+++ b/reply/images_test.go
@@ -1,0 +1,98 @@
+package reply
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectImagesForAnalysisFiltersNoise(t *testing.T) {
+	raw := []string{
+		"https://example.com/logo.png",                  // reject: logo
+		"https://example.com/products/bowl-1.jpg",       // keep: product
+		"https://example.com/icons/payment-visa.svg",    // reject: payment + icons + svg-as-icon shape
+		"https://example.com/products/bowl-2.jpg",       // keep
+		"https://example.com/img/favicon.ico",           // reject: favicon
+		"https://example.com/products/bowl-1.JPG",       // dedupe (case-insensitive)
+		"https://www.facebook.com/tr?id=123",            // reject: tracking pixel
+		"data:image/png;base64,iVBOR...",                // reject: data URI (no scheme http(s))
+		"/relative/path.jpg",                            // reject: relative
+		"https://example.com/products/bowl-3.webp",      // keep
+		"https://example.com/icon-search.svg",           // reject: icon-
+		"https://example.com/sprite-nav.png",            // reject: sprite
+	}
+	got := SelectImagesForAnalysis(raw, "")
+	want := []string{
+		"https://example.com/products/bowl-1.jpg",
+		"https://example.com/products/bowl-2.jpg",
+		"https://example.com/products/bowl-3.webp",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d images, want %d: got=%v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestSelectImagesForAnalysisCaps(t *testing.T) {
+	var raw []string
+	for i := 0; i < 50; i++ {
+		raw = append(raw, "https://example.com/products/p"+itoa(i)+".jpg")
+	}
+	got := SelectImagesForAnalysis(raw, "")
+	if len(got) != MaxImagesForAnalysis {
+		t.Errorf("expected cap at %d, got %d", MaxImagesForAnalysis, len(got))
+	}
+	// Body order preserved — first 8 should be p0..p7.
+	for i, u := range got {
+		if !strings.Contains(u, "/p"+itoa(i)+".jpg") {
+			t.Errorf("got[%d] = %q, expected to contain p%d", i, u, i)
+		}
+	}
+}
+
+func TestSelectImagesForAnalysisExcludesScreenshotURL(t *testing.T) {
+	screenshot := "https://firecrawl-cdn.example/screenshots/abc123.png"
+	raw := []string{
+		"https://example.com/products/bowl.jpg",
+		screenshot,                            // should be excluded
+		strings.ToUpper(screenshot),           // case-insensitive dedupe
+		"https://example.com/products/mug.jpg",
+	}
+	got := SelectImagesForAnalysis(raw, screenshot)
+	for _, u := range got {
+		if strings.EqualFold(u, screenshot) {
+			t.Errorf("screenshot URL %q should be excluded from product images", u)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 product images after screenshot filter, got %d: %v", len(got), got)
+	}
+}
+
+func TestSelectImagesForAnalysisEmptyInput(t *testing.T) {
+	if got := SelectImagesForAnalysis(nil, ""); got != nil {
+		t.Errorf("nil input should return nil, got %v", got)
+	}
+	if got := SelectImagesForAnalysis([]string{}, ""); got != nil {
+		t.Errorf("empty input should return nil, got %v", got)
+	}
+}
+
+// itoa: tiny stdlib-free int-to-string for tests, avoids strconv import
+// for a single use case.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/reply/inspect.go
+++ b/reply/inspect.go
@@ -46,11 +46,39 @@ const inspectUserAgent = "tider/0.1 (review-mode inspection; contact /u/tider28)
 //
 // Both backends return *types.Inspection with the same shape;
 // downstream steps (review notes, drafter) read whatever's present.
+//
+// Inspect is the LEGACY entry point. New review-mode callers should use
+// InspectReviewTarget instead — it requires Firecrawl + a screenshot
+// per SPEC_REVIEW_VISUAL_FIRECRAWL.md and refuses the HTML fallback
+// path entirely.
 func Inspect(ctx context.Context, client *http.Client, target string) (*types.Inspection, error) {
 	if key := strings.TrimSpace(os.Getenv("FIRECRAWL_API_KEY")); key != "" {
 		return InspectFirecrawl(ctx, client, key, target)
 	}
 	return InspectHTML(ctx, client, target)
+}
+
+// InspectReviewTarget is the entry point for review mode. It requires
+// FIRECRAWL_API_KEY and a non-empty ScreenshotURL on the response —
+// review mode is a visual review per SPEC_REVIEW_VISUAL_FIRECRAWL.md
+// and silently downgrading to HTML or to a no-screenshot path would
+// produce reviews that *look* visual but aren't.
+//
+// Errors are explicit so the user can route around them with
+// `--mode=reply` (the recoverable escape hatch) or by setting the key.
+func InspectReviewTarget(ctx context.Context, client *http.Client, target string) (*types.Inspection, error) {
+	key := strings.TrimSpace(os.Getenv("FIRECRAWL_API_KEY"))
+	if key == "" {
+		return nil, fmt.Errorf("review mode requires visual site inspection, but FIRECRAWL_API_KEY is not set; either set the key or rerun with --mode=reply")
+	}
+	insp, err := InspectFirecrawl(ctx, client, key, target)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(insp.ScreenshotURL) == "" {
+		return nil, fmt.Errorf("review mode requires a screenshot, but Firecrawl returned none for %s", target)
+	}
+	return insp, nil
 }
 
 // InspectHTML is the stdlib-only backend: fetch HTML, parse via

--- a/reply/inspect_test.go
+++ b/reply/inspect_test.go
@@ -234,6 +234,85 @@ func TestInspectFirecrawlErrorDoesNotFallBackToHTML(t *testing.T) {
 	}
 }
 
+// SPEC_REVIEW_VISUAL_FIRECRAWL.md mandates that review mode require
+// Firecrawl + a screenshot. InspectReviewTarget enforces both invariants
+// and produces explicit errors callers can route around with
+// `--mode=reply`.
+
+func TestInspectReviewTargetRequiresFirecrawlKey(t *testing.T) {
+	t.Setenv("FIRECRAWL_API_KEY", "")
+	_, err := InspectReviewTarget(context.Background(), &http.Client{}, "https://example.com/")
+	if err == nil {
+		t.Fatal("expected error when FIRECRAWL_API_KEY is unset")
+	}
+	if !strings.Contains(err.Error(), "FIRECRAWL_API_KEY") {
+		t.Errorf("error should name the missing env var: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--mode=reply") {
+		t.Errorf("error should hint at the --mode=reply escape hatch: %v", err)
+	}
+}
+
+func TestInspectReviewTargetRequiresScreenshot(t *testing.T) {
+	// Firecrawl returns success but with no screenshot URL.
+	resp := `{
+  "success": true,
+  "data": {
+    "markdown": "# Welcome",
+    "metadata": {"title": "X", "statusCode": 200}
+  }
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+	prev := firecrawlAPIBase
+	firecrawlAPIBase = srv.URL
+	defer func() { firecrawlAPIBase = prev }()
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	_, err := InspectReviewTarget(context.Background(), &http.Client{}, "https://example.com/")
+	if err == nil {
+		t.Fatal("expected error when Firecrawl returns no screenshot")
+	}
+	if !strings.Contains(err.Error(), "screenshot") {
+		t.Errorf("error should name the missing screenshot: %v", err)
+	}
+}
+
+func TestInspectReviewTargetHappyPath(t *testing.T) {
+	resp := `{
+  "success": true,
+  "data": {
+    "markdown": "# Welcome\n\nReal content.",
+    "screenshot": "https://firecrawl-cdn.example/sig/abc.png",
+    "links": [],
+    "metadata": {"title": "Shop", "statusCode": 200}
+  }
+}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+	prev := firecrawlAPIBase
+	firecrawlAPIBase = srv.URL
+	defer func() { firecrawlAPIBase = prev }()
+	t.Setenv("FIRECRAWL_API_KEY", "test-key")
+
+	insp, err := InspectReviewTarget(context.Background(), &http.Client{}, "https://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if insp.Source != "firecrawl" {
+		t.Errorf("Source = %q", insp.Source)
+	}
+	if insp.ScreenshotURL == "" {
+		t.Error("ScreenshotURL should be populated on happy path")
+	}
+}
+
 func TestCollapseWhitespace(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"  hello  world  ", "hello world"},

--- a/reply/render.go
+++ b/reply/render.go
@@ -28,6 +28,22 @@ func RenderMarkdown(b *types.ReplyBundle, threadTitle string, sessionPath string
 	if sessionPath != "" {
 		fmt.Fprintf(&sb, "Session: %s\n", sessionPath)
 	}
+	// Inspection-depth header — populated only in review mode so the
+	// reader can see what was inspected before reading the draft. Per
+	// SPEC_REVIEW_VISUAL_FIRECRAWL.md "Output rendering".
+	if b.Inspection != nil {
+		fmt.Fprintf(&sb, "Inspection: %s\n", inspectionDescription(b.Inspection))
+		if b.Inspection.ScreenshotPath != "" {
+			sb.WriteString("Screenshot: saved\n")
+		}
+		fmt.Fprintf(&sb, "Images analyzed: %d\n", b.Inspection.ImagesAnalyzed)
+		if b.Inspection.ShopType != "" {
+			fmt.Fprintf(&sb, "Shop type: %s\n", b.Inspection.ShopType)
+		}
+		if len(b.Inspection.Limitations) > 0 {
+			fmt.Fprintf(&sb, "Limitations: %s\n", strings.Join(b.Inspection.Limitations, "; "))
+		}
+	}
 	sb.WriteString("\n")
 
 	pick := findDraft(b.Drafts, b.PickID)
@@ -54,6 +70,26 @@ func RenderMarkdown(b *types.ReplyBundle, threadTitle string, sessionPath string
 	return sb.String()
 }
 
+// inspectionDescription turns an InspectionSummary into a one-line
+// description for the rendered header. "Firecrawl visual" when the
+// firecrawl backend ran with a screenshot; "Firecrawl (no screenshot)"
+// is a defensive case but should not occur in practice — the review-
+// mode invariant requires a screenshot. Fallback to Source verbatim
+// for unknown values so future backends don't render as empty.
+func inspectionDescription(s *types.InspectionSummary) string {
+	switch s.Source {
+	case "firecrawl":
+		if s.ScreenshotPath != "" {
+			return "Firecrawl visual"
+		}
+		return "Firecrawl (no screenshot)"
+	case "":
+		return "unknown"
+	default:
+		return s.Source
+	}
+}
+
 func findDraft(drafts []types.ReplyDraft, id string) *types.ReplyDraft {
 	for i := range drafts {
 		if drafts[i].ID == id {
@@ -74,17 +110,19 @@ func alternatives(drafts []types.ReplyDraft, pickID string) []types.ReplyDraft {
 }
 
 // displayLabel maps known variant ids to their spec-mandated display
-// form (SPEC_REPLY_REFINEMENT.md, "Output rendering"). Hyphen retention
-// is intentional and per-label: "thread-aware" reads as a compound
-// modifier and keeps its hyphen; "personal-story" and "question-first"
-// read as noun phrases and use spaces.
+// form. SPEC_REPLY_REFINEMENT.md "Output rendering" defines the reply-
+// mode forms; SPEC_REVIEW_VISUAL_FIRECRAWL.md adds review-mode-specific
+// variants. Hyphen retention is per-label and intentional: compound
+// modifiers like "thread-aware" / "structured-review" keep the hyphen;
+// noun phrases like "personal-story" / "question-first" use spaces.
 var displayLabel = map[string]string{
-	"best":           "Best",
-	"short":          "Short",
-	"thread-aware":   "Thread-Aware",
-	"personal-story": "Personal Story",
-	"question-first": "Question First",
-	"detailed":       "Detailed",
+	"best":              "Best",
+	"short":             "Short",
+	"thread-aware":      "Thread-Aware",
+	"personal-story":    "Personal Story",
+	"question-first":    "Question First",
+	"detailed":          "Detailed",
+	"structured-review": "Structured-Review",
 }
 
 // titleCaseLabel returns the display form of a draft label. Known labels

--- a/reply/render_test.go
+++ b/reply/render_test.go
@@ -103,15 +103,60 @@ func TestRenderMarkdownNilBundle(t *testing.T) {
 	}
 }
 
+// Review-mode renders an inspection-depth header showing what was
+// inspected. Reply-mode bundles (Inspection nil) render the previous
+// shape unchanged. Per SPEC_REVIEW_VISUAL_FIRECRAWL.md "Output rendering".
+func TestRenderMarkdownReviewModeShowsInspectionHeader(t *testing.T) {
+	b := sampleBundle()
+	b.Mode = types.ReplyModeReview
+	b.Inspection = &types.InspectionSummary{
+		Source:         "firecrawl",
+		ScreenshotPath: "/sessions/abc/screenshots/homepage.png",
+		ImagesAnalyzed: 4,
+		ShopType:       "handmade",
+		Limitations:    []string{"homepage only", "checkout not inspected"},
+	}
+	md := RenderMarkdown(b, "review my shop?", "/sessions/abc")
+	checks := []string{
+		"Mode: review",
+		"Inspection: Firecrawl visual",
+		"Screenshot: saved",
+		"Images analyzed: 4",
+		"Shop type: handmade",
+		"Limitations: homepage only; checkout not inspected",
+	}
+	for _, c := range checks {
+		if !strings.Contains(md, c) {
+			t.Errorf("missing %q\n--- output ---\n%s", c, md)
+		}
+	}
+}
+
+// Reply-mode bundles (no Inspection) render the original shape — no
+// stray Inspection / Screenshot / Limitations lines.
+func TestRenderMarkdownReplyModeOmitsInspectionHeader(t *testing.T) {
+	b := sampleBundle()
+	if b.Inspection != nil {
+		t.Fatal("sampleBundle should not pre-populate Inspection")
+	}
+	md := RenderMarkdown(b, "title", "/x")
+	for _, banned := range []string{"Inspection:", "Screenshot:", "Images analyzed:", "Shop type:", "Limitations:"} {
+		if strings.Contains(md, banned) {
+			t.Errorf("reply-mode rendering should omit %q\n--- output ---\n%s", banned, md)
+		}
+	}
+}
+
 func TestTitleCaseLabel(t *testing.T) {
 	cases := []struct{ in, want string }{
 		// Spec-mandated display forms (SPEC_REPLY_REFINEMENT.md "Output rendering").
 		{"best", "Best"},
 		{"short", "Short"},
-		{"thread-aware", "Thread-Aware"},   // hyphen retained — compound modifier
-		{"personal-story", "Personal Story"}, // space — noun phrase
-		{"question-first", "Question First"}, // space — noun phrase
+		{"thread-aware", "Thread-Aware"},          // hyphen retained — compound modifier
+		{"personal-story", "Personal Story"},      // space — noun phrase
+		{"question-first", "Question First"},      // space — noun phrase
 		{"detailed", "Detailed"},
+		{"structured-review", "Structured-Review"}, // hyphen retained — compound modifier (review-mode variant)
 		// Unknown labels fall back to kebab→title-case-with-hyphens so future
 		// variant names render reasonably without a code change.
 		{"long-multi-part", "Long-Multi-Part"},

--- a/reply/review.go
+++ b/reply/review.go
@@ -70,10 +70,18 @@ func BuildReviewNotes(ctx context.Context, p llm.Provider, model string, inspect
 // — comments are NOT included in review-mode prompts because the user
 // isn't replying to the conversation, they're reviewing the OP's
 // resource.
+//
+// VisualNotes is populated when review mode ran the visual analyzer
+// (FIRECRAWL_API_KEY + vision-capable model). It carries screenshot/
+// product-image observations that the drafter prompt cites alongside
+// the text-derived Notes. May be nil for threads where visual analysis
+// genuinely produced nothing (rare; review mode requires a screenshot
+// per SPEC_REVIEW_VISUAL_FIRECRAWL.md).
 type ReviewDraftInput struct {
 	Thread        *types.Thread
 	Mode          *types.ReplyModeResult
 	Notes         *types.ReviewNotes
+	VisualNotes   *types.VisualReviewNotes
 	Contexts      []types.LoadedReplyContext
 	AuthorContext string
 }
@@ -157,6 +165,7 @@ func renderReviewPrompt(input *ReviewDraftInput) (string, error) {
 		Weaknesses    []string
 		Suggestions   []string
 		OpenQuestions []string
+		VisualNotes   *types.VisualReviewNotes
 		AuthorContext string
 		Contexts      []types.LoadedReplyContext
 	}{
@@ -168,6 +177,7 @@ func renderReviewPrompt(input *ReviewDraftInput) (string, error) {
 		Weaknesses:    input.Notes.Weaknesses,
 		Suggestions:   input.Notes.Suggestions,
 		OpenQuestions: input.Notes.OpenQuestions,
+		VisualNotes:   input.VisualNotes,
 		AuthorContext: input.AuthorContext,
 		Contexts:      input.Contexts,
 	})

--- a/reply/review_test.go
+++ b/reply/review_test.go
@@ -183,12 +183,69 @@ func TestRenderReviewPromptCitesNotesAndOmitsEmpty(t *testing.T) {
 		"Five years at Cloudflare",
 		"# Context (project material",
 		"kova body",
-		"Do not name or pitch the project",
+		"name or pitch the project", // bold markup may surround "not"; assert the substring that survives either form
 	}
 	for _, s := range checks {
 		if !strings.Contains(prompt, s) {
 			t.Errorf("review prompt missing %q\n--- prompt ---\n%s", s, prompt)
 		}
+	}
+}
+
+// VisualNotes propagation: when ReviewDraftInput.VisualNotes is set,
+// the review prompt MUST include the visual section so the drafter can
+// cite specific visual observations. When VisualNotes is nil, the
+// section MUST be omitted (no "Visual review notes" header) so the
+// drafter doesn't hallucinate visual feedback for a thread that didn't
+// have it.
+func TestRenderReviewPromptIncludesVisualNotes(t *testing.T) {
+	in := sampleReviewInput()
+	in.VisualNotes = &types.VisualReviewNotes{
+		ShopType: "handmade",
+		Summary:  "warm one-person handmade studio with weak product proof",
+		Observations: []types.VisualObservation{
+			{
+				Area:           "product_images",
+				Finding:        "no in-hand or scale shot in the first 3 images",
+				Evidence:       "all top-down crops",
+				Severity:       "high",
+				Recommendation: "add a hand-held photo to slot 1 or 2",
+			},
+		},
+		KovaSignals: []string{"texture invisible at the photo crops shown"},
+	}
+
+	prompt, err := RenderReviewPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := []string{
+		"# Visual review notes",
+		"ShopType: handmade",
+		"warm one-person handmade studio",
+		"product_images",
+		"no in-hand or scale shot",
+		"## Kova signals",
+		"texture invisible at the photo crops",
+		"do not recommend \"show your maker process\"", // gating rule appears in the prompt
+	}
+	for _, s := range checks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+}
+
+func TestRenderReviewPromptOmitsVisualSectionWhenNil(t *testing.T) {
+	in := sampleReviewInput()
+	in.VisualNotes = nil
+
+	prompt, err := RenderReviewPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(prompt, "# Visual review notes") {
+		t.Error("Visual review notes section should be omitted when VisualNotes is nil")
 	}
 }
 

--- a/reply/visual.go
+++ b/reply/visual.go
@@ -1,0 +1,141 @@
+package reply
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/prompts"
+)
+
+var reviewVisualTmpl = template.Must(template.ParseFS(prompts.FS, "review_visual.tmpl"))
+
+// DefaultVisualMaxTokens — the visual analyzer returns structured JSON
+// with bounded fields; 4096 is generous and accommodates reasoning
+// models that consume internal tokens.
+const DefaultVisualMaxTokens = 4096
+
+// VisualInput is what AnalyzeVisual needs. Inspection provides the
+// captured artifacts (screenshot path, image URLs, title, headings) and
+// Contexts seed the Kova lens. ScreenshotPath MUST point at a local
+// file — the analyzer reads + base64-encodes it so a re-run after the
+// signed Firecrawl URL expires still works.
+type VisualInput struct {
+	Inspection *types.Inspection
+	Contexts   []types.LoadedReplyContext
+	// ImageURLs are the specific product/page image references to attach
+	// (already filtered to exclude logos/icons/payment badges by
+	// SelectImagesForAnalysis). Pass nil for screenshot-only analysis.
+	ImageURLs []string
+}
+
+// AnalyzeVisual runs the visual review prompt against the screenshot and
+// optional product images. The provider must support image inputs —
+// callers should gate with llm.SupportsVision(provider, model) and fail
+// fast at the CLI layer rather than trip a provider-level error here.
+func AnalyzeVisual(ctx context.Context, p llm.Provider, model string, input *VisualInput, maxTokens int) (*types.VisualReviewNotes, error) {
+	if input == nil || input.Inspection == nil {
+		return nil, fmt.Errorf("visual analyzer: nil input or inspection")
+	}
+	insp := input.Inspection
+	if insp.ScreenshotPath == "" {
+		return nil, fmt.Errorf("visual analyzer: ScreenshotPath required (review-mode invariant)")
+	}
+	if maxTokens <= 0 {
+		maxTokens = DefaultVisualMaxTokens
+	}
+
+	prompt, err := renderVisualPrompt(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the image inputs: screenshot first (always), then any
+	// selected product images. Screenshot uses local Path so the request
+	// is self-contained; product images use remote URLs (v1 doesn't
+	// download them per spec).
+	images := []llm.ImageInput{{Path: insp.ScreenshotPath}}
+	for _, u := range input.ImageURLs {
+		images = append(images, llm.ImageInput{URL: u})
+	}
+
+	resp, err := p.Complete(ctx, llm.Request{
+		Model:     model,
+		MaxTokens: maxTokens,
+		JSONMode:  true,
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: prompt}},
+		Images:    images,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("visual analyzer: %w", err)
+	}
+
+	var raw struct {
+		ShopType     string                     `json:"shop_type"`
+		Summary      string                     `json:"summary"`
+		Observations []types.VisualObservation  `json:"observations"`
+		KovaSignals  []string                   `json:"kova_signals"`
+		Questions    []string                   `json:"questions"`
+		Limitations  []string                   `json:"limitations"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &raw); err != nil {
+		return nil, fmt.Errorf("visual analyzer: parse json: %w (model returned: %q)", err, truncate(resp.Content, 200))
+	}
+	if raw.ShopType == "" {
+		// The classification gate matters for the KovaSignals filter —
+		// missing shop_type means we can't trust the kova_signals
+		// payload. Fail loud.
+		return nil, fmt.Errorf("visual analyzer: response missing shop_type (required for KovaSignals gating)")
+	}
+	// Belt-and-suspenders: enforce the KovaSignals gate on this side too,
+	// in case the model violates the prompt rule. handmade and boutique
+	// are the only ShopTypes where kova_signals are valid.
+	if raw.ShopType != "handmade" && raw.ShopType != "boutique" {
+		raw.KovaSignals = nil
+	}
+
+	return &types.VisualReviewNotes{
+		TargetURL:    insp.URL,
+		ShopType:     raw.ShopType,
+		Summary:      raw.Summary,
+		Observations: raw.Observations,
+		KovaSignals:  raw.KovaSignals,
+		Questions:    raw.Questions,
+		Limitations:  raw.Limitations,
+		Generated:    time.Now().UTC(),
+	}, nil
+}
+
+// RenderVisualPrompt is exported for inspection / dry-run use.
+func RenderVisualPrompt(input *VisualInput) (string, error) {
+	return renderVisualPrompt(input)
+}
+
+func renderVisualPrompt(input *VisualInput) (string, error) {
+	var buf bytes.Buffer
+	insp := input.Inspection
+	err := reviewVisualTmpl.Execute(&buf, struct {
+		TargetURL       string
+		Title           string
+		MetaDescription string
+		Headings        []types.Heading
+		ImageURLs       []string
+		Contexts        []types.LoadedReplyContext
+	}{
+		TargetURL:       insp.URL,
+		Title:           insp.Title,
+		MetaDescription: insp.MetaDescription,
+		Headings:        insp.Headings,
+		ImageURLs:       input.ImageURLs,
+		Contexts:        input.Contexts,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render visual prompt: %w", err)
+	}
+	return buf.String(), nil
+}

--- a/reply/visual_test.go
+++ b/reply/visual_test.go
@@ -1,0 +1,227 @@
+package reply
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/types"
+)
+
+// fakeProvider is shared with drafter_test.go via package compilation.
+// Reuse here for symmetry. If the shared fake ever moves, this comment
+// catches the dependency.
+
+func sampleVisualInput(t *testing.T) *VisualInput {
+	t.Helper()
+	tmp := t.TempDir()
+	shotPath := filepath.Join(tmp, "shot.png")
+	if err := os.WriteFile(shotPath, []byte("fake-png-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return &VisualInput{
+		Inspection: &types.Inspection{
+			URL:             "https://shop.example/",
+			Title:           "Handmade Ceramic Bowls",
+			MetaDescription: "Wheel-thrown ceramics from a one-person studio.",
+			ScreenshotPath:  shotPath,
+			Headings: []types.Heading{
+				{Level: 1, Text: "Welcome to the studio"},
+				{Level: 2, Text: "Latest pieces"},
+			},
+		},
+		ImageURLs: []string{
+			"https://shop.example/img/bowl-1.jpg",
+			"https://shop.example/img/bowl-2.jpg",
+		},
+	}
+}
+
+const handmadeVisualResp = `{
+  "shop_type": "handmade",
+  "summary": "Solo ceramicist; warm but generic photography.",
+  "observations": [
+    {"area":"product_images","finding":"hero shot lacks scale reference","evidence":"first three images are top-down crops with no hand or object for scale","severity":"medium","recommendation":"add a hand-held shot to one of the first 2 photos"}
+  ],
+  "kova_signals": ["no in-hand or scale shot in the first 2 product images","texture is invisible at the photo crops shown"],
+  "questions": ["are these all single pieces or a series?"],
+  "limitations": ["screenshot only covers homepage; no product detail page inspected"]
+}`
+
+func TestAnalyzeVisualHappyPath(t *testing.T) {
+	p := &fakeProvider{name: "fake", response: handmadeVisualResp}
+	notes, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notes.ShopType != "handmade" {
+		t.Errorf("ShopType = %q", notes.ShopType)
+	}
+	if len(notes.KovaSignals) != 2 {
+		t.Errorf("expected 2 kova signals (handmade gates allow them), got %d", len(notes.KovaSignals))
+	}
+	if len(notes.Observations) != 1 {
+		t.Errorf("Observations = %d", len(notes.Observations))
+	}
+	if !p.gotReq.JSONMode {
+		t.Error("visual analyzer should set JSONMode")
+	}
+	// Screenshot must have been attached as a local Path image.
+	if len(p.gotReq.Images) < 1 {
+		t.Fatal("expected at least one image in the request")
+	}
+	if p.gotReq.Images[0].Path == "" {
+		t.Error("first image (screenshot) should be passed by Path, not URL")
+	}
+	// Product images attach as URL refs.
+	urlCount := 0
+	for _, img := range p.gotReq.Images[1:] {
+		if img.URL != "" && img.Path == "" {
+			urlCount++
+		}
+	}
+	if urlCount != 2 {
+		t.Errorf("expected 2 URL-referenced product images, got %d", urlCount)
+	}
+}
+
+// KovaSignals must be filtered out when the analyzer returns a shop_type
+// outside {handmade, boutique}, regardless of what the model says — the
+// Go side is belt-and-suspenders against prompt-rule violations. The
+// PND Industrial Suppliers regression target.
+func TestAnalyzeVisualGatesKovaSignalsForB2B(t *testing.T) {
+	const b2bResp = `{
+  "shop_type": "b2b_industrial",
+  "summary": "industrial supplier, quote-driven",
+  "observations": [],
+  "kova_signals": ["model violated the prompt by populating this anyway"],
+  "questions": [],
+  "limitations": []
+}`
+	p := &fakeProvider{name: "fake", response: b2bResp}
+	notes, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notes.ShopType != "b2b_industrial" {
+		t.Errorf("ShopType = %q", notes.ShopType)
+	}
+	if len(notes.KovaSignals) != 0 {
+		t.Errorf("KovaSignals must be empty for b2b_industrial (regression target), got %v", notes.KovaSignals)
+	}
+}
+
+// Same for SaaS, dropship, services, portfolio, unclear — none should
+// have KovaSignals leak through.
+func TestAnalyzeVisualGatesKovaSignalsForAllNonHandmadeTypes(t *testing.T) {
+	for _, st := range []string{"dropship", "saas", "services", "portfolio", "unclear"} {
+		t.Run(st, func(t *testing.T) {
+			resp := `{"shop_type":"` + st + `","summary":"x","observations":[],"kova_signals":["leak"],"questions":[],"limitations":[]}`
+			p := &fakeProvider{name: "fake", response: resp}
+			notes, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(notes.KovaSignals) != 0 {
+				t.Errorf("ShopType=%s: KovaSignals must be empty, got %v", st, notes.KovaSignals)
+			}
+		})
+	}
+}
+
+// Boutique counts as Kova-adjacent — KovaSignals should pass through.
+func TestAnalyzeVisualKeepsKovaSignalsForBoutique(t *testing.T) {
+	const resp = `{"shop_type":"boutique","summary":"x","observations":[],"kova_signals":["keep this"],"questions":[],"limitations":[]}`
+	p := &fakeProvider{name: "fake", response: resp}
+	notes, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes.KovaSignals) != 1 {
+		t.Errorf("boutique should keep kova_signals, got %v", notes.KovaSignals)
+	}
+}
+
+func TestAnalyzeVisualMissingShopTypeErrors(t *testing.T) {
+	const resp = `{"shop_type":"","summary":"x","observations":[]}`
+	p := &fakeProvider{name: "fake", response: resp}
+	_, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err == nil || !strings.Contains(err.Error(), "shop_type") {
+		t.Errorf("expected missing-shop_type error, got %v", err)
+	}
+}
+
+func TestAnalyzeVisualMissingScreenshotErrors(t *testing.T) {
+	input := sampleVisualInput(t)
+	input.Inspection.ScreenshotPath = ""
+	p := &fakeProvider{name: "fake", response: handmadeVisualResp}
+	_, err := AnalyzeVisual(context.Background(), p, "gpt-4o", input, 0)
+	if err == nil || !strings.Contains(err.Error(), "ScreenshotPath required") {
+		t.Errorf("expected screenshot-required error, got %v", err)
+	}
+}
+
+func TestAnalyzeVisualBadJSONErrors(t *testing.T) {
+	p := &fakeProvider{name: "fake", response: "not json"}
+	_, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err == nil || !strings.Contains(err.Error(), "parse json") {
+		t.Errorf("expected parse error, got %v", err)
+	}
+}
+
+func TestAnalyzeVisualProviderErrorPropagated(t *testing.T) {
+	p := &fakeProvider{name: "fake", err: errors.New("rate limited")}
+	_, err := AnalyzeVisual(context.Background(), p, "gpt-4o", sampleVisualInput(t), 0)
+	if err == nil || !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected provider error, got %v", err)
+	}
+}
+
+func TestAnalyzeVisualNilInputErrors(t *testing.T) {
+	p := &fakeProvider{name: "fake", response: handmadeVisualResp}
+	_, err := AnalyzeVisual(context.Background(), p, "gpt-4o", nil, 0)
+	if err == nil {
+		t.Error("nil input should error")
+	}
+}
+
+// Prompt rendering: make sure the visual prompt includes target URL,
+// title, headings, and context references, and lists the shop_type
+// classes. Done as a smoke test, not a per-line lock.
+func TestRenderVisualPromptIncludesKeyElements(t *testing.T) {
+	input := sampleVisualInput(t)
+	input.Contexts = []types.LoadedReplyContext{
+		{ID: "kova", Source: "bank", Body: "kova body"},
+	}
+	prompt, err := RenderVisualPrompt(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := []string{
+		"https://shop.example/",
+		"Handmade Ceramic Bowls",
+		"(h1) Welcome to the studio",
+		"From bank (kova)",
+		"kova body",
+		"shop_type",
+		"handmade",
+		"b2b_industrial",
+		"kova_signals",
+		"do NOT pitch",     // anti-pitch rule
+		"Do NOT name the project", // explicit Kova rename ban
+	}
+	for _, s := range checks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+}
+
+// pin llm import to ensure visibility — the visual analyzer is the
+// first non-test code in this package that uses llm.Request.Images, so
+// catching shape mismatches here is useful.
+var _ = llm.Request{}


### PR DESCRIPTION
## Summary

Implements `SPEC_REVIEW_VISUAL_FIRECRAWL.md` (committed in this PR as the design doc).

The previous review pipeline wired Firecrawl to *disk* — the screenshot was downloaded, the path stored in `inspection.json`, then nothing read it. Review notes ran on text-only markdown extraction. This PR closes the loop:

- **Firecrawl is required** for review mode. No HTML fallback. Missing `FIRECRAWL_API_KEY` or missing screenshot fails before drafting, with the error pointing at `--mode=reply` as the recoverable escape hatch.
- **Visual analyzer** consumes the screenshot + up to 8 filtered product images via a vision-capable OpenAI model. Returns structured `VisualReviewNotes` with `ShopType` + observations + Kova signals.
- **Kova-fit classification** gates the `KovaSignals` slot. Only `handmade` / `boutique` pages get Kova-thesis advice. B2B / SaaS / dropship / services / portfolio / unclear pages get visual feedback without "show your maker process" — the PND Industrial Suppliers regression target.
- **Merged review notes**: text notes (existing) and visual notes (new) both flow into the review drafter. The drafter prompt explicitly forbids visual feedback without supporting visual notes.
- **New review variants**: best / short / structured-review / question-first — replacing the old length-based detailed variant for review mode.
- **Inspection-depth header** on the rendered output: `Inspection: Firecrawl visual / Screenshot: saved / Images analyzed: 4 / Shop type: handmade / Limitations: ...`. Populated only in review mode.
- **`--mode=reply` override** in v1: skips the OP-only classifier and runs the normal reply pipeline. Use when the classifier mistakes a discussion thread for a review request, or when `FIRECRAWL_API_KEY` isn't set and you want a normal reply anyway.

## What's deferred to v1.5 (per spec)

- Anthropic vision (provider returns a clear error today; routes vision tasks to OpenAI)
- Progress UX (`[1/8] fetching...` stderr lines)
- Local image persistence (Firecrawl image URLs pass through as remote `image_url` to OpenAI; the screenshot IS persisted and embedded base64)

## Test plan

- [x] `go test ./...` green
- [x] `llm.Request.Images` shape: data URL with correct MIME from Path; URL passthrough; plain-text shape regression check; missing-user-message error; Anthropic-refuses-images
- [x] `InspectReviewTarget`: missing key / missing screenshot / happy path
- [x] Image filtering: rejects logos / favicons / payment badges / tracking pixels / data URIs / relative paths; caps at 8; excludes screenshot URL
- [x] `AnalyzeVisual`: happy path; KovaSignals gated for b2b_industrial / dropship / saas / services / portfolio / unclear; KovaSignals kept for handmade and boutique; missing-shop_type errors; missing-screenshot errors
- [x] Review prompt: VisualNotes section appears when set, omitted when nil
- [x] Renderer: review-mode inspection header; reply-mode shape unchanged; `Structured-Review` title-case
- [ ] Manual: rerun the PND Industrial Suppliers thread (or any B2B review thread) and verify (a) Firecrawl-required succeeds with valid key, (b) ShopType is correctly classified non-handmade, (c) draft does NOT recommend "show your process", (d) `Inspection: Firecrawl visual` appears in the output header
- [ ] Manual: rerun the original Shopify burnout thread with `--mode=reply` and verify it skips classification (no Firecrawl call) and produces a normal reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)