### PR TITLE
reply: angle-based variants v2 — postable comments, no reasoning

### DIFF
--- a/SPEC_REPLY_REFINEMENT.md
+++ b/SPEC_REPLY_REFINEMENT.md
@@ -20,7 +20,7 @@ Observed example: a Shopify thread where the OP is a solo store owner burned out
 - track funnel metrics
 - hire a part-time editor
 
-Most of that advice is plausible, but the result reads like a generic marketing consultant checklist. It repeats what the thread already contains, especially "pick one platform" and "repurpose content." It also produced a `detailed` variant that was longer rather than more differentiated.
+Most of that advice is plausible, but the result reads like a generic marketing consultant checklist. It repeats what the thread already contains, especially "pick one platform" and "repurpose content." It also produced too many bullets and a `detailed` variant that was longer rather than more differentiated.
 
 The strongest context-specific insight from Kova was weaker than it should have been:
 
@@ -66,7 +66,33 @@ No `draft comment` phrase should appear in user-facing product copy.
 
 ## Core design shift
 
-Replace the default `detailed` variant with angle-based variants.
+Replace the default `detailed` variant with a compact postable format:
+
+```text
+Best Pick
+
+<ready-to-post comment>
+
+Alternative Picks
+
+Shorter
+
+<shorter ready-to-post comment>
+
+Counterpoint
+
+<contrarian/minority/thread-aware angle, if useful>
+
+Warmer / Personal
+
+<personal-context version, only if relevant>
+
+Question
+
+<question-first version, only if needed>
+```
+
+No reasoning or editing notes should render by default. The output should feel like a set of comments the user can quickly choose from and edit, not a report about the comments. Reasoning is still recorded in `drafts.json` for audit/debug.
 
 ### Old variant model
 
@@ -82,19 +108,18 @@ The problem: `detailed` is a length variant. It often creates a longer checklist
 ### New variant model
 
 ```text
-best
-short
-thread-aware
-personal-story, if supported
-question-first, if needed
-detailed, only if the OP explicitly asks for a plan, diagnosis, technical steps, or multi-part answer
+best               -> rendered as "Best Pick"
+shorter            -> rendered as "Shorter"
+counterpoint       -> rendered as "Counterpoint"
+warmer-personal    -> rendered as "Warmer / Personal", only when supported
+question           -> rendered as "Question", only when needed
 ```
 
-The model does not have to output every variant. Three strong variants are better than four padded ones.
+The model does not have to output every variant. Two to four strong drafts are better than a full menu. `Detailed` is removed entirely — there is no `detailed` slot and no `Technical Steps` slot in v1. Technical/troubleshooting threads can make `best` longer when concrete detail is necessary.
 
 ## Variant definitions
 
-### `best`
+### `best` / `Best Pick`
 
 The recommended reply. It should be the comment the user is most likely to post.
 
@@ -104,27 +129,30 @@ Properties:
 - specific
 - directly useful to the OP
 - grounded in OP + top comments + supplied context
-- usually 120-220 words for business/community subs
+- usually 120-180 words for business/community subs
 - can be shorter if the answer is obvious
+- defaults to short paragraphs, not bullets
+- can be a counterpoint-style reply if that is the strongest version
 
 For the Shopify burnout example, `best` should focus on one sharp frame:
 
 > Build a repeatable proof-capture loop, not a bigger content calendar.
 
-### `short`
+### `shorter` / `Shorter`
 
 The shortest viable reply.
 
 Properties:
 
-- one paragraph or a few bullets
+- usually one paragraph
 - 40-90 words in most non-technical threads
 - no setup, no throat-clearing
 - preserves the core advice from `best`
+- no bullet list unless one or two bullets materially improve readability
 
-### `thread-aware`
+### `counterpoint` / `Counterpoint`
 
-Reacts to something important already present in comments.
+Offers a contrarian, minority, or thread-aware angle when useful.
 
 This is the replacement for most `detailed` output in Reddit-style business/trade/community subs.
 
@@ -133,19 +161,20 @@ Purpose:
 - add a missing nuance
 - resolve tension between top comments
 - push back on advice that is directionally right but incomplete
+- represent a useful minority POV
 - avoid repeating the same consensus comment
 
-For the Shopify burnout example, the useful counter-comment was that batching can fail because it still requires creative energy on demand. A good `thread-aware` variant should engage that:
+**Distinct-frame rule.** If `best` is itself counterpoint-flavored, `counterpoint` MUST take a different contrarian/minority angle. If no different angle exists, skip the slot — do not duplicate the `best` frame.
+
+For the Shopify burnout example, the useful counter-comment was that batching can fail because it still requires creative energy on demand. A good `counterpoint` variant should engage that:
 
 ```text
-I agree with the "pick one platform" advice, but I would be careful with generic batching. Batching only works if the task is capture, not creativity.
+I would be careful with the idea that the answer is just "be more consistent."
 
-Instead of sitting down to invent content, keep a repeatable proof-shot list: product in hand for scale, close-up texture, quick use/demo, packing an order, and one process clip. Film those whenever you already have the product out. Then on busy weeks you are assembling from a small clip library, not trying to be creative from zero.
-
-That is the difference between a content calendar and content inventory.
+Consistency matters, but if the system depends on you constantly inventing content, it will break every time the shop gets busy. I would optimize for reusable proof instead: film simple clips while the work is already happening — scale, texture, demo, packing, process — and build a small library you can pull from.
 ```
 
-### `personal-story`
+### `warmer-personal` / `Warmer / Personal`
 
 Uses a personal anecdote from `author_context` or supplied contexts only when it clearly fits.
 
@@ -174,7 +203,7 @@ I have seen this up close with a one-person handmade shop: the useful content us
 
 Use "my mom" only if the context explicitly allows personal/family framing or the user requests a personal version.
 
-### `question-first`
+### `question` / `Question`
 
 Use only when more information is required before useful advice is possible.
 
@@ -189,20 +218,11 @@ Bad uses:
 - OP is venting and already has enough context for a useful lightweight answer
 - the question is a disguised invitation to write a mini-consulting plan
 
-### `detailed`
+### No `detailed` by default
 
-Not a default variant.
+Do not generate a `detailed` slot. The variant is removed from the prompt's variant list entirely.
 
-Use only when the OP explicitly asks for:
-
-- step-by-step plan
-- technical troubleshooting
-- implementation details
-- multi-part critique
-- code/config/database/API diagnosis
-- structured store review
-
-If produced, `detailed` must still be concise for the subreddit. It should not be a 10-step playbook unless the OP asked for one.
+For technical/troubleshooting threads, allow more detail inside `Best Pick` when needed. If a separate technical variant is needed in the future, a specific label such as `Technical Steps` can be added then — not a generic `Detailed`.
 
 ## Subreddit-aware behavior
 
@@ -210,13 +230,11 @@ The prompt should infer thread/subreddit style and choose variants accordingly.
 
 ### Signals available to the drafter
 
-The drafter prompt should classify thread style from three signals on the OP, all of which are already fetched and stored in `thread.json`:
+The drafter prompt should classify thread style from three signals on the OP, all already fetched and stored in `thread.json`:
 
-- **Subreddit name** — already passed through to the drafter prompt as `Subreddit: r/{{.Subreddit}}`.
-- **Flair** — currently fetched and stored in `thread.json` (e.g. `"flair": "Marketing"`) and passed to the *mode classifier*, but **not threaded into the drafter prompt today**. This needs fixing as part of this spec: the drafter often has to disambiguate similar subs (`r/Entrepreneur` with flair `Technical Question` vs `Marketing` vs `Personal`) and flair is the fastest signal for that.
+- **Subreddit name** — passed through to the drafter prompt as `Subreddit: r/{{.Subreddit}}`.
+- **Flair** — already threaded through to the drafter (PR #19) and rendered as `Flair: {{.Flair}}` when non-empty.
 - **OP body** — already in the prompt.
-
-Flair must be added to the drafter template inputs so the model can use it for both category inference and tone calibration. When flair is empty or absent, the drafter falls back to subreddit + body.
 
 ### Business, trade, marketing, ecommerce, founder, community subs
 
@@ -231,10 +249,10 @@ Examples:
 Default behavior:
 
 - produce `best`
-- produce `short`
-- prefer `thread-aware`
-- produce `personal-story` only if supported and relevant
-- skip `detailed` unless OP explicitly asks for a plan
+- produce `shorter`
+- prefer `counterpoint` when top comments reveal a repeated pattern, missing nuance, or useful disagreement
+- produce `warmer-personal` only if supported and relevant
+- skip generic `detailed`
 
 Target tone:
 
@@ -255,10 +273,10 @@ Examples:
 
 Default behavior:
 
-- `detailed` may be useful
 - answer with concrete steps, tradeoffs, commands, configs, or diagnostics
-- `thread-aware` is still useful when top comments reveal a misconception
-- avoid personal-story unless credibility matters and is concise
+- allow `Best Pick` to be longer when concrete detail is necessary
+- `counterpoint` is still useful when top comments reveal a misconception
+- avoid `warmer-personal` unless credibility matters and is concise
 
 ### Review/feedback posts
 
@@ -271,7 +289,16 @@ Default behavior:
 - no generic reply if inspection fails
 - do not trigger review mode from comments
 
-This spec does not change review-mode implementation.
+This spec does not change review-mode inspection. **It does** align review-mode variant labels for consistency: `short` → `shorter`, `question-first` → `question`. Review mode keeps its review-specific slots:
+
+```text
+best
+shorter
+structured-review
+question
+```
+
+No `counterpoint` or `warmer-personal` for review mode by default.
 
 ## Context semantics
 
@@ -311,13 +338,6 @@ Use:
 
 If `author_context` and `--context` disagree about the user's current project, `--context` wins for subject matter and `author_context` remains voice-only.
 
-Example:
-
-- config says Streambed
-- command passes `--context=kova`
-
-The reply must not mention Streambed unless the Reddit thread is about Streambed-like work.
-
 ### Mom story rule
 
 The mom story is valuable, but should be optional.
@@ -345,8 +365,6 @@ Avoid it when:
 - the reply already works without personal framing
 
 ## Prompt rules
-
-The reply prompt should add or strengthen these rules.
 
 ### Use context as a lens
 
@@ -385,6 +403,12 @@ For the Shopify example:
 - useful counterpoint: batching still requires creative energy
 - sharper reply: capture inventory, not content calendar
 
+### Counterpoint slot rule
+
+If top comments contain a repeated pattern, missing nuance, or contrarian POV worth surfacing, generate `counterpoint` to engage it; otherwise skip `counterpoint`.
+
+If `best` is itself counterpoint-flavored, `counterpoint` MUST take a different contrarian/minority angle. No duplicate frame.
+
 ### Ban unsupported first-person claims
 
 Never write:
@@ -405,51 +429,68 @@ I have seen this up close with a one-person handmade shop...
 
 only if the context includes that story and the thread fits.
 
+### Bullet rule
+
+Default to short paragraphs, not bullets. Use bullets only when they materially improve readability — typically when listing 3+ short, parallel items the reader would scan rather than read.
+
+Single-bullet "lists" are anti-patterns. Bulleted operating-manual-style replies are anti-patterns.
+
 ### Word-count guidance
 
 Default caps for non-technical reply mode:
 
-- `best`: 120-220 words
-- `short`: 40-90 words
-- `thread-aware`: 90-180 words
-- `personal-story`: 90-180 words
-- `question-first`: 30-80 words
-- `detailed`: skip unless needed; if included, 250-400 words max unless OP explicitly asked for more
+- `best`: 120-180 words
+- `shorter`: 40-90 words
+- `counterpoint`: 80-160 words
+- `warmer-personal`: 70-140 words
+- `question`: 30-80 words
 
 Technical/troubleshooting threads may exceed these caps when concrete detail is necessary.
 
 ## Output rendering
 
-Current renderer sections:
+Target rendered markdown:
 
 ```text
-Best Pick
-Alternatives
+# Reply drafts for r/<subreddit>
+
+Thread: <thread title>
+Mode: <reply|review>
+Session: <session path>
+
+## Best Pick
+
+<ready-to-post comment>
+
+## Alternative Picks
+
+### Shorter
+
+<shorter ready-to-post comment>
+
+### Counterpoint
+
+<contrarian/minority/thread-aware angle, if useful>
+
+### Warmer / Personal
+
+<personal-context version, only if relevant>
+
+### Question
+
+<question-first version, only if needed>
 ```
 
-This can stay, but labels should become meaningful:
+Rendering rules:
 
-- `Short`
-- `Thread-Aware`
-- `Personal Story`
-- `Question First`
-- `Detailed`
-
-`Detailed` should not appear unless generated.
-
-Alternative reasoning should describe the angle, not the length:
-
-Good:
-
-```text
-Engages the batching pushback in the comments and reframes the work as capture inventory.
-```
-
-Bad:
-
-```text
-Provides a step-by-step operating model with concrete tools.
-```
+- No `Why this works`.
+- No reasoning under variants in markdown. Reasoning is preserved in `drafts.json` for audit only.
+- No `Editing Notes`.
+- No `Detailed` by default.
+- Use `## Alternative Picks`, not `## Alternatives`.
+- Render only variants that exist.
+- Keep default output to 2-4 drafts total.
+- Use bullets only when they make the comment easier to read; default to short paragraphs.
 
 ## Ideal output for the Shopify example
 
@@ -462,35 +503,33 @@ tider reply --url=<shopify marketing burnout thread> --context=kova --context=pe
 The recommended `best` reply should resemble:
 
 ```text
-I would make the content system smaller than "be active on every platform."
+I agree with the "pick one platform" advice, but I would separate capture from creativity.
 
-For a solo store, the hard part is not just scheduling posts. It is having repeatable raw material that proves the product is real and worth buying. I would pick one source channel, then build a simple shot list you can reuse every time: product in hand for scale, texture close-up, quick use/demo, packing an order, and one process/maker clip.
+Batching content can still burn you out if it means sitting down and inventing ideas on demand. What works better is building a small footage library while you are already doing normal shop work: product in hand for scale, texture close-up, quick demo, packing an order, process shot, maybe a common question answered with text overlay.
 
-That gives you enough footage to repurpose into reels, pins, product-page clips, and posts without inventing new ideas every day.
+Then on busy weeks, you are assembling from real clips instead of starting from zero.
 
-Also, do not over-polish it. If the product is clear, garage/process footage can work because buyers are often looking for trust: is this real, does it look like the photos, who is behind it?
-
-So I would optimize for a repeatable proof-capture loop, not a bigger content calendar.
+Also, do not over-worry about the garage look. If the product is clear and the footage feels real, that can build more trust than a polished studio-style post.
 ```
 
-The `thread-aware` variant should resemble:
+The `shorter` variant should resemble:
 
 ```text
-I agree with the "pick one platform" advice, but I would be careful with generic batching. Batching only works if the task is capture, not creativity.
-
-Instead of sitting down to invent content, keep a repeatable proof-shot list: product in hand for scale, close-up texture, quick use/demo, packing an order, and one process clip. Film those whenever you already have the product out. Then on busy weeks you are assembling from a small clip library, not trying to be creative from zero.
-
-That is the difference between a content calendar and content inventory.
+Do not try to become a full-time creator. Build a small footage library while doing normal shop work: scale, texture, demo, packing, process. Then reuse those clips on one main channel and repost elsewhere. The goal is to stop inventing content from zero every week.
 ```
 
-The `personal-story` variant, if produced, should resemble:
+The `counterpoint` variant should resemble:
 
 ```text
-I have seen this up close with a one-person handmade shop: the content burden gets heavy fast, but the useful clips usually were not polished. They were simple proof that the product was real: product in hand for scale, texture, packing, and process.
+I would be careful with the idea that the answer is just "be more consistent."
 
-I would not try to run four separate content calendars. I would build one small capture loop: film the same five proof shots whenever the product is already out, then reuse those clips across whichever channel is actually bringing buyers.
+Consistency matters, but if the system depends on you constantly inventing content, it will break every time the shop gets busy. I would optimize for reusable proof instead: film simple clips while the work is already happening — scale, texture, demo, packing, process — and build a small library you can pull from.
+```
 
-That keeps the work closer to running the shop instead of becoming a full-time creator.
+The `warmer-personal` variant, if produced, should resemble:
+
+```text
+I have seen this up close with a one-person handmade shop. The useful content usually was not polished; it was simple proof that the product was real: scale, texture, packing, process. I would build around that instead of trying to run four separate content calendars.
 ```
 
 ## Implementation plan
@@ -501,50 +540,44 @@ Files:
 
 ```text
 prompts/reply.tmpl
-reply/drafter.go
-```
-
-Changes to `prompts/reply.tmpl`:
-
-- replace the variant list with the new angle-based model
-- make `detailed` conditional
-- add subreddit-aware guidance
-- reference `{{.Flair}}` alongside `{{.Subreddit}}` in the thread header (rendered conditionally so empty flair doesn't print "Flair: ")
-- add thread-aware instructions based on top comments
-- add personal-story rules
-- add stronger first-person claim ban
-- add word-count guidance
-- clarify `author_context` vs context-bank roles
-
-Changes to `reply/drafter.go`:
-
-- add `Flair string` to the anonymous struct passed to `replyTmpl.Execute` in `renderReplyPrompt`
-- populate it from `input.Thread.Flair` (the field already exists on `types.Thread`)
-
-This is the gap noted in *Signals available to the drafter*: the data is already on the type, just not threaded through to the drafter template.
-
-### 2. Update tests
-
-Files:
-
-```text
-reply/drafter_test.go
-reply/render_test.go
 ```
 
 Changes:
 
-- update happy-path fake response to include `thread-aware`
-- add prompt-render test assertions for:
-  - `thread-aware`
-  - `personal-story`
-  - `detailed` conditionality
-  - unsupported first-person claim ban
-  - context-as-lens guidance
-  - `Flair: <value>` line appears in the rendered prompt when `Thread.Flair` is non-empty, and is omitted otherwise
-- ensure renderer title-cases labels like `thread-aware` and `personal-story`
+- replace the variant list with the new angle-based model (best, shorter, counterpoint, warmer-personal, question)
+- remove the `detailed` slot entirely from the JSON output schema
+- add the bullet-soft-rule
+- add the counterpoint distinct-frame rule
+- update word-count guidance
+- preserve existing rules: first-person ban, context-as-lens, voice-only author_context, anti-tells
+- update the JSON output example with new variant IDs
 
-### 3. Update type comments
+### 2. Update review prompt for label alignment
+
+File:
+
+```text
+prompts/review.tmpl
+```
+
+Rename `short` → `shorter` and `question-first` → `question` so review-mode and reply-mode share the same labels for the analogous slots. Review mode keeps `structured-review` as its review-specific slot.
+
+### 3. Update renderer
+
+File:
+
+```text
+reply/render.go
+```
+
+- displayLabel map: add new IDs (shorter, counterpoint, warmer-personal, question) with their spec-mandated display forms
+- Section header: `## Alternatives` → `## Alternative Picks`
+- Drop the `> reasoning` blockquote on best-pick rendering
+- Drop the `*reasoning*` italic on alternative rendering
+- Keep markdown heading hierarchy (`# `, `## `, `### `)
+- Old IDs (short, thread-aware, personal-story, question-first, detailed) fall through to the kebab-fallback path; no special backward-compat handling
+
+### 4. Update type comments
 
 File:
 
@@ -552,30 +585,30 @@ File:
 internal/types/types.go
 ```
 
-Change the `ReplyDraft.Label` comment from:
+Update the `ReplyDraft.Label` comment to reflect the new common label set.
 
-```go
-// "best" | "short" | "detailed" | "question-first"
+### 5. Update tests
+
+Files:
+
+```text
+reply/drafter_test.go
+reply/render_test.go
+reply/review_test.go
 ```
 
-to:
+- drafter_test: update happy-path response to use new IDs (best, shorter, counterpoint)
+- drafter_test: prompt-render assertions for counterpoint / warmer-personal slot language, no-detailed, distinct-frame rule
+- render_test: sample bundle uses new IDs, assert `## Alternative Picks`, assert `### Shorter / Counterpoint / Warmer / Personal / Question`, assert reasoning is NOT present in markdown output
+- review_test: update happy-path response and any prompt assertions for the renamed `shorter` / `question` review variants
 
-```go
-// Common labels: "best", "short", "thread-aware", "personal-story",
-// "question-first", "detailed".
-```
-
-The data model does not need a schema change because IDs and labels are already strings.
-
-### 4. Manual verification
-
-Run:
+### 6. Manual verification
 
 ```text
 go test ./...
 ```
 
-Then re-run a known thread:
+Then re-run the Shopify burnout thread:
 
 ```text
 ./tider reply --url=https://www.reddit.com/r/shopify/comments/1sz012f/struggling_on_marketing_my_shopify_store/ --context=kova --context=personal
@@ -583,30 +616,30 @@ Then re-run a known thread:
 
 Expected:
 
-- no generic 10-step `Detailed` default
-- `Best Pick` is concise and Kova-shaped
-- `Thread-Aware` engages the batching/creative-energy counterpoint
-- `Personal Story` appears only if the model can use the one-person handmade shop context naturally
+- output sections are `## Best Pick` and `## Alternative Picks`
+- no `> reasoning` blockquote, no `*reasoning*` italic
+- no `Why this works` / `Editing Notes`
+- no `Detailed` slot
+- `Best Pick` is concise (<=180 words), Kova-shaped, postable
+- `Counterpoint` engages the batching/creative-energy counterpoint when present
+- `Warmer / Personal` appears only if the model can use the one-person handmade shop context naturally
 - no "I ran into the same wall" unless directly supported
 - no mention of Kova by name
-- no mention of Streambed
+- bullet usage limited to genuinely list-shaped material
 
 ## Acceptance criteria
 
 1. `tider reply` still returns valid JSON internally and markdown externally.
-2. Existing session artifacts continue to be written:
-   - `thread.json`
-   - `contexts.json`
-   - `mode.json`
-   - `draft-input.json`
-   - `drafts.json`
-   - `output.md`
-3. The default output for non-technical business/community threads no longer includes a long `Detailed` variant unless OP asked for a plan.
-4. At least one generated variant explicitly engages a high-signal comment or repeated thread pattern when such a pattern exists.
-5. Personal anecdotes are optional and grounded.
-6. `author_context` is treated as voice/background, not a competing project context.
-7. Context-bank project material influences advice without naming or pitching the project by default.
-8. The Shopify marketing-burnout example produces a sharper reply centered on repeatable product-proof capture.
+2. Existing session artifacts continue to be written: `thread.json`, `contexts.json`, `mode.json`, `draft-input.json`, `drafts.json`, `output.md`.
+3. The rendered markdown uses `## Best Pick` and `## Alternative Picks`.
+4. The rendered markdown does not include `> reasoning`, `*reasoning*`, `Why this works`, per-variant reasoning, or `Editing Notes`.
+5. The default output for non-technical business/community threads no longer includes a `Detailed` variant.
+6. Aside from `Shorter`, alternatives represent distinct POVs, not only longer/shorter rewrites.
+7. If top comments contain a repeated pattern, missing nuance, or contrarian POV worth surfacing, `Counterpoint` engages it; otherwise `Counterpoint` is skipped.
+8. Personal anecdotes are optional and grounded.
+9. `author_context` is treated as voice/background, not a competing project context.
+10. Context-bank project material influences advice without naming or pitching the project by default.
+11. The Shopify marketing-burnout example produces a sharper reply centered on repeatable product-proof capture.
 
 ## Future work
 
@@ -614,10 +647,11 @@ Expected:
 - Add session-based regeneration for a specific angle:
 
   ```text
-  tider reply regen --session=<path> --angle=thread-aware
+  tider reply regen --session=<path> --angle=counterpoint
   ```
 
 - Add lightweight subreddit profiles if prompt-only subreddit awareness is insufficient.
+- Add a `Technical Steps` review-mode-style slot for technical subs only if the longer-best-pick path proves insufficient.
 - Add context metadata later if prose conventions become unreliable:
 
   ```yaml

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -295,10 +295,16 @@ type LoadedReplyContext struct {
 
 // ReplyDraft is one variant produced by the reply drafter.
 //
-// Common labels: "best", "short", "thread-aware", "personal-story",
-// "question-first", "detailed". Not exhaustive — labels are free-form
-// strings on the wire so the prompt can evolve without a schema change.
-// The renderer title-cases hyphenated labels for display.
+// Common labels: "best", "shorter", "counterpoint", "warmer-personal",
+// "question". Review mode adds "structured-review". Older sessions may
+// contain legacy labels ("short", "thread-aware", "personal-story",
+// "question-first", "detailed") which the renderer still maps to
+// readable display forms.
+//
+// Labels are free-form strings on the wire so the prompt can evolve
+// without a schema change. Reasoning is preserved for audit/debug but
+// is NOT included in the rendered markdown — see SPEC_REPLY_REFINEMENT.md
+// "Output rendering".
 type ReplyDraft struct {
 	ID        string `json:"id"`
 	Label     string `json:"label"`

--- a/prompts/reply.tmpl
+++ b/prompts/reply.tmpl
@@ -51,24 +51,41 @@ Use context as a **lens, not a topic**. The thesis or worldview from this materi
 
 Classify this thread from the Subreddit name, Flair (if present), and OP's body. Use the inferred category to pick variants and tone.
 
-- **Business / trade / marketing / ecommerce / founder / community** — practical peer voice, one useful frame, fewer tools and metrics, avoid consultant voice. Variants: `best`, `short`, prefer `thread-aware`, `personal-story` if supported. Skip `detailed` unless OP explicitly asked for a plan.
-- **Technical / troubleshooting / engineering** — concrete steps, tradeoffs, code/config/diagnostics. Variants: `best`, `short`, `thread-aware` when comments reveal a misconception, `detailed` when the thread genuinely warrants depth.
-- **Creative / hobbyist / lifestyle** — warm peer voice, lightweight, often shorter. Variants: `best`, `short`; `thread-aware` if comments diverge. Skip `detailed` almost always.
+- **Business / trade / marketing / ecommerce / founder / community** — practical peer voice, one useful frame, fewer tools and metrics, avoid consultant voice.
+- **Technical / troubleshooting / engineering** — concrete steps, tradeoffs, code/config/diagnostics. `best` may be longer when the thread genuinely warrants depth.
+- **Creative / hobbyist / lifestyle** — warm peer voice, lightweight, often shorter.
 
-If the sub doesn't clearly fit, default to business/trade behavior (concise, single frame, skip `detailed`).
+If the sub doesn't clearly fit, default to business/trade behavior (concise, single frame).
 
 # Task — variants
 
-Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if a different angle better fits the thread (e.g. `question-first` when OP omitted critical detail).
+Draft the variants below. **Two to four strong drafts beat a full menu.** Set `pick_id` to your recommended choice — usually `best`, but pick another if a different angle better fits the thread (e.g. `question` when OP omitted critical detail).
 
-- **`best`** — your recommended reply: one sharp frame, specific, peer voice. Grounded in OP + top comments + supplied context. Usually 120-220 words for non-technical subs; can be shorter when the answer is obvious.
-- **`short`** — the shortest viable reply (40-90 words). One paragraph or a few bullets. No setup, no throat-clearing. Skip if `best` is already short.
-- **`thread-aware`** — engages something specific in the existing comments: a missing nuance, tension between top comments, advice that's directionally right but incomplete, or a counterpoint everyone walked past. **Do not duplicate the consensus.** If the comments contain a sharp counter-argument that contradicts your `best` advice, this is the variant where you address it explicitly. Skip if comments add nothing meaningful. 90-180 words.
-- **`personal-story`** — *optional*. Generate ONLY if a supplied context body contains a first-degree personal connection (you, family, close colleague) directly matching OP's situation. The `reasoning` field must name the connection (e.g. "uses one-person handmade shop story from personal.md"). Skip otherwise — do not invent. 90-180 words.
-- **`question-first`** — *optional*. Generate only when OP genuinely needs to give more info before any answer is useful (e.g. broad question with no product/category/data). Skip when OP is venting or has enough context for a lightweight answer. 30-80 words.
-- **`detailed`** — *conditional*. Generate ONLY if the OP explicitly asked for a step-by-step plan, technical troubleshooting, multi-part critique, code/config/database/API diagnosis, or structured review. The `reasoning` field must quote the literal OP phrase that warranted depth (e.g. "OP asked: 'walk me through the steps'"). If you cannot quote OP requesting depth, **do not generate this variant.** Reformatting `best` with section headers does NOT count as detailed. 250-400 words max even when included.
+- **`best`** / displayed as **Best Pick** — your recommended reply: one sharp frame, specific, peer voice. Grounded in OP + top comments + supplied context. Usually 120-180 words for non-technical subs; can be shorter when the answer is obvious. Defaults to short paragraphs, not bullets. May itself be a counterpoint-flavored reply if that is the strongest version.
+- **`shorter`** / displayed as **Shorter** — the shortest viable reply (40-90 words). One paragraph that preserves the core advice from `best`. No setup, no throat-clearing. Skip if `best` is already short.
+- **`counterpoint`** / displayed as **Counterpoint** — a contrarian, minority, or thread-aware angle (80-160 words). Generate ONLY if top comments contain a repeated pattern, missing nuance, or contrarian POV worth surfacing. Otherwise skip.
+- **`warmer-personal`** / displayed as **Warmer / Personal** — a personal-context-flavored reply (70-140 words). Generate ONLY if a supplied context body contains a first-degree personal connection (you, family, close colleague) directly matching OP's situation. The `reasoning` field must name the connection (e.g. "uses one-person handmade shop story from personal.md"). Skip otherwise — do not invent.
+- **`question`** / displayed as **Question** — leads with a question to clarify before advising (30-80 words). Generate only when OP genuinely needs to give more info before any answer is useful. Skip when OP is venting or has enough context for a lightweight answer.
+
+There is no `detailed` variant. Do not generate one. For technical subs that need concrete depth, lengthen `best` instead.
 
 Word counts are guidance, not hard limits — fit the thread.
+
+# Distinct-frame rule (mandatory)
+
+Aside from `shorter`, the alternatives must each represent a **distinct point of view** from `best`. Specifically:
+
+- If `best` is itself a counterpoint frame, `counterpoint` must take a **different** contrarian/minority angle. If no different angle exists, **skip the slot** rather than duplicate the frame.
+- `warmer-personal` must contribute personal-credibility framing that `best` does not already lean on.
+- `question` must surface a genuinely missing fact, not echo a question already implicit in `best`.
+
+Two drafts that say the same thing in different lengths is failure. Choose differentiation over completeness.
+
+# Bullet rule
+
+Default to short paragraphs, not bullets.
+
+Use bullets only when they materially improve readability — typically when listing 3+ short, parallel items the reader would scan rather than read. Single-bullet "lists" and bulleted operating-manual-style replies are anti-patterns.
 
 # Anti-tells (mandatory)
 
@@ -81,7 +98,6 @@ Never:
 - Echo the OP's question back at them as filler
 - "Let me know if you have any questions!" closes
 - **Fabricate first-person experience.** "I ran into the same wall", "What fixed it for me was...", "When I ran my store..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
-- **Reformat `best` as `detailed`.** Numbered 1-N section headers covering the same ground as `best` is not depth, it's padding.
 - **Repeat the consensus.** If three top comments already say "pick one platform," do not lead with "pick one platform." Build on it or push back on it.
 
 Always:
@@ -93,14 +109,14 @@ Always:
 
 # Reasoning field — describe the angle, not the length
 
-The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is.
+The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is. Reasoning is recorded in `drafts.json` for audit/debug — it does NOT appear in the rendered markdown the user sees, so use it to explain your editorial choice cleanly.
 
 Good: "Engages the batching pushback in the comments and reframes the work as capture inventory."
 Bad: "Provides a step-by-step operating model with concrete tools."
 
 # Output
 
-Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-6 entries depending on what fits.
+Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-5 entries depending on what fits.
 
 {
   "drafts": [
@@ -111,14 +127,14 @@ Return a single JSON object exactly matching this shape, no other fields. Omit v
       "reasoning": "one short sentence on the angle"
     },
     {
-      "id": "short",
-      "label": "short",
+      "id": "shorter",
+      "label": "shorter",
       "text": "...",
       "reasoning": "..."
     },
     {
-      "id": "thread-aware",
-      "label": "thread-aware",
+      "id": "counterpoint",
+      "label": "counterpoint",
       "text": "...",
       "reasoning": "name the comment or pattern this engages"
     }

--- a/prompts/reply.tmpl
+++ b/prompts/reply.tmpl
@@ -116,7 +116,7 @@ Bad: "Provides a step-by-step operating model with concrete tools."
 
 # Output
 
-Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-5 entries depending on what fits.
+Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array should have 2-4 entries (never 5; emitting every slot is "the full menu" failure mode the Task section warns against).
 
 {
   "drafts": [

--- a/prompts/review.tmpl
+++ b/prompts/review.tmpl
@@ -107,12 +107,14 @@ Use context as a **lens, not a topic**. The thesis or worldview from this materi
 
 # Task — variants
 
-Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if the thread genuinely fits one (e.g. `question-first` when the open questions in the notes block any useful advice).
+Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if the thread genuinely fits one (e.g. `question` when the open questions in the notes block any useful advice).
 
-- **`best`** — your recommended reply: acknowledge one or two strengths, give 2-4 concrete fixes, include at least one visual observation when visual notes exist. Avoid sounding like an agency audit. Usually 150-300 words.
-- **`short`** — shortest useful review: one strength, one or two highest-leverage fixes. 60-130 words.
-- **`structured-review`** — *use only when OP explicitly asked for critique/review and the findings justify structure.* Format: "What works:" / "What I would fix:" / "Biggest priority:" lists. Keep it postable as a Reddit comment, not an audit. Skip if the findings are sparse.
-- **`question-first`** — *only* if the review cannot be usefully completed without one or two facts (e.g. quote-only vs fixed pricing, intended customer, whether the linked page is a placeholder). Do NOT use this as an excuse to avoid giving visible-page feedback. 30-80 words.
+Variant labels here are aligned with reply-mode labels (SPEC_REPLY_REFINEMENT.md): `shorter` not `short`, `question` not `question-first`. Review mode keeps `structured-review` as its review-specific slot. There is no `counterpoint` or `warmer-personal` for review mode by default.
+
+- **`best`** / displayed as **Best Pick** — your recommended reply: acknowledge one or two strengths, give 2-4 concrete fixes, include at least one visual observation when visual notes exist. Avoid sounding like an agency audit. Usually 150-300 words.
+- **`shorter`** / displayed as **Shorter** — shortest useful review: one strength, one or two highest-leverage fixes. 60-130 words.
+- **`structured-review`** / displayed as **Structured-Review** — *use only when OP explicitly asked for critique/review and the findings justify structure.* Format: "What works:" / "What I would fix:" / "Biggest priority:" lists. Keep it postable as a Reddit comment, not an audit. Skip if the findings are sparse.
+- **`question`** / displayed as **Question** — *only* if the review cannot be usefully completed without one or two facts (e.g. quote-only vs fixed pricing, intended customer, whether the linked page is a placeholder). Do NOT use this as an excuse to avoid giving visible-page feedback. 30-80 words.
 
 # Hard rules — visual feedback grounding
 
@@ -159,7 +161,7 @@ Return a single JSON object exactly matching this shape, no other fields. Omit v
       "text": "...the actual reddit reply text the user would post, grounded in specific notes observations...",
       "reasoning": "one short sentence on the angle"
     },
-    {"id": "short", "label": "short", "text": "...", "reasoning": "..."},
+    {"id": "shorter", "label": "shorter", "text": "...", "reasoning": "..."},
     {"id": "structured-review", "label": "structured-review", "text": "...", "reasoning": "..."}
   ],
   "pick_id": "best"

--- a/reply/drafter_test.go
+++ b/reply/drafter_test.go
@@ -177,6 +177,28 @@ func TestRenderReplyPromptIncludesContextAndAuthor(t *testing.T) {
 			t.Errorf("prompt should not define legacy/removed variant slot %q (v2 spec)\n--- prompt ---\n%s", b, prompt)
 		}
 	}
+
+	// Drafts-array cap regression guard. SPEC_REPLY_REFINEMENT.md is
+	// emphatic: "Two to four strong drafts are better than a full menu"
+	// and "Keep default output to 2-4 drafts total." The variant set has
+	// 5 slots (best/shorter/counterpoint/warmer-personal/question), so
+	// any "2-5" wording in the Output section would license the full
+	// menu the spec calls a failure. The Output section sits last in the
+	// prompt and tends to anchor numerical behavior — keep it at 2-4.
+	bannedCountWording := []string{
+		"2-5 entries",
+		"2 to 5 entries",
+		"2-5 drafts",
+		"2 to 5 drafts",
+	}
+	for _, b := range bannedCountWording {
+		if strings.Contains(prompt, b) {
+			t.Errorf("prompt licenses the full 5-slot menu (%q); spec caps at 2-4\n--- prompt ---\n%s", b, prompt)
+		}
+	}
+	if !strings.Contains(prompt, "2-4 entries") && !strings.Contains(prompt, "2 to 4") {
+		t.Errorf("prompt should specify the 2-4 drafts cap explicitly\n--- prompt ---\n%s", prompt)
+	}
 }
 
 // Flair is conditional: it must appear in the rendered prompt only when

--- a/reply/drafter_test.go
+++ b/reply/drafter_test.go
@@ -28,8 +28,8 @@ func sampleDraftInput() *DraftInput {
 const goodDrafterResp = `{
   "drafts": [
     {"id":"best","label":"best","text":"Best draft text.","reasoning":"one sharp frame for solo store owner"},
-    {"id":"short","label":"short","text":"Short text.","reasoning":"shortest viable answer"},
-    {"id":"thread-aware","label":"thread-aware","text":"Engaging the batching pushback.","reasoning":"top comment's batching critique deserves a response"}
+    {"id":"shorter","label":"shorter","text":"Shorter text.","reasoning":"shortest viable answer"},
+    {"id":"counterpoint","label":"counterpoint","text":"Counterpoint engaging the batching pushback.","reasoning":"top comment's batching critique deserves a response"}
   ],
   "pick_id": "best"
 }`
@@ -50,7 +50,7 @@ func TestGenerateReplyHappyPath(t *testing.T) {
 	for _, d := range bundle.Drafts {
 		gotLabels[d.Label] = true
 	}
-	for _, want := range []string{"best", "short", "thread-aware"} {
+	for _, want := range []string{"best", "shorter", "counterpoint"} {
 		if !gotLabels[want] {
 			t.Errorf("missing variant %q in bundle", want)
 		}
@@ -124,7 +124,7 @@ func TestRenderReplyPromptIncludesContextAndAuthor(t *testing.T) {
 	}
 	checks := []string{
 		"r/shopify",
-		"Flair: Marketing",                   // flair threaded through (new)
+		"Flair: Marketing",                   // flair threaded through (PR #19)
 		"best plugins for performance?",
 		"Looking for plugin recs",
 		"alice", "Try X",                     // top comment leaked in
@@ -136,18 +136,45 @@ func TestRenderReplyPromptIncludesContextAndAuthor(t *testing.T) {
 		"From path",
 		"kova body content",
 		"notes body",
-		"Do not name or pitch the project",
+		"name or pitch the project",          // bold markup may surround "not"
 		"lens, not a topic",                  // context-as-lens guidance
 		"Sub-category inference",             // abstract category guidance, not named-sub list
-		"thread-aware",                       // new variant slot
-		"personal-story",                     // new variant slot
-		"Fabricate first-person experience",  // explicit ban on fake autobiography
-		"Repeat the consensus",               // engage-don't-duplicate rule
+		// v2 variant slots — these are the labels the prompt asks the model to emit.
+		"`shorter`",
+		"`counterpoint`",
+		"`warmer-personal`",
+		"`question`",
+		// Distinct-frame rule (new in v2)
+		"Distinct-frame rule",
+		// Bullet rule (new in v2)
+		"Bullet rule",
+		// First-person ban + consensus-repeat ban (carried over)
+		"Fabricate first-person experience",
+		"Repeat the consensus",
 		"Anti-tells",
 	}
 	for _, s := range checks {
 		if !strings.Contains(prompt, s) {
 			t.Errorf("prompt missing %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+	// V2 removes `detailed` entirely and renames `short` → `shorter`,
+	// `thread-aware` → `counterpoint`, `personal-story` → `warmer-personal`,
+	// `question-first` → `question`. The regression-guard checks for the
+	// slot-definition format used in the prompt's task list ( **`label`** )
+	// rather than any mention of the legacy name — the prompt itself is
+	// allowed to say "there is no `detailed` variant" as a model-facing
+	// instruction.
+	bannedSlotDefinitions := []string{
+		"**`detailed`**",
+		"**`thread-aware`**",
+		"**`personal-story`**",
+		"**`question-first`**",
+		"**`short`**",
+	}
+	for _, b := range bannedSlotDefinitions {
+		if strings.Contains(prompt, b) {
+			t.Errorf("prompt should not define legacy/removed variant slot %q (v2 spec)\n--- prompt ---\n%s", b, prompt)
 		}
 	}
 }

--- a/reply/render.go
+++ b/reply/render.go
@@ -7,10 +7,16 @@ import (
 	"github.com/viggy28/tider/internal/types"
 )
 
-// RenderMarkdown turns a ReplyBundle into a scannable human report,
-// matching the shape in SPEC_REPLY.md. Pick leads with full content;
-// other variants follow under "Alternatives". TTY-aware ANSI styling is
-// applied at the CLI layer (cmd/tider/term.go), not here.
+// RenderMarkdown turns a ReplyBundle into a scannable human report.
+// Pick leads under "## Best Pick"; other variants follow under
+// "## Alternative Picks". TTY-aware ANSI styling is applied at the CLI
+// layer (cmd/tider/term.go), not here.
+//
+// Per SPEC_REPLY_REFINEMENT.md "Output rendering" — the rendered
+// markdown contains ONLY the postable comments, never the per-draft
+// `reasoning` text. Reasoning is recorded in `drafts.json` for audit/
+// debug; surfacing it here would turn the output into a report about
+// the comments rather than the comments themselves.
 //
 // threadTitle is rendered in the header for context — the bundle alone
 // doesn't carry it. sessionPath is the absolute on-disk session
@@ -49,20 +55,14 @@ func RenderMarkdown(b *types.ReplyBundle, threadTitle string, sessionPath string
 	pick := findDraft(b.Drafts, b.PickID)
 	if pick != nil {
 		sb.WriteString("## Best Pick\n\n")
-		if pick.Reasoning != "" {
-			fmt.Fprintf(&sb, "> %s\n\n", pick.Reasoning)
-		}
 		fmt.Fprintf(&sb, "%s\n\n", strings.TrimSpace(pick.Text))
 	}
 
 	others := alternatives(b.Drafts, b.PickID)
 	if len(others) > 0 {
-		sb.WriteString("## Alternatives\n\n")
+		sb.WriteString("## Alternative Picks\n\n")
 		for _, d := range others {
 			fmt.Fprintf(&sb, "### %s\n\n", titleCaseLabel(d.Label))
-			if d.Reasoning != "" {
-				fmt.Fprintf(&sb, "*%s*\n\n", d.Reasoning)
-			}
 			fmt.Fprintf(&sb, "%s\n\n", strings.TrimSpace(d.Text))
 		}
 	}
@@ -110,19 +110,34 @@ func alternatives(drafts []types.ReplyDraft, pickID string) []types.ReplyDraft {
 }
 
 // displayLabel maps known variant ids to their spec-mandated display
-// form. SPEC_REPLY_REFINEMENT.md "Output rendering" defines the reply-
-// mode forms; SPEC_REVIEW_VISUAL_FIRECRAWL.md adds review-mode-specific
-// variants. Hyphen retention is per-label and intentional: compound
-// modifiers like "thread-aware" / "structured-review" keep the hyphen;
-// noun phrases like "personal-story" / "question-first" use spaces.
+// form. SPEC_REPLY_REFINEMENT.md (v2) "Output rendering" defines the
+// reply-mode forms and aligns review-mode labels (`shorter`/`question`
+// shared with reply mode; `structured-review` is review-only).
+//
+// Hyphen retention is per-label and intentional: compound modifiers
+// like "structured-review" keep the hyphen; the canonical "Warmer /
+// Personal" is rendered with explicit spacing per spec.
+//
+// Old ids from earlier specs (short / thread-aware / personal-story /
+// question-first / detailed) are kept in the map so old session
+// drafts.json files re-render with reasonable display labels. New
+// outputs use the v2 ids.
 var displayLabel = map[string]string{
-	"best":              "Best",
-	"short":             "Short",
-	"thread-aware":      "Thread-Aware",
-	"personal-story":    "Personal Story",
-	"question-first":    "Question First",
-	"detailed":          "Detailed",
+	// v2 reply-mode (SPEC_REPLY_REFINEMENT.md)
+	"best":            "Best",
+	"shorter":         "Shorter",
+	"counterpoint":    "Counterpoint",
+	"warmer-personal": "Warmer / Personal",
+	"question":        "Question",
+	// review-mode-specific
 	"structured-review": "Structured-Review",
+	// Legacy ids preserved so old session re-renders aren't ugly. Not
+	// produced by current prompts; keep for backward-compat only.
+	"short":          "Short",
+	"thread-aware":   "Thread-Aware",
+	"personal-story": "Personal Story",
+	"question-first": "Question First",
+	"detailed":       "Detailed",
 }
 
 // titleCaseLabel returns the display form of a draft label. Known labels

--- a/reply/render_test.go
+++ b/reply/render_test.go
@@ -15,10 +15,10 @@ func sampleBundle() *types.ReplyBundle {
 		Mode:      types.ReplyModeReply,
 		Drafts: []types.ReplyDraft{
 			{ID: "best", Label: "best", Text: "Best reply text here.", Reasoning: "concise + fits sub"},
-			{ID: "short", Label: "short", Text: "Short text.", Reasoning: "shortest viable"},
-			{ID: "thread-aware", Label: "thread-aware", Text: "Engages the batching pushback.", Reasoning: "top comment counterpoint"},
-			{ID: "personal-story", Label: "personal-story", Text: "Story-shaped reply.", Reasoning: "uses one-person handmade shop story from personal.md"},
-			{ID: "question-first", Label: "question-first", Text: "What's your stack?", Reasoning: "need more info"},
+			{ID: "shorter", Label: "shorter", Text: "Shorter text.", Reasoning: "shortest viable"},
+			{ID: "counterpoint", Label: "counterpoint", Text: "Engages the batching pushback.", Reasoning: "top comment counterpoint"},
+			{ID: "warmer-personal", Label: "warmer-personal", Text: "Story-shaped reply.", Reasoning: "uses one-person handmade shop story from personal.md"},
+			{ID: "question", Label: "question", Text: "What's your stack?", Reasoning: "need more info"},
 		},
 		PickID:    "best",
 		Generated: time.Now(),
@@ -29,12 +29,12 @@ func TestRenderMarkdownBestPickLeads(t *testing.T) {
 	md := RenderMarkdown(sampleBundle(), "best plugins for performance?", "/tmp/sessions/replies/x")
 
 	pickIdx := strings.Index(md, "## Best Pick")
-	altIdx := strings.Index(md, "## Alternatives")
+	altIdx := strings.Index(md, "## Alternative Picks")
 	if pickIdx == -1 || altIdx == -1 {
 		t.Fatalf("missing section headers\n--- output ---\n%s", md)
 	}
 	if pickIdx > altIdx {
-		t.Errorf("Best Pick should come before Alternatives")
+		t.Errorf("Best Pick should come before Alternative Picks")
 	}
 
 	checks := []string{
@@ -42,22 +42,60 @@ func TestRenderMarkdownBestPickLeads(t *testing.T) {
 		"Thread: best plugins for performance?",
 		"Mode: reply",
 		"Session: /tmp/sessions/replies/x",
-		"## Best Pick",                         // header per spec
-		"> concise + fits sub",                 // pick reasoning as blockquote
-		"Best reply text here.",                // pick text in full
-		"## Alternatives",
-		"### Short",
-		"*shortest viable*",                    // alt reasoning as italic
-		"Short text.",
-		"### Thread-Aware",                     // compound modifier — hyphen retained per spec
-		"### Personal Story",                   // noun phrase — space, not hyphen, per spec
-		"### Question First",                   // noun phrase — space, not hyphen, per spec
+		"## Best Pick",                             // header per spec
+		"Best reply text here.",                    // pick text in full
+		"## Alternative Picks",                     // renamed from "Alternatives" per v2 spec
+		"### Shorter",                              // v2 label, replaces "Short"
+		"Shorter text.",
+		"### Counterpoint",                         // v2 label, replaces "Thread-Aware"
+		"### Warmer / Personal",                    // v2 label with explicit spacing per spec
+		"### Question",                             // v2 label, replaces "Question First"
 		"What's your stack?",
 	}
 	for _, c := range checks {
 		if !strings.Contains(md, c) {
 			t.Errorf("missing %q\n--- output ---\n%s", c, md)
 		}
+	}
+}
+
+// Per SPEC_REPLY_REFINEMENT.md (v2) "Output rendering", the rendered
+// markdown does NOT include per-variant reasoning. Reasoning stays in
+// drafts.json for audit/debug only — surfacing it here would turn the
+// output into a report about the comments rather than the comments
+// themselves.
+func TestRenderMarkdownDoesNotIncludeReasoning(t *testing.T) {
+	md := RenderMarkdown(sampleBundle(), "title", "/x")
+	bannedReasoningStrings := []string{
+		"> concise + fits sub",      // old blockquote on best pick
+		"*shortest viable*",         // old italic on alternative
+		"*top comment counterpoint*",
+		"*need more info*",
+		"concise + fits sub",        // even un-decorated reasoning shouldn't appear
+		"shortest viable",
+		"top comment counterpoint",
+		"uses one-person handmade shop story from personal.md",
+		"need more info",
+		// Forbidden user-facing labels from older drafts:
+		"Why this works",
+		"Editing Notes",
+	}
+	for _, banned := range bannedReasoningStrings {
+		if strings.Contains(md, banned) {
+			t.Errorf("rendered markdown should not contain reasoning text %q\n--- output ---\n%s", banned, md)
+		}
+	}
+}
+
+// Old "## Alternatives" section header was renamed to "## Alternative Picks"
+// in v2. This test catches the regression of the old name slipping back in.
+func TestRenderMarkdownUsesAlternativePicks(t *testing.T) {
+	md := RenderMarkdown(sampleBundle(), "title", "/x")
+	if strings.Contains(md, "## Alternatives\n") {
+		t.Errorf("rendered markdown should not contain old '## Alternatives' header\n--- output ---\n%s", md)
+	}
+	if !strings.Contains(md, "## Alternative Picks") {
+		t.Errorf("rendered markdown must contain '## Alternative Picks' header per v2 spec\n--- output ---\n%s", md)
 	}
 }
 
@@ -80,17 +118,17 @@ func TestRenderMarkdownWithoutThreadTitle(t *testing.T) {
 
 func TestRenderMarkdownPickIDNotInDrafts(t *testing.T) {
 	// Defensive: if PickID points at a missing draft, no Best Pick section
-	// renders, but Alternatives still lists everything.
+	// renders, but Alternative Picks still lists everything.
 	b := sampleBundle()
 	b.PickID = "nope"
 	md := RenderMarkdown(b, "title", "")
 	if strings.Contains(md, "## Best Pick") {
 		t.Error("missing pick should suppress Best Pick header")
 	}
-	if !strings.Contains(md, "## Alternatives") {
-		t.Error("Alternatives should still render")
+	if !strings.Contains(md, "## Alternative Picks") {
+		t.Error("Alternative Picks should still render")
 	}
-	for _, want := range []string{"### Best", "### Short", "### Thread-Aware", "### Personal Story", "### Question First"} {
+	for _, want := range []string{"### Best", "### Shorter", "### Counterpoint", "### Warmer / Personal", "### Question"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("alternative %q should still render", want)
 		}
@@ -149,14 +187,20 @@ func TestRenderMarkdownReplyModeOmitsInspectionHeader(t *testing.T) {
 
 func TestTitleCaseLabel(t *testing.T) {
 	cases := []struct{ in, want string }{
-		// Spec-mandated display forms (SPEC_REPLY_REFINEMENT.md "Output rendering").
+		// v2 reply-mode labels (SPEC_REPLY_REFINEMENT.md "Output rendering").
 		{"best", "Best"},
+		{"shorter", "Shorter"},
+		{"counterpoint", "Counterpoint"},
+		{"warmer-personal", "Warmer / Personal"}, // explicit spacing per spec
+		{"question", "Question"},
+		// Review-mode-specific.
+		{"structured-review", "Structured-Review"},
+		// Legacy ids preserved in the map for old session re-renders.
 		{"short", "Short"},
-		{"thread-aware", "Thread-Aware"},          // hyphen retained — compound modifier
-		{"personal-story", "Personal Story"},      // space — noun phrase
-		{"question-first", "Question First"},      // space — noun phrase
+		{"thread-aware", "Thread-Aware"},
+		{"personal-story", "Personal Story"},
+		{"question-first", "Question First"},
 		{"detailed", "Detailed"},
-		{"structured-review", "Structured-Review"}, // hyphen retained — compound modifier (review-mode variant)
 		// Unknown labels fall back to kebab→title-case-with-hyphens so future
 		// variant names render reasonably without a code change.
 		{"long-multi-part", "Long-Multi-Part"},

--- a/reply/review_test.go
+++ b/reply/review_test.go
@@ -102,9 +102,9 @@ func TestRenderReviewNotesPromptIncludesInspectionFields(t *testing.T) {
 const sampleReviewDrafts = `{
   "drafts": [
     {"id":"best","label":"best","text":"Specific review reply citing the meta description and h1.","reasoning":"balances praise + actionable critique"},
-    {"id":"short","label":"short","text":"Short review reply.","reasoning":"shortest viable"},
-    {"id":"detailed","label":"detailed","text":"Detailed multi-section review.","reasoning":"thread has substance"},
-    {"id":"question-first","label":"question-first","text":"Ask about pricing first.","reasoning":"open question is load-bearing"}
+    {"id":"shorter","label":"shorter","text":"Shorter review reply.","reasoning":"shortest viable"},
+    {"id":"structured-review","label":"structured-review","text":"What works:\nWhat I would fix:\nBiggest priority:","reasoning":"thread has substance and OP asked for critique"},
+    {"id":"question","label":"question","text":"Ask about pricing first.","reasoning":"open question is load-bearing"}
   ],
   "pick_id": "best"
 }`


### PR DESCRIPTION
## Summary

Implements the v2 `SPEC_REPLY_REFINEMENT.md`. The PR #19 model held up directionally but the rendered output read like a report about comments rather than postable comments. v2 makes the markdown a clean menu the user can copy-paste from.

**Variant labels renamed:**

| v1 (PR #19) | v2 (this PR) | Display |
|---|---|---|
| `short` | `shorter` | `Shorter` |
| `thread-aware` | `counterpoint` | `Counterpoint` |
| `personal-story` | `warmer-personal` | `Warmer / Personal` |
| `question-first` | `question` | `Question` |
| `detailed` | _removed_ | — |

**Section rename:** `## Alternatives` → `## Alternative Picks`.

**No more reasoning prose in markdown.** The `> reasoning` blockquote on Best Pick and the `*reasoning*` italic on alternatives are gone. Reasoning is preserved in `drafts.json` for audit/debug — terminal output is now just the comments.

**New prompt rules:**

- **Distinct-frame rule:** aside from `shorter`, alternatives must be distinct POVs, not length variants. If `best` is itself counterpoint-flavored, `counterpoint` takes a different angle or skips. No duplicate frames.
- **Bullet rule:** prose by default; bullets only when listing 3+ short, parallel items the reader would scan rather than read.
- **Counterpoint slot rule:** generate counterpoint only when top comments contain a repeated pattern, missing nuance, or contrarian POV worth surfacing.

**Word counts tightened:** `best` 120-180 (was 120-220), `counterpoint` 80-160, `warmer-personal` 70-140.

**Review-mode aligned:** `short` → `shorter`, `question-first` → `question` in `prompts/review.tmpl`. Review mode keeps its review-specific `structured-review` slot. No counterpoint / warmer-personal for review mode by default.

## What survived from PR #19

- Flair threaded into the drafter prompt
- AuthorContext as voice-only (no project/credential namedrop)
- Context-as-lens rules
- First-person fabrication ban
- Sub-category inference (abstract categories, no named-sub list)
- Inspection-summary header in render output (review mode)

## Compatibility

- Old sessions: `drafts.json` files written by PR #19 still re-render readably. The `displayLabel` map keeps the legacy ids (`short`, `thread-aware`, `personal-story`, `question-first`, `detailed`) so old labels show up as `Short`, `Thread-Aware`, etc. The prompt no longer produces these ids; the map costs nothing.
- No schema change to `ReplyDraft` — labels stay free-form strings.

## Test plan

- [x] `go test ./...` green
- [x] Drafter happy-path uses new variant ids (`shorter`, `counterpoint`)
- [x] Prompt-render assertions: v2 slot names present (`shorter`, `counterpoint`, `warmer-personal`, `question`); legacy slot definitions (` **`detailed`** ` etc.) absent
- [x] Distinct-frame rule + bullet rule present in rendered prompt
- [x] Render assertions: `## Alternative Picks` (regression guard against old `## Alternatives`); `### Shorter` / `### Counterpoint` / `### Warmer / Personal` / `### Question`; reasoning text absent from markdown
- [x] Title-case helper covers v2 ids + legacy ids + kebab fallback
- [x] Visual sanity check on rendered prompt + markdown matches the spec's example layout
- [ ] Manual: rerun the Shopify burnout thread (`./tider reply --url=... --context=kova --context=personal`) and verify (a) output uses `## Best Pick` / `## Alternative Picks`, (b) no reasoning prose in markdown, (c) `Best Pick` ≤180 words, (d) `Counterpoint` engages augustcero's batching pushback if generated, (e) bullet usage limited to genuinely list-shaped material

🤖 Generated with [Claude Code](https://claude.com/claude-code)