### PR TITLE
review: tighten drafter to digestible Reddit comments

### DIFF
--- a/SPEC_REVIEW_DRAFT_REFINEMENT.md
+++ b/SPEC_REVIEW_DRAFT_REFINEMENT.md
@@ -1,0 +1,476 @@
+# Spec: visual review draft refinement for `tider reply`
+
+## Status
+
+Draft spec. This refines the review-mode drafting step after Firecrawl visual inspection has already succeeded.
+
+This spec is about the final Reddit reply quality, not about target capture. Firecrawl screenshot capture, image selection, and visual-note generation are covered by `SPEC_REVIEW_VISUAL_FIRECRAWL.md`.
+
+## Reference session
+
+Use this real session as the primary implementation fixture:
+
+```text
+/Users/viggy28/.tider/sessions/replies/2026-05-01-ecommerce-1t06474-2
+```
+
+Command that produced it:
+
+```text
+./tider reply --url=https://www.reddit.com/r/ecommerce/comments/1t06474/looking_for_website_reviewcriticism/ --context=kova --context=personal
+```
+
+Important artifacts:
+
+```text
+thread.json           # Reddit OP + comments
+contexts.json         # kova + personal context snapshots
+mode.json             # mode=review
+inspection.json       # Firecrawl result; screenshot + image URLs
+visual-input.json     # exact screenshot/images sent to visual analyzer
+visual-notes.json     # visual observations generated from screenshot/images
+review-notes.json     # text/content observations
+draft-input.json      # combined review drafter input
+drafts.json           # generated drafts with reasoning for audit
+output.md             # rendered terminal output
+screenshots/
+  screenshot-20260501-205322.png
+```
+
+The screenshot is a full-page homepage capture. The selected image refs are category/product images. `visual-notes.json` classifies the site as:
+
+```json
+"shop_type": "b2b_industrial"
+```
+
+The output header correctly showed:
+
+```text
+Inspection: Firecrawl visual
+Screenshot: saved
+Images analyzed: 8
+Shop type: b2b_industrial
+```
+
+So the capture/visual-analysis pipeline worked. The remaining problem is the final review draft.
+
+## Problem
+
+The current review reply is too much like an audit.
+
+Observed output problems:
+
+- Too many bullets and too many fixes.
+- The reply reads like an agency checklist, not a Reddit comment.
+- Reasoning lines are rendered in terminal output.
+- The output uses `Alternatives` / `Short` instead of the refined `Alternative Picks` / `Shorter` style.
+- Pricing/policy advice gets too much attention for a B2B industrial supplier where quote-driven purchasing may be normal.
+- The draft underuses the Kova-relevant angle: visual proof, real usage imagery, buyer trust, and reusable organic content.
+- Some visual claims are overconfident or loosely grounded:
+  - "header overwhelm" is not strongly supported by the screenshot.
+  - "images are isolated on plain backgrounds" is partly true, but the page also contains contextual category images.
+  - mobile risk is listed as high even though mobile was not inspected.
+
+The right output should be digestible: 2-3 high-leverage suggestions, centered on what the visual inspection actually supports.
+
+## Product stance
+
+For store/shop review threads, especially when `--context=kova` is supplied, Tider should not produce a generic website audit.
+
+It should use visual inspection to answer:
+
+- Does the site show enough real product proof?
+- Do the images help a buyer understand scale, material, use, category, quality, and trust?
+- Are the visuals mostly catalog/category imagery, or do they show real use/context?
+- What visual assets could improve both the website and organic content?
+- Can simple product/process/use-case clips make the page feel more trustworthy?
+
+The draft should help the Reddit OP and still align with why the user is engaging: learning and contributing around Kova's thesis without naming or pitching Kova.
+
+## Goals
+
+1. Make review-mode replies digestible and postable.
+2. Limit `Best Pick` to 2-3 strongest fixes.
+3. Prefer visual/product-proof feedback over generic website-audit items when visual inspection exists.
+4. Use Kova context as a lens: real product proof, usage imagery, process clips, buyer trust, and organic reuse.
+5. Remove reasoning from rendered markdown output.
+6. Avoid pricing/policy tangents unless they are the clearest blocker or OP explicitly asks about them.
+7. Ground every visual claim in `visual-notes.json`, `inspection.json`, or the screenshot.
+8. Keep `drafts.json` useful for audit/debug without overloading terminal output.
+
+## Non-goals
+
+- No Reddit posting.
+- No changes to Firecrawl capture requirements.
+- No new CLI flags.
+- No `--text-only`.
+- No Kova naming or product pitch by default.
+- No full conversion-rate audit.
+- No Lighthouse, SEO, accessibility, or performance audit.
+- No broad multi-page crawl in this spec.
+
+## Target output format
+
+Review mode should follow the same rendering philosophy as reply mode: postable comments first, no explanatory report.
+
+```text
+Reply drafts for r/<subreddit>
+
+Thread: <thread title>
+Mode: review
+Session: <session path>
+Inspection: Firecrawl visual
+Screenshot: saved
+Images analyzed: <n>
+Shop type: <shop_type>
+Limitations: <limitations>
+
+Best Pick
+
+<ready-to-post review comment>
+
+Alternative Picks
+
+Shorter
+
+<shorter ready-to-post review comment>
+
+Visual / Organic Angle
+
+<image/product-proof/content-reuse angle, if Best Pick did not already center it>
+
+Structured Review
+
+<skimmable structured version, only if useful>
+
+Question
+
+<question-first version, only if critical context is missing>
+```
+
+Rendering rules:
+
+- No `Why this works`.
+- No reasoning under variants.
+- No `Editing Notes`.
+- Use `Alternative Picks`, not `Alternatives`.
+- Use `Shorter`, not `Short`.
+- Render only variants that exist.
+- Keep default output to 2-3 drafts total.
+- `Structured Review` is optional and should not be a full audit.
+
+`drafts.json` may still keep `reasoning` for audit/debug. The markdown renderer should not print it.
+
+## Variant model
+
+### `best` / `Best Pick`
+
+The comment the user is most likely to post.
+
+Default shape:
+
+- one quick strength
+- 2-3 strongest fixes
+- one concrete "thing I would change first" or "one thing I did not like"
+- 150-260 words for review mode
+- short paragraphs by default
+- bullets only if they make the comment easier to scan
+
+When Kova context is present and visual notes support it, `Best Pick` should usually include the visual/product-proof angle.
+
+### `shorter` / `Shorter`
+
+Compressed version.
+
+Default shape:
+
+- one strength
+- 1-2 strongest fixes
+- 70-140 words
+- no audit framing
+
+### `visual-organic` / `Visual / Organic Angle`
+
+Use when the main `Best Pick` did not already center image/product-proof feedback.
+
+Purpose:
+
+- connect visual proof on the site to reusable organic content
+- suggest real use/process/category imagery
+- point out where stock/category visuals are weaker than real proof
+
+Skip this variant if `Best Pick` already uses this frame strongly.
+
+### `structured-review` / `Structured Review`
+
+Optional. Use only if the OP clearly asked for critique and the findings benefit from structure.
+
+Shape:
+
+```text
+What works:
+- ...
+
+What I would fix first:
+- ...
+- ...
+
+Biggest priority:
+- ...
+```
+
+Hard limits:
+
+- max 3 sections
+- max 5 total bullets
+- no pricing/policy section by default
+
+### `question` / `Question`
+
+Only if a critical missing fact blocks useful feedback.
+
+Examples:
+
+- the site is password-gated
+- the screenshot does not show the relevant page
+- OP asks about conversion but no target customer/business model is clear
+
+Do not use `question` as a way to avoid giving visible-page feedback.
+
+## Kova lens
+
+When `--context=kova` is present, review drafts should bias toward visual proof, not generic web critique.
+
+Good Kova-shaped observations:
+
+- "The site is clear, but the visuals feel more like category/catalog imagery than proof of the products in use."
+- "For PPE/safety, real usage shots would build more trust: workers wearing gear, tools on-site, material closeups, certification labels, packaging, delivery/customer examples."
+- "Those same assets can become organic posts, LinkedIn updates, WhatsApp sales collateral, or short product/process clips."
+- "A short real product/use-case clip would probably do more for trust than another generic hero image."
+
+Bad Kova usage:
+
+- "Use Kova."
+- "I built a tool for this."
+- "Etsy listing videos would solve this" when the site is B2B industrial.
+- Turning every review into a video pitch.
+
+The Kova lens should shape the advice, not become the topic.
+
+## Pricing and policy guidance
+
+Do not default to pricing as a top fix.
+
+For B2B, industrial, wholesale, custom, quote-driven, or service-heavy sites:
+
+- exact prices may not be expected
+- "request quote" may be the correct conversion path
+- useful feedback is quote-path clarity, not "publish pricing"
+
+Allowed if grounded:
+
+- "If this is quote-only, make that explicit."
+- "Add MOQ/lead-time/spec-sheet expectations near relevant categories."
+- "Make the quote CTA appear at the decision point."
+
+Avoid unless OP asks or the page is clearly consumer ecommerce:
+
+- "Publish prices."
+- "Show exact pricing."
+- "Pricing is the biggest issue."
+- "Return policy is a top priority."
+
+For the PND session, pricing/policy should not be one of the top 2-3 fixes. The stronger suggestions are visual proof, trust near categories, and quote path at the product/category decision point.
+
+## Grounding rules
+
+The review drafter must not overclaim.
+
+Rules:
+
+- Do not say "header is crowded" unless the screenshot clearly shows crowding.
+- Do not say images are all plain-background if there are contextual category images; use precise wording like "some imagery feels catalog/category-like."
+- Do not make mobile recommendations from a desktop screenshot as a main fix. Put mobile under limitations unless a mobile screenshot was analyzed.
+- Do not claim product pages, checkout, FAQ, or return policy were reviewed unless those pages are in the session artifacts.
+- Do not call something "high severity" in the final reply unless it is one of the selected top fixes.
+
+The drafter should rank candidate findings before writing:
+
+1. Is this strongly supported by visual/text artifacts?
+2. Is it high leverage for OP?
+3. Does it fit the thread/subreddit tone?
+4. Does it fit supplied context, especially Kova?
+
+Only the top 2-3 should make `Best Pick`.
+
+## Ideal output for the PND session
+
+Given:
+
+```text
+tider reply --url=https://www.reddit.com/r/ecommerce/comments/1t06474/looking_for_website_reviewcriticism/ --context=kova --context=personal
+```
+
+With session:
+
+```text
+/Users/viggy28/.tider/sessions/replies/2026-05-01-ecommerce-1t06474-2
+```
+
+`Best Pick` should resemble:
+
+```text
+First impression is solid: I understood quickly that you are an industrial/PPE supplier, and the authorized brand mentions help.
+
+The biggest thing I would improve is the visual proof. A lot of the site feels like category/catalog imagery. For safety/PPE, I would want to see more real-world context: workers wearing the gear, tools being used on-site, closeups of materials/certifications, packaging, and a few customer or industry examples.
+
+That kind of imagery does two jobs: it makes the website feel more trustworthy, and it gives you reusable organic content for LinkedIn, Instagram, WhatsApp, or sales follow-up without inventing separate marketing posts.
+
+I would also move trust signals closer to the product/category sections. If you are an authorized partner or products meet specific standards, show that near the relevant cards, not only in general site copy.
+
+One thing I did not like: the site is clear, but it does not yet show enough real usage proof to make a buyer feel confident quickly.
+```
+
+`Shorter` should resemble:
+
+```text
+The site is clear, and I understood the PPE/industrial focus quickly.
+
+The main thing I would improve is visual proof. A lot of the imagery feels like category/catalog imagery. For safety products, I would add real usage shots: workers wearing PPE, tools on-site, material/certification closeups, packaging, and customer/industry examples.
+
+Those same visuals can also become organic content for LinkedIn/Instagram/WhatsApp, so it is not just a website improvement.
+```
+
+`Structured Review`, if generated, should resemble:
+
+```text
+What works:
+- Clear positioning as an industrial/PPE supplier.
+- Authorized brand mentions help credibility.
+
+What I would fix first:
+- Add more real-world product proof: workers wearing gear, tools on-site, material/certification closeups.
+- Move trust signals closer to the category/product cards.
+
+Biggest priority:
+- Make the visuals feel less like a catalog and more like proof that these products are used by real customers in real environments.
+```
+
+## Implementation plan
+
+### 1. Update review reply prompt
+
+Files:
+
+```text
+prompts/review_reply.tmpl
+reply/review.go
+```
+
+Prompt changes:
+
+- instruct the model to choose only 2-3 strongest fixes for `best`
+- bias toward visual/product-proof feedback when `VisualNotes` exist
+- add Kova lens guidance when contexts include Kova-like product-proof material
+- remove generic audit tone
+- discourage pricing/policy as default top fixes for B2B/quote-driven sites
+- require grounding in `visual_notes` and `review_notes`
+- prohibit mobile/layout claims not supported by artifacts
+- rename variants:
+  - `short` -> `shorter`
+  - `question-first` -> `question`
+  - keep `structured-review`
+  - optionally add `visual-organic`
+- continue returning strict JSON
+- keep `reasoning` in JSON if useful, but make clear it is not rendered
+
+### 2. Update renderer
+
+File:
+
+```text
+reply/render.go
+```
+
+Changes:
+
+- render `Alternative Picks`, not `Alternatives`
+- render `Shorter`, not `Short`
+- render `Structured Review`, not `Structured-Review`
+- render `Visual / Organic Angle` for `visual-organic`
+- render `Question` for `question`
+- do not print `Reasoning`
+- preserve review header metadata:
+  - `Inspection`
+  - `Screenshot`
+  - `Images analyzed`
+  - `Shop type`
+  - `Limitations`
+
+### 3. Update tests
+
+Files:
+
+```text
+reply/review_test.go
+reply/render_test.go
+```
+
+Add/update tests for:
+
+- review prompt includes 2-3 strongest fixes guidance
+- review prompt includes Kova/product-proof lens when contexts are supplied
+- review prompt discourages pricing/policy as default B2B top fixes
+- review prompt warns against unsupported mobile/header/image overclaims
+- generated review variants use `shorter`, `structured-review`, optional `visual-organic`, optional `question`
+- renderer prints `Alternative Picks`
+- renderer does not print `Reasoning`
+- renderer maps labels correctly
+
+### 4. Manual validation
+
+Re-run:
+
+```text
+./tider reply --url=https://www.reddit.com/r/ecommerce/comments/1t06474/looking_for_website_reviewcriticism/ --context=kova --context=personal
+```
+
+Compare against the fixture session:
+
+```text
+/Users/viggy28/.tider/sessions/replies/2026-05-01-ecommerce-1t06474-2
+```
+
+Validation checks:
+
+- `Best Pick` is digestible and under ~260 words.
+- `Best Pick` has 2-3 fixes, not 5+.
+- no reasoning lines are rendered.
+- no pricing/policy tangent unless tightly framed as quote-path clarity.
+- visual/product-proof angle appears when Kova context is present.
+- no unsupported "header crowded" claim.
+- no mobile recommendation as a top fix unless mobile screenshot was analyzed.
+- `Alternative Picks` uses postable drafts, not audit commentary.
+
+## Acceptance criteria
+
+1. Review-mode markdown output no longer renders reasoning lines.
+2. Review-mode markdown uses `Alternative Picks`.
+3. Review-mode `Best Pick` defaults to 2-3 high-leverage fixes.
+4. When visual notes exist and Kova context is present, review drafts prioritize image/product-proof/organic-content feedback when supported.
+5. B2B/quote-driven sites do not get pricing/policy as default top advice.
+6. Visual claims are tightly grounded in `visual-notes.json`, `inspection.json`, and the screenshot.
+7. The PND session produces a digestible Reddit comment, not an agency-style audit.
+8. `drafts.json` can retain `reasoning` for audit/debug, but `output.md` and terminal output do not show it.
+
+## Future work
+
+- Add mobile screenshot analysis.
+- Add product/category page follow-up inspection.
+- Add session regeneration for review angles:
+
+  ```text
+  tider reply regen --session=<path> --angle=visual-organic
+  ```
+
+- Add a human-selectable review focus only if real usage shows the default focus is too narrow.

--- a/prompts/review.tmpl
+++ b/prompts/review.tmpl
@@ -107,21 +107,74 @@ Use context as a **lens, not a topic**. The thesis or worldview from this materi
 
 # Task — variants
 
-Draft the variants below. **Three strong variants beat four padded ones.** Set `pick_id` to your recommended choice — usually `best`, but pick another if the thread genuinely fits one (e.g. `question` when the open questions in the notes block any useful advice).
+Draft the variants below. **Two to three strong drafts beat a four-fix audit.** Set `pick_id` to your recommended choice — usually `best`, but pick another if the thread genuinely fits one (e.g. `question` when the open questions in the notes block any useful advice).
 
 Variant labels here are aligned with reply-mode labels (SPEC_REPLY_REFINEMENT.md): `shorter` not `short`, `question` not `question-first`. Review mode keeps `structured-review` as its review-specific slot. There is no `counterpoint` or `warmer-personal` for review mode by default.
 
-- **`best`** / displayed as **Best Pick** — your recommended reply: acknowledge one or two strengths, give 2-4 concrete fixes, include at least one visual observation when visual notes exist. Avoid sounding like an agency audit. Usually 150-300 words.
-- **`shorter`** / displayed as **Shorter** — shortest useful review: one strength, one or two highest-leverage fixes. 60-130 words.
-- **`structured-review`** / displayed as **Structured-Review** — *use only when OP explicitly asked for critique/review and the findings justify structure.* Format: "What works:" / "What I would fix:" / "Biggest priority:" lists. Keep it postable as a Reddit comment, not an audit. Skip if the findings are sparse.
+- **`best`** / displayed as **Best Pick** — your recommended reply: acknowledge ONE quick strength, then **MAX 3 fixes ranked by leverage**, then optionally one concrete "thing I would change first" or "one thing I did not like". Include at least one visual observation when visual notes exist. Avoid sounding like an agency audit. 150-260 words. Default to short paragraphs, not bullets.
+- **`shorter`** / displayed as **Shorter** — shortest useful review: one strength + 1-2 highest-leverage fixes. 70-140 words.
+- **`structured-review`** / displayed as **Structured Review** — *use only when OP explicitly asked for critique/review and the findings justify structure.* Format: "What works:" / "What I would fix first:" / "Biggest priority:" lists. **Hard caps: max 3 sections, max 5 total bullets across all sections.** Keep it postable as a Reddit comment, not an audit. Skip if the findings are sparse. No pricing/policy section by default for B2B/quote-driven sites.
 - **`question`** / displayed as **Question** — *only* if the review cannot be usefully completed without one or two facts (e.g. quote-only vs fixed pricing, intended customer, whether the linked page is a placeholder). Do NOT use this as an excuse to avoid giving visible-page feedback. 30-80 words.
 
 # Hard rules — visual feedback grounding
 
 - Do NOT mention visual / layout / image / screenshot feedback unless the Visual review notes section above contains a corresponding observation. If there are no visual notes, do not write "your hero section..." or "your product photos...".
 - When you draw on a visual observation, paraphrase the specific finding — don't generalize. "Your first three product shots are top-down crops with no scale reference" beats "your photos could be better."
-- If `ShopType` is `b2b_industrial`, `saas`, `services`, `portfolio`, or `unclear`, do not recommend "show your maker process" or "add a making-of clip" — that's Kova-thesis advice and only applies when ShopType is `handmade` or `boutique`.
-- When `KovaSignals` is non-empty, those are the highest-leverage visual gaps for this thread; lead with one of them in `best`.
+
+## Severity-based ranking (mandatory)
+
+Rank candidate findings before writing `best`. Use ONLY observations with `severity` of `high` or `medium` for the Best Pick fix list. `severity=low` observations are demoted — they may appear in `structured-review` if generated, but never in `Best Pick`'s top fixes.
+
+If after applying severity filtering you have fewer than 3 high/medium findings, that's fine — emit only what's strongly supported. **2 strong fixes beat 3 fixes where one is filler.**
+
+## Mobile-claim handling
+
+If the visual notes' `Limitations` block mentions that mobile responsiveness was inferred / not directly inspected (typical wording: "Mobile responsiveness is inferred and not directly inspected from the screenshot"), then:
+
+- Skip any `mobile_risk` observation from the Best Pick fix list, regardless of severity.
+- Mobile findings may appear in `structured-review` only if explicitly framed as inferred (e.g. "From a desktop-only capture I cannot verify mobile, but...").
+- Do NOT recommend mobile redesign as a top fix from a desktop-only inspection.
+
+## Kova lens (mandatory when Kova-shaped context is supplied)
+
+When supplied Context contains a Kova-shaped thesis (visual proof, scale, texture, function, process, real product imagery, buyer trust), use it to **bias** review feedback toward what the camera can actually fix.
+
+Apply this lens DIFFERENTLY depending on `ShopType`:
+
+- **`handmade` / `boutique`** — `KovaSignals` is the headline. Lead with one of them. The "maker process / making-of / in-hand at scale" framing is allowed and on-thesis. Use it.
+- **`b2b_industrial` / `saas` / `services` / `portfolio` / `dropship` / `unclear`** — `KovaSignals` is empty (correctly gated upstream), but the Kova thesis still applies, **just reshaped**:
+  - For B2B/industrial: real-use imagery (workers wearing PPE, tools on-site, certification labels, packaging/delivery, customer/industry examples), trust signals near category/product cards, NOT "show your maker process".
+  - For SaaS/services: real product/UI in-context screenshots, real customer/team/use-case imagery, NOT polished hero stock graphics.
+  - For dropship/portfolio: contextual usage shots over isolated catalog images.
+  - Universal: "those same visuals double as reusable organic content (LinkedIn, IG, WhatsApp sales follow-up) — not just a website fix."
+
+Do NOT name or pitch the project even when context body mentions it. The Kova thesis shapes the angle; it never becomes the topic.
+
+## B2B / quote-driven pricing & policy guidance
+
+For sites where the inspected page or `ShopType` indicates B2B, industrial, wholesale, custom, quote-driven, or service-heavy commerce, exact prices may not be expected and "request a quote" may be the correct conversion path. Do not default to "publish pricing" or "post a return policy" as top fixes.
+
+**Allowed phrasings (when grounded):**
+- *"If this is quote-only, make that explicit on the category cards."*
+- *"Add MOQ / lead-time / spec-sheet expectations near the relevant categories."*
+- *"Move the quote CTA to the product/category decision point, not just the global header."*
+- *"Make 'request a quote' visually unmissable when a buyer is at the product card."*
+
+**Forbidden phrasings unless OP explicitly asks or the page is clearly consumer ecommerce:**
+- *"Publish prices."*
+- *"Show exact pricing."*
+- *"Pricing is the biggest issue."*
+- *"Return policy is a top priority."*
+- *"Add a returns/warranty section."* (unless OP asks)
+
+For consumer-ecommerce sites (handmade, boutique, dropship, retail), pricing/returns advice IS allowed when grounded in the visual or text notes — same evidence-citation rule applies.
+
+## Visual-notes `questions[]` handling
+
+If `visual-notes.json` has a `questions[]` array, those are open questions the analyzer flagged. Do NOT surface them in `Best Pick` or `Shorter` (no "Open Qs:" tail blocks). Two paths:
+
+- If a question is genuinely load-bearing (the review can't usefully be completed without the answer), surface it in the optional `question` variant.
+- Otherwise, drop it. Open-question dumps make the comment feel like an audit.
 
 # Anti-tells (mandatory)
 
@@ -135,23 +188,26 @@ Never:
 - Sycophantic praise without substance
 - **Fabricate first-person experience.** "I ran the same kind of shop", "What worked for me was..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
 - **Reformat `best` as `structured-review`.** Adding "What works:" / "What I would fix:" headers around the same content is not depth, it's padding.
+- **Mobile claims from a desktop-only capture as a top fix.** See *Mobile-claim handling* above.
+- **Pricing/policy as a top fix on a B2B / quote-driven site.** See *B2B / quote-driven pricing & policy guidance* above.
+- **Bullet lists longer than 3 items in `Best Pick`.** If you have 4+ fixes, you are auditing — drop the weakest one.
+- **"Header is crowded" / "navigation feels cluttered" without specific evidence in visual notes.** Don't infer crowding from a screenshot the visual analyzer didn't flag — quote the analyzer's observation or skip the fix.
 
 Always:
 - Cite specific evidence — quote a heading, reference the meta description, paraphrase a visual observation
 - Be a constructive peer, not a consultant pitching a service
-- If the notes flag open questions and they're load-bearing, surface 1-2 so OP knows what would unlock better feedback
 - Keep critique kind but specific
 
 # Reasoning field — describe the angle, not the length
 
-The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is.
+The `reasoning` field on each draft should describe **why this angle fits this thread**, not how long the draft is. Reasoning is recorded in `drafts.json` for audit/debug — it does NOT appear in the rendered markdown the user sees.
 
 Good: "Leads with the highest-severity visual finding (no scale reference) and ties it to the thread's stated goal."
 Bad: "Provides a thorough multi-section review with structured headers."
 
 # Output
 
-Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array can have 2-4 entries depending on what fits.
+Return a single JSON object exactly matching this shape, no other fields. Omit variants you chose not to generate — the `drafts` array should have 2-3 entries (never 4+; emitting a full slate makes the output read like an audit).
 
 {
   "drafts": [

--- a/prompts/review_visual.tmpl
+++ b/prompts/review_visual.tmpl
@@ -77,6 +77,7 @@ For any other ShopType (dropship, b2b_industrial, saas, services, portfolio, unc
 - Do NOT infer behavior you can't see: checkout flow, page speed, mobile rendering not in the screenshot, conversion rates, inventory, prices not visible.
 - Do NOT fabricate observations. If the screenshot is partial or low-quality, list that in `limitations`.
 - Severity: `high` for observations that materially hurt trust or conversion; `medium` for clear-but-fixable issues; `low` for polish-level notes.
+- **Mobile-risk severity cap.** When the inspected screenshot is desktop-only (the typical Firecrawl `screenshot@fullPage` capture), `mobile_risk` observations may be inferred at best — never directly verified. Cap their severity at `medium`. If you list any `mobile_risk` observation, you MUST also add a matching note to `limitations` that mobile responsiveness was not directly inspected, so the downstream drafter can defensively skip mobile recommendations from desktop captures.
 - Recommendations should be one specific actionable change, not "improve your branding".
 
 # Output

--- a/reply/render.go
+++ b/reply/render.go
@@ -110,27 +110,32 @@ func alternatives(drafts []types.ReplyDraft, pickID string) []types.ReplyDraft {
 }
 
 // displayLabel maps known variant ids to their spec-mandated display
-// form. SPEC_REPLY_REFINEMENT.md (v2) "Output rendering" defines the
-// reply-mode forms and aligns review-mode labels (`shorter`/`question`
-// shared with reply mode; `structured-review` is review-only).
+// form. SPEC_REPLY_REFINEMENT.md "Output rendering" defines the
+// reply-mode forms; SPEC_REVIEW_DRAFT_REFINEMENT.md aligns review-mode
+// labels — `shorter` / `question` are shared with reply mode and
+// `structured-review` is review-only.
 //
-// Hyphen retention is per-label and intentional: compound modifiers
-// like "structured-review" keep the hyphen; the canonical "Warmer /
-// Personal" is rendered with explicit spacing per spec.
+// Display formatting is per-label and intentional: compound modifiers
+// stay hyphenated only when the hyphen reads as part of the adjective
+// (the now-removed legacy "Thread-Aware" was an example). The canonical
+// "Warmer / Personal" uses an explicit slash. The review-mode
+// `Structured Review` label is a noun phrase and uses a space, per
+// SPEC_REVIEW_DRAFT_REFINEMENT.md "Output rendering" — earlier code
+// rendered "Structured-Review" with a hyphen and was corrected.
 //
-// Old ids from earlier specs (short / thread-aware / personal-story /
-// question-first / detailed) are kept in the map so old session
+// Legacy ids from earlier specs (short / thread-aware / personal-story
+// / question-first / detailed) are kept in the map so old session
 // drafts.json files re-render with reasonable display labels. New
-// outputs use the v2 ids.
+// outputs use the current ids only.
 var displayLabel = map[string]string{
-	// v2 reply-mode (SPEC_REPLY_REFINEMENT.md)
+	// reply-mode (SPEC_REPLY_REFINEMENT.md)
 	"best":            "Best",
 	"shorter":         "Shorter",
 	"counterpoint":    "Counterpoint",
 	"warmer-personal": "Warmer / Personal",
 	"question":        "Question",
-	// review-mode-specific
-	"structured-review": "Structured-Review",
+	// review-mode (SPEC_REVIEW_DRAFT_REFINEMENT.md)
+	"structured-review": "Structured Review",
 	// Legacy ids preserved so old session re-renders aren't ugly. Not
 	// produced by current prompts; keep for backward-compat only.
 	"short":          "Short",

--- a/reply/render_test.go
+++ b/reply/render_test.go
@@ -193,8 +193,9 @@ func TestTitleCaseLabel(t *testing.T) {
 		{"counterpoint", "Counterpoint"},
 		{"warmer-personal", "Warmer / Personal"}, // explicit spacing per spec
 		{"question", "Question"},
-		// Review-mode-specific.
-		{"structured-review", "Structured-Review"},
+		// Review-mode-specific (SPEC_REVIEW_DRAFT_REFINEMENT.md). Renders
+		// with a space, not a hyphen — the spec calls it a noun phrase.
+		{"structured-review", "Structured Review"},
 		// Legacy ids preserved in the map for old session re-renders.
 		{"short", "Short"},
 		{"thread-aware", "Thread-Aware"},

--- a/reply/review_test.go
+++ b/reply/review_test.go
@@ -227,7 +227,12 @@ func TestRenderReviewPromptIncludesVisualNotes(t *testing.T) {
 		"no in-hand or scale shot",
 		"## Kova signals",
 		"texture invisible at the photo crops",
-		"do not recommend \"show your maker process\"", // gating rule appears in the prompt
+		// Per SPEC_REVIEW_DRAFT_REFINEMENT.md the Kova lens is reshaped per
+		// shop type — handmade/boutique gets the maker-process framing,
+		// other shop types get reshaped advice (real-use imagery, etc.)
+		// without that framing.
+		"\"show your maker process\"", // appears in both the handmade-allowed and B2B-forbidden contexts
+		"NOT \"show your maker process\"", // explicit reshape rule for B2B/SaaS/etc.
 	}
 	for _, s := range checks {
 		if !strings.Contains(prompt, s) {
@@ -260,5 +265,108 @@ func TestRenderReviewPromptOmitsEmptyCategories(t *testing.T) {
 		if strings.Contains(prompt, s) {
 			t.Errorf("category section %q should be omitted when empty", s)
 		}
+	}
+}
+
+// SPEC_REVIEW_DRAFT_REFINEMENT.md tightens review-mode drafting after
+// the PND fixture run produced an audit-shaped Best Pick with 5 fixes.
+// The prompt must now enforce: 2-3 fixes (hard cap), severity-based
+// ranking, mobile-claim handling for desktop-only captures, B2B
+// pricing/policy guardrails with concrete allowed/forbidden phrases,
+// reshaped Kova lens for non-handmade shop types, "Structured Review"
+// display label (space, not hyphen), and dropping visual-notes
+// questions[] from Best Pick / Shorter.
+func TestRenderReviewPromptIncludesV2RefinementRules(t *testing.T) {
+	in := sampleReviewInput()
+	in.Contexts = []types.LoadedReplyContext{{ID: "kova", Source: "bank", Body: "kova body content"}}
+
+	prompt, err := RenderReviewPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hard cap on fixes + tighter word budget for Best Pick.
+	hardCapChecks := []string{
+		"MAX 3 fixes",                 // explicit hard cap on Best Pick fix list
+		"150-260 words",               // tighter word budget than the old 150-300
+		"2-3 entries",                 // drafts array cap (down from 2-4)
+		"emitting a full slate makes", // failure-mode note guarding the cap
+	}
+	for _, s := range hardCapChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing hard-cap rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Severity-based ranking: only high/medium make Best Pick.
+	severityChecks := []string{
+		"Severity-based ranking",
+		"`severity` of `high` or `medium`",
+		"`severity=low`",       // demoted to structured-review only
+		"2 strong fixes beat 3 fixes where one is filler",
+	}
+	for _, s := range severityChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing severity rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Mobile-claim handling — defensive skip when limitations contradict.
+	mobileChecks := []string{
+		"Mobile-claim handling",
+		"Skip any `mobile_risk` observation",
+		"desktop-only inspection",
+	}
+	for _, s := range mobileChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing mobile rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// B2B pricing/policy rules with concrete allowed/forbidden phrases.
+	pricingChecks := []string{
+		"B2B / quote-driven pricing & policy guidance",
+		"If this is quote-only, make that explicit",
+		"Add MOQ / lead-time / spec-sheet expectations",
+		"Move the quote CTA to the product/category decision point",
+		"Forbidden phrasings",
+		"Publish prices.",
+		"Pricing is the biggest issue.",
+	}
+	for _, s := range pricingChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing pricing/policy rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Reshaped Kova lens — non-handmade shops still get visual-proof
+	// guidance, just without the maker-process framing.
+	kovaChecks := []string{
+		"Kova lens",
+		"reshaped",
+		"real-use imagery",
+		"workers wearing PPE",          // concrete B2B example
+		"reusable organic content",     // organic-content reuse angle
+	}
+	for _, s := range kovaChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing Kova-lens reshape rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Visual-notes questions[] handling — drop from Best Pick / Shorter.
+	if !strings.Contains(prompt, "Visual-notes `questions[]` handling") {
+		t.Errorf("review prompt missing visual-notes questions[] handling rule\n--- prompt ---\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "no \"Open Qs:\" tail blocks") {
+		t.Errorf("review prompt missing the explicit ban on Open Qs: tail blocks\n--- prompt ---\n%s", prompt)
+	}
+
+	// Display label rename — Structured Review (space) per spec.
+	if !strings.Contains(prompt, "displayed as **Structured Review**") {
+		t.Errorf("review prompt should reference 'Structured Review' (space, not hyphen)\n--- prompt ---\n%s", prompt)
+	}
+	if strings.Contains(prompt, "displayed as **Structured-Review**") {
+		t.Errorf("review prompt still references the legacy 'Structured-Review' (hyphen) form\n--- prompt ---\n%s", prompt)
 	}
 }

--- a/reply/visual_test.go
+++ b/reply/visual_test.go
@@ -213,6 +213,14 @@ func TestRenderVisualPromptIncludesKeyElements(t *testing.T) {
 		"kova_signals",
 		"do NOT pitch",     // anti-pitch rule
 		"Do NOT name the project", // explicit Kova rename ban
+		// SPEC_REVIEW_DRAFT_REFINEMENT.md tightens mobile_risk severity:
+		// from a desktop-only screenshot, mobile claims are inferred at
+		// best, so the analyzer must cap mobile_risk severity at medium
+		// and add a corresponding limitations note. This protects the
+		// downstream review drafter from getting "high"-severity mobile
+		// findings the user shouldn't surface as a top fix.
+		"Mobile-risk severity cap",
+		"Cap their severity at `medium`",
 	}
 	for _, s := range checks {
 		if !strings.Contains(prompt, s) {


### PR DESCRIPTION
## Summary

Implements `SPEC_REVIEW_DRAFT_REFINEMENT.md` (added to repo in this PR). The PND Industrial Suppliers fixture session showed the review drafter producing an audit-shaped Best Pick (5 fixes, pricing/policy on a B2B quote-driven site, mobile claims from a desktop-only capture). This tightens the drafter so review-mode output reads like a postable Reddit comment.

## What changes for the user

For the same PND-style B2B thread the user just ran:

**Before** — Best Pick had 5 fixes including "Address policy and pricing gaps" and "Reduce header overwhelm".
**After** — Best Pick is capped at MAX 3 fixes by leverage, severity-filtered (no `low`-severity findings), with reshaped Kova lens (real-use imagery / certification near category cards / "those visuals double as organic content") instead of the maker-process framing the B2B gate was silencing entirely.

## Specific changes

`prompts/review.tmpl`:

- **Hard cap MAX 3 fixes** in Best Pick (down from 2-4), 150-260 words (down from 150-300)
- **Drafts array 2-3** (down from 2-4) — full slate reads as audit
- **Severity-based ranking** — only `high`/`medium` make Best Pick; `low` only in `structured-review`
- **Mobile-claim handling** — when limitations note mobile was inferred, drafter skips `mobile_risk` from Best Pick regardless of severity
- **Reshaped Kova lens** — B2B/SaaS/services/portfolio still get visual-proof guidance (real-use imagery, certification visibility, organic-content reuse), just without "show your maker process" framing
- **B2B pricing/policy guardrails** — concrete allowed/forbidden phrase lists per spec
- **Visual-notes questions[] handling** — dropped from Best Pick/Shorter; only in `question` variant
- **Anti-tells expanded** — bullet lists >3 items; unsupported "header is crowded"; mobile claims from desktop capture; pricing/policy as top fix on B2B

`prompts/review_visual.tmpl`:

- **Mobile-risk severity cap** — desktop-only screenshots cap mobile_risk at `medium` and require a matching limitations entry. Belt-and-suspenders to the drafter-side filter.

`reply/render.go`:

- `displayLabel["structured-review"]`: `"Structured-Review"` → `"Structured Review"` (space, per spec)

## What's NOT in this PR (deferred)

- `visual-organic` slot — the spec floats this as optional. Reshaped Kova lens covers most of what it would address; keeping the variant-set tight matches the spec's "fewer drafts, distinct angles" philosophy.

## Test plan

- [x] `go test ./...` green
- [x] Review prompt asserts: MAX 3 fixes / 150-260 / 2-3 entries language present
- [x] Severity ranking rule present (`high`/`medium`-only for Best Pick, `severity=low` demoted)
- [x] Mobile-claim handling rule present
- [x] B2B pricing concrete allowed phrases ("If quote-only, make that explicit" / "Add MOQ / lead-time / spec-sheet expectations" / "Move the quote CTA to the product/category decision point")
- [x] B2B pricing concrete forbidden phrases ("Publish prices." / "Pricing is the biggest issue.")
- [x] Reshaped Kova lens has B2B examples (workers wearing PPE, real-use imagery, reusable organic content)
- [x] Visual-notes questions[] handling rule present, "Open Qs:" tail blocks banned
- [x] `Structured Review` (space) is the displayed label; legacy `Structured-Review` (hyphen) regression-guarded
- [x] Visual-analyzer prompt asserts mobile-risk severity cap
- [ ] Manual: rerun the PND ecommerce thread (`./tider reply --url=...1t06474... --context=kova --context=personal`) and verify (a) Best Pick has MAX 3 fixes, (b) no pricing/policy advice, (c) no "header overwhelm" claim, (d) no mobile recommendations as top fix, (e) Kova-shaped feedback (real-use imagery, certification-near-categories) appears for the B2B shop type

🤖 Generated with [Claude Code](https://claude.com/claude-code)