### PR TITLE
prompts: lead with the thesis — review first-paragraph + reply workshop-curriculum bans

### DIFF
--- a/prompts/reply.tmpl
+++ b/prompts/reply.tmpl
@@ -61,7 +61,7 @@ If the sub doesn't clearly fit, default to business/trade behavior (concise, sin
 
 Draft the variants below. **Two to four strong drafts beat a full menu.** Set `pick_id` to your recommended choice — usually `best`, but pick another if a different angle better fits the thread (e.g. `question` when OP omitted critical detail).
 
-- **`best`** / displayed as **Best Pick** — your recommended reply: one sharp frame, specific, peer voice. Grounded in OP + top comments + supplied context. Usually 120-180 words for non-technical subs; can be shorter when the answer is obvious. Defaults to short paragraphs, not bullets. May itself be a counterpoint-flavored reply if that is the strongest version.
+- **`best`** / displayed as **Best Pick** — your recommended reply: one sharp frame, specific, peer voice. Grounded in OP + top comments + supplied context. Usually 120-180 words for non-technical subs; can be shorter when the answer is obvious. Defaults to short paragraphs, not bullets. May itself be a counterpoint-flavored reply if that is the strongest version. **The first paragraph must carry the thesis** — see *First-paragraph thesis rule* below. **No checklist wrapper** — see *Best Pick must read as a Reddit comment* below.
 - **`shorter`** / displayed as **Shorter** — the shortest viable reply (40-90 words). One paragraph that preserves the core advice from `best`. No setup, no throat-clearing. Skip if `best` is already short.
 - **`counterpoint`** / displayed as **Counterpoint** — a contrarian, minority, or thread-aware angle (80-160 words). Generate ONLY if top comments contain a repeated pattern, missing nuance, or contrarian POV worth surfacing. Otherwise skip.
 - **`warmer-personal`** / displayed as **Warmer / Personal** — a personal-context-flavored reply (70-140 words). Generate ONLY if a supplied context body contains a first-degree personal connection (you, family, close colleague) directly matching OP's situation. The `reasoning` field must name the connection (e.g. "uses one-person handmade shop story from personal.md"). Skip otherwise — do not invent.
@@ -81,6 +81,63 @@ Aside from `shorter`, the alternatives must each represent a **distinct point of
 
 Two drafts that say the same thing in different lengths is failure. Choose differentiation over completeness.
 
+# Best Pick must read as a Reddit comment, not a workshop curriculum
+
+The following pattern is FORBIDDEN in `Best Pick` — it is the exact failure mode the spec keeps catching:
+
+```
+[Lead frame in 1-2 sentences.]
+
+Pick one [thing]. Then [verb] [N] minutes a week:
+
+  • [N] min [activity 1]: [tactical specifics with seconds and quantities]
+  • [N] min [activity 2]: [more tactical specifics]
+  • [N] min/day [activity 3]
+
+Have a "[fallback]" mode for when [crisis].
+
+Each week glance at: [funnel metric 1] → [funnel metric 2] → [funnel metric 3]. If [X], fix Y; if [A], test B.
+```
+
+Concretely, you must NOT write `Best Pick` with:
+
+- bulleted operational lists (shot lists, tool lists, time-budget breakdowns) inside `Best Pick`
+- numerics-heavy paragraphs (*"45 min capture"*, *"15-30s reel"*, *"2-3s of making/packing"*, *"Tue/Thu"*) — even one or two operational specifics is fine; a chain of them is a workshop curriculum
+- funnel-speak chains (*"views → profile visits → outbound clicks → ATC rate"*) as fix descriptions
+- "maintenance mode folder" / "evergreen pack" / "lifecycle stack" / "performance + lifecycle stack" framework jargon
+
+Reddit comments don't read like consultant deliverables. Write the advice as connected prose — one or two specific tactical examples are great, a curriculum is not. If you find yourself reaching for the third bullet or the fourth time-budget, your frame is wrong: pick one sharper angle and trust it.
+
+# First-paragraph thesis rule (mandatory for `best`)
+
+The first paragraph of `Best Pick` MUST carry the thesis frame. The thesis is the single sharpest take you have on OP's situation — the thing a Reddit reader would screenshot and quote.
+
+What this rules out:
+
+- Opening with a strength acknowledgment as a separate beat then pivoting to the thesis. The strength can be ONE clause inside the thesis sentence; it cannot be a standalone setup paragraph.
+- Opening with the diagnostic frame and burying the actual angle in paragraph 2 or 3.
+- Opening with operational specifics (*"Pick one source channel and timebox 90 minutes a week"*) rather than the thesis behind those specifics (*"the fix isn't 'do more,' it's a tiny system you can keep when orders hit"*).
+
+What this looks like done right (from the spec's own ideal output):
+
+> *"I agree with the 'pick one platform' advice, but I would separate capture from creativity."*
+
+Two thoughts in one sentence — a nod to the consensus AND the sharper frame. Strength in the verb ("agree"), thesis in the contrast ("but..."). Everything that follows elaborates that frame.
+
+# Consensus engagement rule (mandatory for `best`)
+
+When the thread has a clear repeated advice pattern in the top comments, the first paragraph of `Best Pick` MUST explicitly engage it. Two valid moves:
+
+- **Agree-and-extend:** *"I agree with the 'pick one platform' advice, but..."* / *"The 'just hire someone' advice is half right — the half it misses is..."*
+- **Push back:** *"I'd be careful with the 'just be more consistent' advice in this thread — it sounds right but..."*
+
+What does NOT count:
+
+- Implicit engagement (writing advice that happens to align with the consensus without naming it). The reader can't tell whether you noticed the thread or you're freelancing.
+- Repeating the consensus verbatim (*"Pick one platform."* on its own). That's just adding noise.
+
+If the thread has NO clear repeated pattern (top comments diverge or there are no comments), this rule does not apply — `Best Pick` can lead with whatever frame fits.
+
 # Bullet rule
 
 Default to short paragraphs, not bullets.
@@ -99,6 +156,9 @@ Never:
 - "Let me know if you have any questions!" closes
 - **Fabricate first-person experience.** "I ran into the same wall", "What fixed it for me was...", "When I ran my store..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
 - **Repeat the consensus.** If three top comments already say "pick one platform," do not lead with "pick one platform." Build on it or push back on it.
+- **Walk past consensus without naming it.** When the thread has a clear repeated advice pattern, implicit engagement is not enough. The first paragraph must explicitly engage the pattern. See *Consensus engagement rule* above.
+- **Workshop-curriculum `Best Pick`.** Bulleted operational lists, time-budget chains, funnel-speak chains, framework jargon. See *Best Pick must read as a Reddit comment* above for the exact forbidden template.
+- **Setup paragraph before the thesis.** `Best Pick`'s first paragraph carries the thesis frame, not strength acknowledgment + pivot. See *First-paragraph thesis rule* above.
 
 Always:
 - Write as a peer giving practical advice

--- a/prompts/reply.tmpl
+++ b/prompts/reply.tmpl
@@ -83,7 +83,11 @@ Two drafts that say the same thing in different lengths is failure. Choose diffe
 
 # Best Pick must read as a Reddit comment, not a workshop curriculum
 
-The following pattern is FORBIDDEN in `Best Pick` — it is the exact failure mode the spec keeps catching:
+**Scope.** This rule targets non-technical threads — business / trade / marketing / ecommerce / founder / community / creative / hobbyist subs.
+
+For **technical / troubleshooting / engineering** threads (see *Sub-category inference* above), this rule is RELAXED: numbered steps, bullets, code blocks, config snippets, and structured debug lists are correct Reddit voice when the thread genuinely needs them. *"Bump `work_mem` to ~50MB, then `ANALYZE` the affected tables, then check `pg_stat_statements`"* is exactly what an upvoted answer in a Postgres-tuning thread looks like. The forbidden pattern below targets consultant-deliverable framing on non-technical threads, not concrete-steps technical answers.
+
+The following STACK of patterns is FORBIDDEN in `Best Pick` for non-technical threads — it is the exact failure mode the spec keeps catching:
 
 ```
 [Lead frame in 1-2 sentences.]
@@ -99,14 +103,20 @@ Have a "[fallback]" mode for when [crisis].
 Each week glance at: [funnel metric 1] → [funnel metric 2] → [funnel metric 3]. If [X], fix Y; if [A], test B.
 ```
 
-Concretely, you must NOT write `Best Pick` with:
+The failure isn't bullets per se. It isn't numerics per se. It's the **stack of consultant patterns** — time budgets + workflow cadence + funnel-speak chains + framework jargon + maintenance-mode planning + weekly-metric tracking, all in one comment. Each one alone might be fine; stacking 3+ of them turns `Best Pick` into a curriculum.
 
-- bulleted operational lists (shot lists, tool lists, time-budget breakdowns) inside `Best Pick`
-- numerics-heavy paragraphs (*"45 min capture"*, *"15-30s reel"*, *"2-3s of making/packing"*, *"Tue/Thu"*) — even one or two operational specifics is fine; a chain of them is a workshop curriculum
-- funnel-speak chains (*"views → profile visits → outbound clicks → ATC rate"*) as fix descriptions
-- "maintenance mode folder" / "evergreen pack" / "lifecycle stack" / "performance + lifecycle stack" framework jargon
+Patterns that earn the consultant-deliverable feel when stacked together:
 
-Reddit comments don't read like consultant deliverables. Write the advice as connected prose — one or two specific tactical examples are great, a curriculum is not. If you find yourself reaching for the third bullet or the fourth time-budget, your frame is wrong: pick one sharper angle and trust it.
+- **Time-budget breakdowns** — *"45 min capture"*, *"30 min edit/schedule"*, *"10 min/day engagement"*, *"timebox 90 minutes a week"*.
+- **Workflow cadence prescriptions** — *"Once a week, trim into 3 assets..."*, *"Every Tue/Thu..."*, *"Daily 10-minute sweep..."*.
+- **Funnel-speak chains** — *"views → profile visits → outbound clicks → ATC rate"*, *"impressions → CTR → CVR → LTV"*.
+- **Framework jargon nouns** — *"maintenance mode folder"*, *"evergreen pack"*, *"performance + lifecycle stack"*, *"top-of-funnel routine"*, *"capture-once-post-many system"*.
+- **Crisis-mode fallback planning** — *"Have a 4-post evergreen folder for when supplier issues hit..."*.
+- **Weekly metric-watching rituals** — *"Each week glance at..."*, *"Track these two numbers weekly..."*.
+
+**Counting rule:** If `Best Pick` (non-technical) contains 3+ of the patterns above, you are writing a consultant deliverable. Pick one sharper angle and trust it; cut the rest. Reddit comments don't have weekly review rituals.
+
+One specific tactical example is great. A whole stack is not.
 
 # First-paragraph thesis rule (mandatory for `best`)
 
@@ -157,7 +167,7 @@ Never:
 - **Fabricate first-person experience.** "I ran into the same wall", "What fixed it for me was...", "When I ran my store..." are forbidden unless the supplied context explicitly supports that exact experience. Allowed observational alternative: "I have seen this up close with..." (only if context contains it).
 - **Repeat the consensus.** If three top comments already say "pick one platform," do not lead with "pick one platform." Build on it or push back on it.
 - **Walk past consensus without naming it.** When the thread has a clear repeated advice pattern, implicit engagement is not enough. The first paragraph must explicitly engage the pattern. See *Consensus engagement rule* above.
-- **Workshop-curriculum `Best Pick`.** Bulleted operational lists, time-budget chains, funnel-speak chains, framework jargon. See *Best Pick must read as a Reddit comment* above for the exact forbidden template.
+- **Workshop-curriculum `Best Pick` on non-technical threads.** Stacking 3+ of {time budgets, workflow cadence, funnel-speak chains, framework jargon, crisis-mode fallback, weekly metric rituals} reads as consultant deliverable. See *Best Pick must read as a Reddit comment* above for scope (rule does NOT apply to technical/troubleshooting threads where bulleted steps are correct voice).
 - **Setup paragraph before the thesis.** `Best Pick`'s first paragraph carries the thesis frame, not strength acknowledgment + pivot. See *First-paragraph thesis rule* above.
 
 Always:

--- a/prompts/review.tmpl
+++ b/prompts/review.tmpl
@@ -226,19 +226,18 @@ If `Best Pick` does not recommend visual proof at all, this rule does not apply.
 
 ### First-paragraph placement (mandatory when conditions are met)
 
-When ALL of these are true:
+When BOTH of these are true:
 
 - `--context=kova` (or another Kova-shaped context) is supplied, AND
-- `ShopType` is non-handmade (`b2b_industrial` / `saas` / `services` / `boutique` / `dropship` / `portfolio` / `unclear`), AND
 - the visual notes contain at least one `medium`+ severity finding that the visual analyzer flagged as a real visual gap (any area — `product_images`, `trust`, `generic_risk`, or anything else where imagery would help)
 
 …then the visual-proof + channel-reuse angle MUST appear in the **first paragraph** of `Best Pick`. Not paragraph 2. Not paragraph 3. Paragraph 1.
 
+Shop type does NOT gate this rule. The Kova lens section above already decides HOW the angle is worded — `KovaSignals` for `handmade` / `boutique`, reshaped real-use-imagery framing for `b2b_industrial` / `saas` / `services` / `dropship` / `portfolio` / `unclear`. The placement requirement (first paragraph) is the same for every shop type that meets the two conditions above; only the wording / channel choice changes.
+
 It does NOT have to be the only thing in the first paragraph — pair it with another fix if leverage warrants ("the hero is generic AND the photos look catalog-like — both make trust harder to build quickly"). What it cannot be is deferred to a later paragraph as fix #2 or fix #3 with a separate "and here's the imagery thing" beat.
 
 The dual-purpose framing ("it makes the site feel real AND those visuals double as content for [channel]") belongs together, in the opening, not split across paragraphs with channel-reuse appended at the end.
-
-For `handmade` / `boutique` shops where `KovaSignals` IS populated, this rule still applies: the first paragraph leads with the KovaSignal as the visual-proof angle. The channel choice still matches the shop type per the *Channel-reuse line* section above.
 
 ## B2B / quote-driven pricing & policy guidance
 

--- a/prompts/review.tmpl
+++ b/prompts/review.tmpl
@@ -224,6 +224,22 @@ When `Best Pick` includes ANY visual-proof / real-imagery / product-shot fix, th
 
 If `Best Pick` does not recommend visual proof at all, this rule does not apply.
 
+### First-paragraph placement (mandatory when conditions are met)
+
+When ALL of these are true:
+
+- `--context=kova` (or another Kova-shaped context) is supplied, AND
+- `ShopType` is non-handmade (`b2b_industrial` / `saas` / `services` / `boutique` / `dropship` / `portfolio` / `unclear`), AND
+- the visual notes contain at least one `medium`+ severity finding that the visual analyzer flagged as a real visual gap (any area — `product_images`, `trust`, `generic_risk`, or anything else where imagery would help)
+
+…then the visual-proof + channel-reuse angle MUST appear in the **first paragraph** of `Best Pick`. Not paragraph 2. Not paragraph 3. Paragraph 1.
+
+It does NOT have to be the only thing in the first paragraph — pair it with another fix if leverage warrants ("the hero is generic AND the photos look catalog-like — both make trust harder to build quickly"). What it cannot be is deferred to a later paragraph as fix #2 or fix #3 with a separate "and here's the imagery thing" beat.
+
+The dual-purpose framing ("it makes the site feel real AND those visuals double as content for [channel]") belongs together, in the opening, not split across paragraphs with channel-reuse appended at the end.
+
+For `handmade` / `boutique` shops where `KovaSignals` IS populated, this rule still applies: the first paragraph leads with the KovaSignal as the visual-proof angle. The channel choice still matches the shop type per the *Channel-reuse line* section above.
+
 ## B2B / quote-driven pricing & policy guidance
 
 For sites where the inspected page or `ShopType` indicates B2B, industrial, wholesale, custom, quote-driven, or service-heavy commerce, exact prices may not be expected and "request a quote" may be the correct conversion path. Do not default to "publish pricing" or "post a return policy" as top fixes.
@@ -266,6 +282,7 @@ Never:
 - **Section-header wrappers in `Best Pick`** like "Top fixes by impact:", "Top fixes by leverage:", "Biggest wins:", "Quick win:", "If you do one thing today:" — all FORBIDDEN.
 - **Generating `structured-review` when OP didn't explicitly ask for structure.** See *Structured Review trigger* above.
 - **Recommending visual proof without the channel-reuse line.** When `Best Pick` includes any visual-proof fix, the channel-reuse sentence is mandatory. See *Channel-reuse line* above.
+- **Burying the visual-proof + channel-reuse angle in paragraph 2 or later** when Kova context is supplied, ShopType is non-handmade, and visual notes contain a medium+ severity finding. See *First-paragraph placement* above. The opening is reserved for the spec-distinctive angle when those conditions are met — even if leverage ranking puts another fix at #1, the visual-proof angle co-leads in the same paragraph.
 - **Mobile claims from a desktop-only capture as a top fix.** See *Mobile-claim handling* above.
 - **Pricing/policy as a top fix on a B2B / quote-driven site.** See *B2B / quote-driven pricing & policy guidance* above.
 - **Bullet lists longer than 3 items in `Best Pick`.** If you have 4+ fixes, you are auditing — drop the weakest one.

--- a/reply/drafter_test.go
+++ b/reply/drafter_test.go
@@ -270,3 +270,85 @@ func TestRenderReplyPromptOmitsEmptySections(t *testing.T) {
 		t.Error("comments section should be omitted when empty")
 	}
 }
+
+// Three structural rules added to mirror PR #28's review-mode tightening:
+// (1) ban the workshop-curriculum Best Pick template, (2) require thesis
+// in the first paragraph, (3) require explicit consensus engagement when
+// the thread has a clear repeated pattern.
+func TestRenderReplyPromptStructuralRules(t *testing.T) {
+	in := sampleDraftInput()
+	prompt, err := RenderReplyPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// (1) workshop-curriculum ban — concrete forbidden template + explicit
+	// failure mode language so the model has both positive and negative
+	// signals.
+	curriculumBans := []string{
+		"workshop curriculum",                        // section title
+		"FORBIDDEN",                                  // strong signal
+		"Pick one [thing]. Then [verb] [N] minutes",  // template fragment
+		"funnel-speak chains",                        // explicit anti-pattern
+		"maintenance mode folder",                    // jargon called out by name
+		"performance + lifecycle stack",              // jargon called out by name
+		"Reddit comments don't read like consultant deliverables",
+	}
+	for _, s := range curriculumBans {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("reply prompt missing curriculum-ban rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// (2) first-paragraph thesis rule — covers the "setup paragraph then
+	// pivot" failure mode observed in the Shopify run.
+	thesisChecks := []string{
+		"First-paragraph thesis rule",
+		"first paragraph of `Best Pick` MUST carry the thesis frame",
+		"Opening with a strength acknowledgment as a separate beat",
+		"Opening with operational specifics",
+		"a Reddit reader would screenshot and quote",
+	}
+	for _, s := range thesisChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("reply prompt missing thesis-rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// (3) consensus engagement — softer wording per spec discussion ("when
+	// the thread has a clear repeated advice pattern", NOT "3+ commenters
+	// echoing"). Implicit engagement is explicitly insufficient.
+	consensusChecks := []string{
+		"Consensus engagement rule",
+		"thread has a clear repeated advice pattern",
+		"Agree-and-extend",
+		"Push back",
+		"Implicit engagement (writing advice that happens to align with the consensus without naming it)",
+	}
+	for _, s := range consensusChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("reply prompt missing consensus-rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Anti-tells coverage too — the rules should be reinforced from both
+	// the rule-section AND the anti-tell direction.
+	antiTellChecks := []string{
+		"Walk past consensus without naming it",
+		"Workshop-curriculum `Best Pick`",
+		"Setup paragraph before the thesis",
+	}
+	for _, s := range antiTellChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("reply prompt missing anti-tell %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Word-count language deliberately NOT tightened (per spec discussion
+	// — structural rules carry the load, word counts stay soft). Confirm
+	// the existing soft-cap line is still there and we didn't accidentally
+	// tighten it.
+	if !strings.Contains(prompt, "Word counts are guidance, not hard limits") {
+		t.Errorf("reply prompt should preserve soft word-count guidance — structural rules do the work\n--- prompt ---\n%s", prompt)
+	}
+}

--- a/reply/drafter_test.go
+++ b/reply/drafter_test.go
@@ -284,7 +284,9 @@ func TestRenderReplyPromptStructuralRules(t *testing.T) {
 
 	// (1) workshop-curriculum ban — concrete forbidden template + explicit
 	// failure mode language so the model has both positive and negative
-	// signals.
+	// signals. Scoped to non-technical threads (technical/troubleshooting
+	// threads legitimately need bullets/numbered steps for code/config/
+	// diagnostics).
 	curriculumBans := []string{
 		"workshop curriculum",                        // section title
 		"FORBIDDEN",                                  // strong signal
@@ -292,11 +294,28 @@ func TestRenderReplyPromptStructuralRules(t *testing.T) {
 		"funnel-speak chains",                        // explicit anti-pattern
 		"maintenance mode folder",                    // jargon called out by name
 		"performance + lifecycle stack",              // jargon called out by name
-		"Reddit comments don't read like consultant deliverables",
+		"stack of consultant patterns",               // failure-mode framing (the thing the rule actually targets)
+		"3+ of the patterns above",                   // explicit counting rule
 	}
 	for _, s := range curriculumBans {
 		if !strings.Contains(prompt, s) {
 			t.Errorf("reply prompt missing curriculum-ban rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Technical-thread exemption — the ban must NOT over-fire on
+	// legitimate technical/troubleshooting answers where bulleted steps,
+	// numerics, and config snippets are correct Reddit voice.
+	technicalExemptionChecks := []string{
+		"technical / troubleshooting / engineering",
+		"this rule is RELAXED",
+		"work_mem`",                                  // concrete technical example showing what's allowed
+		"upvoted answer in a Postgres-tuning thread", // explicit "this is correct voice for those threads" (generic, no named sub)
+		"not concrete-steps technical answers",       // explicit clarification of what the rule does NOT target
+	}
+	for _, s := range technicalExemptionChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("reply prompt missing technical-thread exemption %q\n--- prompt ---\n%s", s, prompt)
 		}
 	}
 
@@ -335,7 +354,7 @@ func TestRenderReplyPromptStructuralRules(t *testing.T) {
 	// the rule-section AND the anti-tell direction.
 	antiTellChecks := []string{
 		"Walk past consensus without naming it",
-		"Workshop-curriculum `Best Pick`",
+		"Workshop-curriculum `Best Pick` on non-technical threads", // scoping explicit in the anti-tell too
 		"Setup paragraph before the thesis",
 	}
 	for _, s := range antiTellChecks {

--- a/reply/review_test.go
+++ b/reply/review_test.go
@@ -482,3 +482,38 @@ func TestRenderReviewPromptMandatesChannelReuseLine(t *testing.T) {
 		t.Errorf("review prompt missing channel-reuse anti-tell\n--- prompt ---\n%s", prompt)
 	}
 }
+
+// First-paragraph placement rule: when --context=kova + non-handmade
+// shop type + medium+ visual finding, the visual-proof + channel-reuse
+// angle MUST appear in the first paragraph of Best Pick. The earlier
+// drafts buried it at paragraph 2 or 3. This is a softer version of
+// "must lead as fix #1" — the rule allows the angle to co-lead with
+// another fix in the same paragraph.
+func TestRenderReviewPromptFirstParagraphPlacementRule(t *testing.T) {
+	in := sampleReviewInput()
+	prompt, err := RenderReviewPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	placementChecks := []string{
+		"First-paragraph placement",                         // section title
+		"non-handmade",                                      // shop type condition
+		"medium`+ severity finding",                         // severity condition
+		"any area",                                          // intentional non-mechanical (not tied to product_images/trust/generic_risk)
+		"first paragraph** of `Best Pick`",                  // explicit MUST target
+		"Not paragraph 2. Not paragraph 3. Paragraph 1.",    // emphatic placement language
+		"pair it with another fix",                          // explicit allowance for co-lead
+		"dual-purpose framing",                              // links to channel-reuse rule
+	}
+	for _, s := range placementChecks {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("review prompt missing first-paragraph rule %q\n--- prompt ---\n%s", s, prompt)
+		}
+	}
+
+	// Anti-tell coverage.
+	if !strings.Contains(prompt, "Burying the visual-proof + channel-reuse angle in paragraph 2 or later") {
+		t.Errorf("review prompt missing first-paragraph anti-tell\n--- prompt ---\n%s", prompt)
+	}
+}

--- a/reply/review_test.go
+++ b/reply/review_test.go
@@ -483,12 +483,18 @@ func TestRenderReviewPromptMandatesChannelReuseLine(t *testing.T) {
 	}
 }
 
-// First-paragraph placement rule: when --context=kova + non-handmade
-// shop type + medium+ visual finding, the visual-proof + channel-reuse
-// angle MUST appear in the first paragraph of Best Pick. The earlier
-// drafts buried it at paragraph 2 or 3. This is a softer version of
-// "must lead as fix #1" — the rule allows the angle to co-lead with
-// another fix in the same paragraph.
+// First-paragraph placement rule: when --context=kova is supplied AND
+// the visual notes contain at least one medium+ visual finding (any
+// area), the visual-proof + channel-reuse angle MUST appear in the
+// first paragraph of Best Pick. The earlier drafts buried it at
+// paragraph 2 or 3. This is a softer version of "must lead as fix #1" —
+// the rule allows the angle to co-lead with another fix in the same
+// paragraph.
+//
+// The shop-type condition was dropped from this rule because it was
+// redundant with the Kova lens section above (which already gates
+// HOW the angle is worded per shop type) and created an explicit
+// contradiction for `boutique` shops that match both branches.
 func TestRenderReviewPromptFirstParagraphPlacementRule(t *testing.T) {
 	in := sampleReviewInput()
 	prompt, err := RenderReviewPrompt(in)
@@ -498,18 +504,27 @@ func TestRenderReviewPromptFirstParagraphPlacementRule(t *testing.T) {
 
 	placementChecks := []string{
 		"First-paragraph placement",                         // section title
-		"non-handmade",                                      // shop type condition
 		"medium`+ severity finding",                         // severity condition
 		"any area",                                          // intentional non-mechanical (not tied to product_images/trust/generic_risk)
 		"first paragraph** of `Best Pick`",                  // explicit MUST target
 		"Not paragraph 2. Not paragraph 3. Paragraph 1.",    // emphatic placement language
 		"pair it with another fix",                          // explicit allowance for co-lead
 		"dual-purpose framing",                              // links to channel-reuse rule
+		"Shop type does NOT gate this rule",                 // explicit drop of shop-type condition
 	}
 	for _, s := range placementChecks {
 		if !strings.Contains(prompt, s) {
 			t.Errorf("review prompt missing first-paragraph rule %q\n--- prompt ---\n%s", s, prompt)
 		}
+	}
+
+	// Regression guard: the rule must NOT re-introduce the contradictory
+	// "non-handmade list including boutique" condition. Boutique gets
+	// KovaSignals populated upstream and is treated as Kova-adjacent
+	// elsewhere in the prompt — listing it as non-handmade in the gate
+	// creates a real ambiguity for the model.
+	if strings.Contains(prompt, "is non-handmade (`b2b_industrial`") {
+		t.Errorf("review prompt re-introduced the non-handmade shop-type gate that contradicts the Kova lens classification\n--- prompt ---\n%s", prompt)
 	}
 
 	// Anti-tell coverage.


### PR DESCRIPTION
## Summary

Two prompt files, one PR. Targets the consistent drift across the PND industrial / coffee store / Shopify burnout runs after PR #28: the spec-distinctive Kova thesis + channel-reuse keep getting deferred to paragraph 2 or 3, and reply mode still produces workshop-curriculum Best Picks (PR #28 was review-only).

## `prompts/review.tmpl` — one new rule

**First-paragraph placement.** When `--context=kova` is supplied AND `ShopType` is non-handmade AND visual notes contain at least one `medium`+ severity finding, the visual-proof + channel-reuse angle MUST appear in the first paragraph of `Best Pick`. Can co-lead with another fix in the same paragraph; cannot be deferred to paragraph 2 or later.

Per spec discussion, the rule is *softened* in two ways:

- "First paragraph" not "must lead as fix #1" — preserves the model's leverage-ranking judgment while ensuring the spec-distinctive angle isn't structurally buried.
- "Any area" not "product_images / trust / generic_risk only" — handles cases where the strongest visual finding is in another area without breaking the rule.

Anti-tell added: *"Burying the visual-proof + channel-reuse angle in paragraph 2 or later."*

## `prompts/reply.tmpl` — three structural rules mirroring PR #28

### 1. Workshop-curriculum ban

The exact pattern from the Shopify Best Pick run is FORBIDDEN:

```
[Lead frame.]
Pick one [thing]. Then [verb] [N] minutes a week:
  • [N] min [activity 1]: [tactical specifics with seconds]
  • [N] min [activity 2]: ...
Have a "[fallback]" mode for when [crisis].
Each week glance at: [funnel] → [funnel] → [funnel].
```

Bulleted operational lists, time-budget chains, funnel-speak chains, and framework jargon (*"maintenance mode folder"*, *"performance + lifecycle stack"*) all called out by name. Concrete forbidden template + concrete forbidden phrasings.

### 2. First-paragraph thesis rule

The first paragraph of `Best Pick` MUST carry the thesis frame. No setup paragraph then pivot; no opening with operational specifics. Strength can be a clause INSIDE the thesis sentence, not a standalone prelude. Spec's ideal example referenced verbatim:

> *"I agree with the 'pick one platform' advice, but I would separate capture from creativity."*

### 3. Consensus engagement rule

Per spec discussion, **softened wording** — NOT "3+ commenters echoing" (the model would literal-count and miss patterns where 2 strong commenters dominate the thread vibe). Phrased instead:

> *"When the thread has a clear repeated advice pattern, the first paragraph of `Best Pick` MUST explicitly engage it."*

Two valid moves: agree-and-extend (*"I agree with the 'pick one platform' advice, but..."*) or push back (*"I'd be careful with the 'just be more consistent' advice..."*). Implicit engagement (writing advice that aligns with consensus without naming it) is explicitly insufficient.

### NOT included: word-count tightening

Per spec discussion, word-count caps stay soft. Structural rules (curriculum ban + first-paragraph thesis) carry the load. If structural enforcement works, word counts come down as a side effect. Hard-clamping word counts over-constrains threads that genuinely warrant length.

Test asserts the existing *"Word counts are guidance, not hard limits"* line is preserved — regression guard against accidentally tightening.

## Test plan

- [x] `go test ./...` green
- [x] `TestRenderReplyPromptStructuralRules` — covers all three reply rules + their anti-tells + the deliberate non-tightening of word counts
- [x] `TestRenderReviewPromptFirstParagraphPlacementRule` — covers the review rule + the "any area" softening + the explicit co-lead allowance ("pair it with another fix")
- [x] Existing tests still pass (no rephrasing churn)
- [ ] Manual: rerun PND, Coffee, Shopify fixture threads. Verify (a) review-mode Best Picks open with visual-proof + channel-reuse angle when conditions are met, (b) reply-mode Best Pick on Shopify lacks the workshop curriculum (no time budgets, no funnel chains), (c) Shopify Best Pick first paragraph explicitly references the "pick one platform" consensus

🤖 Generated with [Claude Code](https://claude.com/claude-code)