### PR TITLE
reply: feedback loop for posted text + outcomes (#36)

### DIFF
--- a/cmd/tider/reply_outcome.go
+++ b/cmd/tider/reply_outcome.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/reply"
+)
+
+var landedStates = []string{
+	"landed",
+	"ignored",
+	"too_long",
+	"too_generic",
+	"too_operational",
+	"too_soft",
+}
+
+var kovaSignals = []string{
+	"helped",
+	"hurt",
+	"neutral",
+}
+
+var replyOutcomeCmd = &cobra.Command{
+	Use:   "outcome <session-id>",
+	Short: "Record what happened 2-3 days after a posted reply",
+	Long: `Record the engagement outcome of a reply you posted earlier with
+` + "`tider reply post`" + `. Run this 2-3 days after posting, when
+upvotes / replies / engagement signals have settled.
+
+Requires post.json to already exist in the session — outcomes are
+relative to a recorded posting, not a draft.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReplyOutcome,
+}
+
+func init() {
+	replyCmd.AddCommand(replyOutcomeCmd)
+}
+
+func runReplyOutcome(cmd *cobra.Command, args []string) error {
+	sid := args[0]
+
+	root, err := reply.SessionsRoot()
+	if err != nil {
+		return err
+	}
+	sess, err := reply.ResolveSession(root, sid)
+	if err != nil {
+		return err
+	}
+
+	// Outcome only makes sense relative to a posted reply. Reject the
+	// outcome-before-post path explicitly so the user knows what to do
+	// next instead of getting a confusing missing-file error.
+	if !sess.HasFile("post.json") {
+		return fmt.Errorf("no post.json in session %s — record the posted reply first with `tider reply post %s`", filepath.Base(sess.Path()), filepath.Base(sess.Path()))
+	}
+
+	var post types.ReplyPost
+	if err := sess.LoadJSON("post.json", &post); err != nil {
+		return fmt.Errorf("read post.json: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "session: %s\n", filepath.Base(sess.Path()))
+	if post.ThreadURL != "" {
+		fmt.Fprintf(os.Stderr, "thread:  %s\n", post.ThreadURL)
+	}
+	if !post.PostedAt.IsZero() {
+		fmt.Fprintf(os.Stderr, "posted:  %s (%s ago)\n",
+			post.PostedAt.Local().Format("2006-01-02 15:04"),
+			humanAge(time.Since(post.PostedAt)))
+	}
+
+	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
+	fmt.Fprintln(os.Stderr, "posted reply:")
+	fmt.Fprintln(os.Stderr, post.FinalText)
+	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
+
+	if sess.HasFile("outcome.json") {
+		in := bufio.NewReader(os.Stdin)
+		ok, err := confirmYesNo(in, os.Stderr, "outcome.json already exists for this session. Overwrite?")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("aborted by user")
+		}
+	}
+
+	in := bufio.NewReader(os.Stdin)
+
+	upvotes, err := promptInt(in, os.Stderr, "upvotes / score: ")
+	if err != nil {
+		return err
+	}
+	opReplied, err := promptYesNo(in, os.Stderr, "did the OP reply?")
+	if err != nil {
+		return err
+	}
+	otherEngagement, err := promptYesNo(in, os.Stderr, "any other comment engagement (sub-thread, replies-to-your-reply, etc.)?")
+	if err != nil {
+		return err
+	}
+	landed, err := promptChoice(in, os.Stderr, "landed_state", landedStates)
+	if err != nil {
+		return err
+	}
+	kova, err := promptChoice(in, os.Stderr, "kova_signal (did the kova angle help, hurt, or stay neutral?)", kovaSignals)
+	if err != nil {
+		return err
+	}
+	note := promptLine(in, os.Stderr, "optional note (Enter to skip): ")
+
+	outcome := &types.ReplyOutcome{
+		SessionID:              filepath.Base(sess.Path()),
+		ThreadURL:              post.ThreadURL,
+		PostedAt:               post.PostedAt,
+		CheckedAt:              time.Now().UTC(),
+		Upvotes:                upvotes,
+		OPReplied:              opReplied,
+		OtherCommentEngagement: otherEngagement,
+		LandedState:            landed,
+		KovaSignal:             kova,
+		Note:                   strings.TrimSpace(note),
+	}
+	if err := sess.SaveOutcome(outcome); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "\nwrote %s\n", filepath.Join(sess.Path(), "outcome.json"))
+	return nil
+}
+
+// promptInt prompts for an integer. Empty input defaults to 0 (a posted
+// reply with no upvotes is a real signal, not a missing-data signal).
+func promptInt(in *bufio.Reader, out io.Writer, prompt string) (int, error) {
+	for {
+		fmt.Fprint(out, prompt)
+		line, err := in.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return 0, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return 0, nil
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			fmt.Fprintln(out, "  not a number, try again")
+			continue
+		}
+		return n, nil
+	}
+}
+
+// promptYesNo blocks until the user answers y/n. Empty input is rejected
+// — outcome capture is structured-by-design, so we want a real signal,
+// not a default-on-blank.
+func promptYesNo(in *bufio.Reader, out io.Writer, prompt string) (bool, error) {
+	for {
+		fmt.Fprintf(out, "%s [y/n]: ", prompt)
+		line, err := in.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return false, err
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		case "":
+			fmt.Fprintln(out, "  please answer y or n")
+		default:
+			fmt.Fprintln(out, "  please answer y or n")
+		}
+	}
+}
+
+// promptChoice presents a numbered list of options and parses a number
+// or exact-name reply. Loops until the user picks something valid —
+// outcome capture is meant to be structured.
+func promptChoice(in *bufio.Reader, out io.Writer, label string, options []string) (string, error) {
+	fmt.Fprintf(out, "\n%s:\n", label)
+	for i, o := range options {
+		fmt.Fprintf(out, "  %d) %s\n", i+1, o)
+	}
+	known := make(map[string]bool, len(options))
+	for _, o := range options {
+		known[o] = true
+	}
+	for {
+		fmt.Fprint(out, "select (number or name): ")
+		line, err := in.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		entry := strings.ToLower(strings.TrimSpace(line))
+		if entry == "" {
+			fmt.Fprintln(out, "  selection required")
+			continue
+		}
+		if n, err := strconv.Atoi(entry); err == nil {
+			if n >= 1 && n <= len(options) {
+				return options[n-1], nil
+			}
+			fmt.Fprintf(out, "  out of range (1-%d)\n", len(options))
+			continue
+		}
+		if known[entry] {
+			return entry, nil
+		}
+		fmt.Fprintln(out, "  not a valid option")
+	}
+}

--- a/cmd/tider/reply_outcome.go
+++ b/cmd/tider/reply_outcome.go
@@ -88,8 +88,15 @@ func runReplyOutcome(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(os.Stderr, post.FinalText)
 	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
 
+	// One bufio.Reader for the whole interactive path. bufio reads
+	// stdin in 4KB chunks and buffers anything past the first newline;
+	// instantiating a second reader (as we used to for the overwrite
+	// confirmation) drops those buffered bytes, so a piped answer
+	// stream like `y\n5\nyes\n...` would lose everything after `y\n`
+	// and the questionnaire would hit a spurious EOF.
+	in := bufio.NewReader(os.Stdin)
+
 	if sess.HasFile("outcome.json") {
-		in := bufio.NewReader(os.Stdin)
 		ok, err := confirmYesNo(in, os.Stderr, "outcome.json already exists for this session. Overwrite?")
 		if err != nil {
 			return err
@@ -98,8 +105,6 @@ func runReplyOutcome(cmd *cobra.Command, args []string) error {
 			return errors.New("aborted by user")
 		}
 	}
-
-	in := bufio.NewReader(os.Stdin)
 
 	upvotes, err := promptInt(in, os.Stderr, "upvotes / score: ")
 	if err != nil {

--- a/cmd/tider/reply_outcome.go
+++ b/cmd/tider/reply_outcome.go
@@ -167,6 +167,11 @@ func promptInt(in *bufio.Reader, out io.Writer, prompt string) (int, error) {
 // promptYesNo blocks until the user answers y/n. Empty input is rejected
 // — outcome capture is structured-by-design, so we want a real signal,
 // not a default-on-blank.
+//
+// On stdin EOF (closed pipe / non-interactive invocation) we abort
+// rather than re-prompt: ReadString returns "" + io.EOF immediately
+// and forever once the underlying file is exhausted, so a naive retry
+// loop spins indefinitely.
 func promptYesNo(in *bufio.Reader, out io.Writer, prompt string) (bool, error) {
 	for {
 		fmt.Fprintf(out, "%s [y/n]: ", prompt)
@@ -179,17 +184,19 @@ func promptYesNo(in *bufio.Reader, out io.Writer, prompt string) (bool, error) {
 			return true, nil
 		case "n", "no":
 			return false, nil
-		case "":
-			fmt.Fprintln(out, "  please answer y or n")
-		default:
-			fmt.Fprintln(out, "  please answer y or n")
 		}
+		if err == io.EOF {
+			return false, errors.New("stdin closed before yes/no answer")
+		}
+		fmt.Fprintln(out, "  please answer y or n")
 	}
 }
 
 // promptChoice presents a numbered list of options and parses a number
 // or exact-name reply. Loops until the user picks something valid —
 // outcome capture is meant to be structured.
+//
+// On stdin EOF we abort rather than re-prompt; see promptYesNo.
 func promptChoice(in *bufio.Reader, out io.Writer, label string, options []string) (string, error) {
 	fmt.Fprintf(out, "\n%s:\n", label)
 	for i, o := range options {
@@ -206,11 +213,8 @@ func promptChoice(in *bufio.Reader, out io.Writer, label string, options []strin
 			return "", err
 		}
 		entry := strings.ToLower(strings.TrimSpace(line))
-		if entry == "" {
-			fmt.Fprintln(out, "  selection required")
-			continue
-		}
-		if n, err := strconv.Atoi(entry); err == nil {
+
+		if n, atoiErr := strconv.Atoi(entry); atoiErr == nil {
 			if n >= 1 && n <= len(options) {
 				return options[n-1], nil
 			}
@@ -220,6 +224,14 @@ func promptChoice(in *bufio.Reader, out io.Writer, label string, options []strin
 		if known[entry] {
 			return entry, nil
 		}
-		fmt.Fprintln(out, "  not a valid option")
+
+		if err == io.EOF {
+			return "", fmt.Errorf("stdin closed before %s selection", label)
+		}
+		if entry == "" {
+			fmt.Fprintln(out, "  selection required")
+		} else {
+			fmt.Fprintln(out, "  not a valid option")
+		}
 	}
 }

--- a/cmd/tider/reply_outcome_test.go
+++ b/cmd/tider/reply_outcome_test.go
@@ -98,3 +98,49 @@ func TestPromptChoiceLoopsOnInvalid(t *testing.T) {
 		t.Errorf("got %q, want %q", got, landedStates[0])
 	}
 }
+
+func TestPromptYesNoAbortsOnEOF(t *testing.T) {
+	// Empty stdin (closed pipe) → ReadString returns "" + io.EOF
+	// repeatedly. Without an explicit EOF check, the retry loop would
+	// spin forever. Verify we abort with a clear error instead.
+	in := bufio.NewReader(strings.NewReader(""))
+	_, err := promptYesNo(in, io.Discard, "?")
+	if err == nil {
+		t.Fatal("expected error on EOF, got nil")
+	}
+	if !strings.Contains(err.Error(), "stdin closed") {
+		t.Errorf("expected stdin-closed error, got %v", err)
+	}
+}
+
+func TestPromptYesNoAbortsAfterInvalidThenEOF(t *testing.T) {
+	// First read returns garbage (re-prompt), second read is EOF — must
+	// abort, not spin.
+	in := bufio.NewReader(strings.NewReader("maybe\n"))
+	_, err := promptYesNo(in, io.Discard, "?")
+	if err == nil {
+		t.Fatal("expected error on EOF after invalid input, got nil")
+	}
+	if !strings.Contains(err.Error(), "stdin closed") {
+		t.Errorf("expected stdin-closed error, got %v", err)
+	}
+}
+
+func TestPromptChoiceAbortsOnEOF(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader(""))
+	_, err := promptChoice(in, io.Discard, "landed", landedStates)
+	if err == nil {
+		t.Fatal("expected error on EOF, got nil")
+	}
+	if !strings.Contains(err.Error(), "stdin closed") {
+		t.Errorf("expected stdin-closed error, got %v", err)
+	}
+}
+
+func TestPromptChoiceAbortsAfterInvalidThenEOF(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader("99\n"))
+	_, err := promptChoice(in, io.Discard, "landed", landedStates)
+	if err == nil {
+		t.Fatal("expected error on EOF after invalid input, got nil")
+	}
+}

--- a/cmd/tider/reply_outcome_test.go
+++ b/cmd/tider/reply_outcome_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestPromptIntDefaultsToZeroOnBlank(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader("\n"))
+	got, err := promptInt(in, io.Discard, "upvotes: ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0 {
+		t.Errorf("blank should default to 0, got %d", got)
+	}
+}
+
+func TestPromptIntRetriesOnBadInput(t *testing.T) {
+	// First line is junk → should reprompt and accept the second.
+	in := bufio.NewReader(strings.NewReader("not-a-number\n42\n"))
+	got, err := promptInt(in, io.Discard, "upvotes: ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 42 {
+		t.Errorf("got %d, want 42", got)
+	}
+}
+
+func TestPromptYesNoAcceptsBothForms(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"n\n", false},
+		{"no\n", false},
+	}
+	for _, c := range cases {
+		in := bufio.NewReader(strings.NewReader(c.input))
+		got, err := promptYesNo(in, io.Discard, "?")
+		if err != nil {
+			t.Fatalf("input=%q: %v", c.input, err)
+		}
+		if got != c.want {
+			t.Errorf("input=%q got %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+func TestPromptYesNoLoopsOnInvalid(t *testing.T) {
+	// "maybe" should reprompt; "y" closes the loop.
+	in := bufio.NewReader(strings.NewReader("maybe\ny\n"))
+	got, err := promptYesNo(in, io.Discard, "?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected true after retry")
+	}
+}
+
+func TestPromptChoiceByNumber(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader("3\n"))
+	got, err := promptChoice(in, io.Discard, "landed", landedStates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != landedStates[2] {
+		t.Errorf("got %q, want %q", got, landedStates[2])
+	}
+}
+
+func TestPromptChoiceByName(t *testing.T) {
+	in := bufio.NewReader(strings.NewReader("HELPED\n"))
+	got, err := promptChoice(in, io.Discard, "kova", kovaSignals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "helped" {
+		t.Errorf("got %q, want helped (case-insensitive name)", got)
+	}
+}
+
+func TestPromptChoiceLoopsOnInvalid(t *testing.T) {
+	// 99 → out of range, "garbage" → unknown, "1" → first option.
+	in := bufio.NewReader(strings.NewReader("99\ngarbage\n1\n"))
+	got, err := promptChoice(in, io.Discard, "landed", landedStates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != landedStates[0] {
+		t.Errorf("got %q, want %q", got, landedStates[0])
+	}
+}

--- a/cmd/tider/reply_outcome_test.go
+++ b/cmd/tider/reply_outcome_test.go
@@ -144,3 +144,73 @@ func TestPromptChoiceAbortsAfterInvalidThenEOF(t *testing.T) {
 		t.Fatal("expected error on EOF after invalid input, got nil")
 	}
 }
+
+// TestPromptsShareSingleReader exercises the full outcome questionnaire
+// sequence (overwrite confirm + upvotes + two yes/no + two choice +
+// note) against a single bufio.Reader, simulating piped answers. This
+// is the regression test for the bug where runReplyOutcome instantiated
+// a fresh bufio.Reader for the overwrite-confirm step and another for
+// the questionnaire — the first reader would buffer chunks past its
+// own newline and the second reader would lose those bytes, causing
+// later prompts to spuriously hit EOF.
+func TestPromptsShareSingleReader(t *testing.T) {
+	// Simulating: overwrite=y, upvotes=5, op_replied=y, other=n,
+	//             landed=1 ("landed"), kova=helped, note="quick note".
+	// All in one piped stream. If the bug returned, the second prompt
+	// onward would all see EOF.
+	input := "y\n5\ny\nn\n1\nhelped\nquick note\n"
+	in := bufio.NewReader(strings.NewReader(input))
+
+	overwrite, err := confirmYesNo(in, io.Discard, "overwrite?")
+	if err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	if !overwrite {
+		t.Error("overwrite should be true")
+	}
+
+	upvotes, err := promptInt(in, io.Discard, "upvotes: ")
+	if err != nil {
+		t.Fatalf("upvotes: %v", err)
+	}
+	if upvotes != 5 {
+		t.Errorf("upvotes = %d, want 5", upvotes)
+	}
+
+	opReplied, err := promptYesNo(in, io.Discard, "op replied?")
+	if err != nil {
+		t.Fatalf("op_replied: %v", err)
+	}
+	if !opReplied {
+		t.Error("op_replied should be true")
+	}
+
+	other, err := promptYesNo(in, io.Discard, "other engagement?")
+	if err != nil {
+		t.Fatalf("other: %v", err)
+	}
+	if other {
+		t.Error("other should be false")
+	}
+
+	landed, err := promptChoice(in, io.Discard, "landed", landedStates)
+	if err != nil {
+		t.Fatalf("landed: %v", err)
+	}
+	if landed != landedStates[0] {
+		t.Errorf("landed = %q, want %q", landed, landedStates[0])
+	}
+
+	kova, err := promptChoice(in, io.Discard, "kova", kovaSignals)
+	if err != nil {
+		t.Fatalf("kova: %v", err)
+	}
+	if kova != "helped" {
+		t.Errorf("kova = %q, want helped", kova)
+	}
+
+	note := promptLine(in, io.Discard, "note: ")
+	if note != "quick note" {
+		t.Errorf("note = %q, want %q", note, "quick note")
+	}
+}

--- a/cmd/tider/reply_post.go
+++ b/cmd/tider/reply_post.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/reply"
+)
+
+// editDeltaTags is the v1 list of "how did the posted text differ from
+// what tider drafted" tags presented at `tider reply post` time. Order
+// mirrors the issue clarification (#36 comment) so the menu numbering
+// stays stable across runs.
+var editDeltaTags = []string{
+	"keep-mostly-same",
+	"shorter",
+	"rewrote-thesis",
+	"dropped-checklist",
+	"added-personal-opener",
+	"added-kova",
+	"removed-kova",
+	"moved-earlier",
+	"more-direct",
+}
+
+var replyPostCmd = &cobra.Command{
+	Use:   "post <session-id>",
+	Short: "Record the final text that was actually posted to Reddit",
+	Long: `Record the reply you posted manually to Reddit, writing it back
+into the originating session under post.json.
+
+Workflow:
+  1. tider reply --url=...    (generates drafts)
+  2. you edit + post manually on reddit.com
+  3. tider reply post <session-id>   (paste final text, capture deltas)
+
+The session id is the directory name printed by the original
+` + "`tider reply`" + ` invocation, e.g. 2026-05-02-shopify-1abc23.
+Any unique substring (commonly just the postID) is also accepted.
+
+Paste your final reply when prompted; press Ctrl-D to end input.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReplyPost,
+}
+
+func init() {
+	replyCmd.AddCommand(replyPostCmd)
+}
+
+func runReplyPost(cmd *cobra.Command, args []string) error {
+	sid := args[0]
+
+	root, err := reply.SessionsRoot()
+	if err != nil {
+		return err
+	}
+	sess, err := reply.ResolveSession(root, sid)
+	if err != nil {
+		return err
+	}
+
+	// Best-effort thread load — drives the session header and the
+	// thread_url field on post.json. A failed-state session may have no
+	// thread.json, but we still allow `reply post` so the user can
+	// record what they actually wrote.
+	var thread types.Thread
+	hasThread := sess.LoadJSON("thread.json", &thread) == nil
+
+	fmt.Fprintf(os.Stderr, "session: %s\n", filepath.Base(sess.Path()))
+	if hasThread {
+		fmt.Fprintf(os.Stderr, "thread:  %s\n", thread.Title)
+		fmt.Fprintf(os.Stderr, "sub:     r/%s\n", thread.Subreddit)
+	}
+
+	// Use a single buffered reader for every interactive prompt so that
+	// subsequent line reads after the multiline paste don't race against
+	// each other on stdin.
+	in := bufio.NewReader(os.Stdin)
+
+	// Idempotency: existing post.json gets overwritten only with explicit
+	// confirmation. We want the loop to be append-friendly without
+	// silently destroying a prior capture.
+	if sess.HasFile("post.json") {
+		ok, err := confirmYesNo(in, os.Stderr, "post.json already exists for this session. Overwrite?")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("aborted by user")
+		}
+	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Paste the final posted reply. Press Ctrl-D when done.")
+	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
+
+	finalText, err := readMultiline(in)
+	if err != nil {
+		return fmt.Errorf("read reply text: %w", err)
+	}
+	finalText = strings.TrimRight(finalText, "\n")
+	if strings.TrimSpace(finalText) == "" {
+		return errors.New("no reply text captured")
+	}
+
+	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
+	fmt.Fprintln(os.Stderr, "captured:")
+	fmt.Fprintln(os.Stderr, finalText)
+	fmt.Fprintln(os.Stderr, strings.Repeat("─", 60))
+
+	// After Ctrl-D the underlying bufio.Reader is at EOF. Subsequent
+	// prompts re-read from os.Stdin directly via a fresh reader, which
+	// works in a TTY (the EOT only ends the current read) but will
+	// silently default for piped input. That's the right tradeoff: the
+	// piped case is "I have a script, just save the text" — no tags
+	// expected.
+	prompts := bufio.NewReader(os.Stdin)
+	feedback := promptTags(prompts, os.Stderr, editDeltaTags)
+	note := promptLine(prompts, os.Stderr, "optional note (Enter to skip): ")
+
+	threadURL := ""
+	if hasThread {
+		threadURL = thread.URL
+	}
+
+	post := &types.ReplyPost{
+		SessionID: filepath.Base(sess.Path()),
+		ThreadURL: threadURL,
+		FinalText: finalText,
+		PostedAt:  time.Now().UTC(),
+		Feedback:  feedback,
+		Note:      strings.TrimSpace(note),
+	}
+	if err := sess.SavePost(post); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "\nwrote %s\n", filepath.Join(sess.Path(), "post.json"))
+	if len(feedback) > 0 {
+		fmt.Fprintf(os.Stderr, "tags:  %s\n", strings.Join(feedback, ", "))
+	}
+	return nil
+}
+
+// readMultiline reads from r until EOF (Ctrl-D on a TTY) and returns the
+// accumulated text. Empty lines inside the text are preserved verbatim
+// because Reddit replies often contain paragraph breaks.
+func readMultiline(r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// confirmYesNo prompts for a yes/no answer. Treats blank as "no" — the
+// safer default for destructive operations like overwrite.
+func confirmYesNo(in *bufio.Reader, out io.Writer, prompt string) (bool, error) {
+	fmt.Fprintf(out, "%s [y/N]: ", prompt)
+	line, err := in.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// promptTags presents a numbered tag list and parses a comma-separated
+// selection (numbers or names). Empty input means "no tags". Unknown
+// entries are silently dropped — the loop stays light, the user can
+// re-run if they care about precision.
+func promptTags(in *bufio.Reader, out io.Writer, tags []string) []string {
+	fmt.Fprintln(out, "\nedit-delta tags (how did the posted text diverge from the draft?):")
+	for i, t := range tags {
+		fmt.Fprintf(out, "  %d) %s\n", i+1, t)
+	}
+	fmt.Fprintf(out, "select (comma-separated numbers or names, Enter to skip): ")
+
+	line, err := in.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return nil
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+
+	known := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		known[t] = true
+	}
+
+	var picked []string
+	seen := make(map[string]bool)
+	for _, raw := range strings.Split(line, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if n, err := strconv.Atoi(entry); err == nil {
+			if n >= 1 && n <= len(tags) {
+				tag := tags[n-1]
+				if !seen[tag] {
+					picked = append(picked, tag)
+					seen[tag] = true
+				}
+			}
+			continue
+		}
+		entry = strings.ToLower(entry)
+		if known[entry] && !seen[entry] {
+			picked = append(picked, entry)
+			seen[entry] = true
+		}
+	}
+	return picked
+}
+
+// promptLine prints a prompt and reads one line from in. EOF (piped
+// stdin already drained) returns empty silently — the caller decides
+// whether emptiness is OK.
+func promptLine(in *bufio.Reader, out io.Writer, prompt string) string {
+	fmt.Fprint(out, prompt)
+	line, err := in.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return ""
+	}
+	return strings.TrimRight(line, "\n")
+}

--- a/cmd/tider/reply_post_test.go
+++ b/cmd/tider/reply_post_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPromptTagsParsesNumbersAndNames(t *testing.T) {
+	tags := []string{"keep-mostly-same", "shorter", "rewrote-thesis", "more-direct"}
+
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"single number", "2\n", []string{"shorter"}},
+		{"multiple numbers", "1,3\n", []string{"keep-mostly-same", "rewrote-thesis"}},
+		{"name", "more-direct\n", []string{"more-direct"}},
+		{"mixed name and number", "shorter, 3\n", []string{"shorter", "rewrote-thesis"}},
+		{"dedupe", "2,2,shorter\n", []string{"shorter"}},
+		{"out of range silently dropped", "99,1\n", []string{"keep-mostly-same"}},
+		{"unknown name silently dropped", "garbage,shorter\n", []string{"shorter"}},
+		{"empty returns nil", "\n", nil},
+		{"whitespace returns nil", "  \n", nil},
+		{"case-insensitive name", "SHORTER\n", []string{"shorter"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := bufio.NewReader(strings.NewReader(c.input))
+			got := promptTags(in, io.Discard, tags)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("input=%q got %v, want %v", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+func TestConfirmYesNoDefaultsToNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},      // blank → no (safer default for overwrite)
+		{"garbage\n", false}, // anything else → no
+	}
+	for _, c := range cases {
+		in := bufio.NewReader(strings.NewReader(c.input))
+		got, err := confirmYesNo(in, io.Discard, "overwrite?")
+		if err != nil {
+			t.Fatalf("input=%q: %v", c.input, err)
+		}
+		if got != c.want {
+			t.Errorf("input=%q got %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+func TestReadMultilinePreservesBlankLines(t *testing.T) {
+	// Reddit replies routinely contain paragraph breaks; the spec calls
+	// out that blank-line termination is wrong because of this. Verify
+	// blank lines round-trip.
+	input := "first paragraph\n\nsecond paragraph\n\n  indented line\n"
+	got, err := readMultiline(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != input {
+		t.Errorf("body changed: %q vs %q", got, input)
+	}
+}

--- a/cmd/tider/reply_recent.go
+++ b/cmd/tider/reply_recent.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/reply"
+)
+
+const outcomeDueAfter = 48 * time.Hour
+
+var replyRecentLimit int
+
+var replyRecentCmd = &cobra.Command{
+	Use:   "recent",
+	Short: "List recent reply sessions with their lifecycle status",
+	Long: `Show the most recent reply sessions, newest first. Useful for
+finding the right session id to feed to ` + "`tider reply post`" + ` or
+` + "`tider reply outcome`" + `.
+
+Status values:
+  drafted          drafts.json exists, no post.json yet
+  posted           post.json exists, no outcome.json yet
+  outcome-recorded outcome.json exists
+  failed           session dir exists but drafts.json was never written
+
+Posted sessions older than 48h are also flagged "outcome-due" — that's
+when the post is mature enough for engagement signals to settle.`,
+	RunE: runReplyRecent,
+}
+
+func init() {
+	replyRecentCmd.Flags().IntVarP(&replyRecentLimit, "limit", "n", 10, "max sessions to display (newest first)")
+	replyCmd.AddCommand(replyRecentCmd)
+}
+
+func runReplyRecent(cmd *cobra.Command, args []string) error {
+	root, err := reply.SessionsRoot()
+	if err != nil {
+		return err
+	}
+	sessions, err := reply.ListSessions(root, replyRecentLimit)
+	if err != nil {
+		return err
+	}
+	if len(sessions) == 0 {
+		fmt.Fprintln(os.Stderr, "no reply sessions found at", root)
+		return nil
+	}
+
+	now := time.Now()
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SESSION\tSUB\tMODE\tAGE\tSTATUS\tTITLE")
+	for _, s := range sessions {
+		row := buildRecentRow(s, now)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.id, row.sub, row.mode, row.age, row.status, row.title)
+	}
+	return w.Flush()
+}
+
+type recentRow struct {
+	id     string
+	sub    string
+	mode   string
+	age    string
+	status string
+	title  string
+}
+
+// buildRecentRow assembles one display row from a session directory by
+// reading whatever metadata is on disk. Each load is best-effort because
+// older / failed sessions may be missing thread.json or mode.json — the
+// row should still render with hyphens for the missing columns rather
+// than crashing the whole listing.
+func buildRecentRow(s *reply.Session, now time.Time) recentRow {
+	id := filepath.Base(s.Path())
+	row := recentRow{
+		id:     id,
+		sub:    "-",
+		mode:   "-",
+		title:  "-",
+		status: string(s.Status()),
+	}
+
+	var thread types.Thread
+	if err := s.LoadJSON("thread.json", &thread); err == nil {
+		if thread.Subreddit != "" {
+			row.sub = "r/" + thread.Subreddit
+		}
+		if thread.Title != "" {
+			row.title = truncate(thread.Title, 60)
+		}
+	}
+
+	var mode types.ReplyModeResult
+	if err := s.LoadJSON("mode.json", &mode); err == nil && mode.Mode != "" {
+		row.mode = string(mode.Mode)
+	}
+
+	// Age: prefer Generated time on the bundle (drafter completion is
+	// the canonical "session became useful" moment), fall back to dir
+	// mtime which NewSession sets at create time.
+	created := dirMTime(s.Path(), now)
+	var bundle types.ReplyBundle
+	if err := s.LoadJSON("drafts.json", &bundle); err == nil && !bundle.Generated.IsZero() {
+		created = bundle.Generated
+	}
+	row.age = humanAge(now.Sub(created))
+
+	// Outcome-due annotation: posted but past the 48h soak window. Only
+	// applies to "posted" — drafted/failed haven't reached that stage,
+	// outcome-recorded is past it.
+	if row.status == string(reply.SessionStatusPosted) {
+		var post types.ReplyPost
+		postedAt := created
+		if err := s.LoadJSON("post.json", &post); err == nil && !post.PostedAt.IsZero() {
+			postedAt = post.PostedAt
+		}
+		if now.Sub(postedAt) >= outcomeDueAfter {
+			row.status = row.status + " (outcome-due)"
+		}
+	}
+
+	return row
+}
+
+func dirMTime(path string, fallback time.Time) time.Time {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fallback
+	}
+	return fi.ModTime()
+}
+
+// humanAge renders a duration as a single-unit, coarse-grained label
+// like "3h" or "2d". The recent list is for at-a-glance triage, not
+// exact times — precision past the leading unit is noise.
+func humanAge(d time.Duration) string {
+	if d < time.Minute {
+		return "just now"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\t", " ")
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/cmd/tider/reply_recent_test.go
+++ b/cmd/tider/reply_recent_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+	"github.com/viggy28/tider/reply"
+)
+
+func TestBuildRecentRowDraftedNoMode(t *testing.T) {
+	// Drafted-state session (drafts.json present, no post.json). Should
+	// surface mode + sub + title from the session files, status=drafted,
+	// no outcome-due annotation.
+	root := t.TempDir()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s, err := reply.NewSession(root, "shopify", "abc123", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveThread(&types.Thread{Subreddit: "shopify", PostID: "abc123", Title: "Help with my store"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveMode(&types.ReplyModeResult{Mode: types.ReplyModeReply}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveDrafts(&types.ReplyBundle{Mode: types.ReplyModeReply, Generated: now}); err != nil {
+		t.Fatal(err)
+	}
+
+	row := buildRecentRow(s, now.Add(2*time.Hour))
+	if row.status != string(reply.SessionStatusDrafted) {
+		t.Errorf("status = %q, want drafted", row.status)
+	}
+	if row.sub != "r/shopify" {
+		t.Errorf("sub = %q, want r/shopify", row.sub)
+	}
+	if row.mode != "reply" {
+		t.Errorf("mode = %q, want reply", row.mode)
+	}
+	if !strings.Contains(row.title, "Help with my store") {
+		t.Errorf("title = %q, want containing 'Help with my store'", row.title)
+	}
+	if row.age != "2h" {
+		t.Errorf("age = %q, want 2h", row.age)
+	}
+}
+
+func TestBuildRecentRowFailedSession(t *testing.T) {
+	// Session dir exists (e.g. review-mode bailed at inspection) with
+	// only thread.json + mode.json. No drafts.json → status=failed.
+	root := t.TempDir()
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s, err := reply.NewSession(root, "shopify", "fail1", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveThread(&types.Thread{Subreddit: "shopify", PostID: "fail1", Title: "T"}); err != nil {
+		t.Fatal(err)
+	}
+
+	row := buildRecentRow(s, now)
+	if row.status != string(reply.SessionStatusFailed) {
+		t.Errorf("status = %q, want failed", row.status)
+	}
+}
+
+func TestBuildRecentRowOutcomeDueAfter48h(t *testing.T) {
+	root := t.TempDir()
+	postedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s, err := reply.NewSession(root, "shopify", "old1", postedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveThread(&types.Thread{Subreddit: "shopify", PostID: "old1", Title: "T"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveDrafts(&types.ReplyBundle{Mode: types.ReplyModeReply, Generated: postedAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePost(&types.ReplyPost{
+		SessionID: filepath.Base(s.Path()),
+		FinalText: "x",
+		PostedAt:  postedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 50 hours later — past the 48h soak window.
+	row := buildRecentRow(s, postedAt.Add(50*time.Hour))
+	if !strings.Contains(row.status, "outcome-due") {
+		t.Errorf("expected outcome-due annotation after 48h, got %q", row.status)
+	}
+}
+
+func TestBuildRecentRowPostedNotYetDue(t *testing.T) {
+	root := t.TempDir()
+	postedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s, err := reply.NewSession(root, "shopify", "fresh1", postedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveDrafts(&types.ReplyBundle{Mode: types.ReplyModeReply, Generated: postedAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePost(&types.ReplyPost{
+		SessionID: filepath.Base(s.Path()),
+		FinalText: "x",
+		PostedAt:  postedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 12h later — well within the soak window, no annotation.
+	row := buildRecentRow(s, postedAt.Add(12*time.Hour))
+	if strings.Contains(row.status, "outcome-due") {
+		t.Errorf("did not expect outcome-due before 48h, got %q", row.status)
+	}
+	if row.status != string(reply.SessionStatusPosted) {
+		t.Errorf("status = %q, want posted", row.status)
+	}
+}
+
+func TestBuildRecentRowOutcomeRecordedNoAnnotation(t *testing.T) {
+	// outcome-recorded should not get the outcome-due annotation even
+	// if the post is old — the loop is closed.
+	root := t.TempDir()
+	postedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	s, err := reply.NewSession(root, "shopify", "done1", postedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveDrafts(&types.ReplyBundle{Mode: types.ReplyModeReply, Generated: postedAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePost(&types.ReplyPost{SessionID: filepath.Base(s.Path()), FinalText: "x", PostedAt: postedAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveOutcome(&types.ReplyOutcome{
+		SessionID:   filepath.Base(s.Path()),
+		PostedAt:    postedAt,
+		CheckedAt:   postedAt.Add(72 * time.Hour),
+		LandedState: "landed",
+		KovaSignal:  "neutral",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	row := buildRecentRow(s, postedAt.Add(72*time.Hour))
+	if row.status != string(reply.SessionStatusOutcomeRecorded) {
+		t.Errorf("status = %q, want outcome-recorded", row.status)
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{5 * time.Minute, "5m"},
+		{59 * time.Minute, "59m"},
+		{1 * time.Hour, "1h"},
+		{23 * time.Hour, "23h"},
+		{24 * time.Hour, "1d"},
+		{72 * time.Hour, "3d"},
+	}
+	for _, c := range cases {
+		if got := humanAge(c.d); got != c.want {
+			t.Errorf("humanAge(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"short", 60, "short"},
+		{"a long title that should be truncated at the boundary", 20, "a long title that s…"},
+		{"with\ttab", 60, "with tab"}, // tabs replaced for tabwriter safety
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.n); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.n, got, c.want)
+		}
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -443,3 +443,39 @@ type InspectionSummary struct {
 	ShopType       string   `json:"shop_type,omitempty"`
 	Limitations    []string `json:"limitations,omitempty"`
 }
+
+// ReplyPost records the final reply text the user actually posted, plus
+// edit-delta tags describing how it diverged from the generated drafts.
+// Written by `tider reply post <session-id>` into the same session
+// directory as drafts.json. SessionID is duplicated into the payload so
+// the file is portable / indexable independent of its parent directory.
+//
+// SourceDraftID is intentionally optional: in v1 the user pastes the
+// final text directly without selecting a draft, since the common
+// workflow is "generate drafts → modify manually → post the result".
+type ReplyPost struct {
+	SessionID     string    `json:"session_id"`
+	ThreadURL     string    `json:"thread_url"`
+	SourceDraftID string    `json:"source_draft_id,omitempty"`
+	FinalText     string    `json:"final_text"`
+	PostedAt      time.Time `json:"posted_at"`
+	Feedback      []string  `json:"feedback,omitempty"`
+	Note          string    `json:"note,omitempty"`
+}
+
+// ReplyOutcome captures what happened to a posted reply 2-3 days later.
+// Written by `tider reply outcome <session-id>` and requires a prior
+// post.json in the same session — outcomes only make sense relative to
+// something that was actually posted.
+type ReplyOutcome struct {
+	SessionID              string    `json:"session_id"`
+	ThreadURL              string    `json:"thread_url"`
+	PostedAt               time.Time `json:"posted_at"`
+	CheckedAt              time.Time `json:"checked_at"`
+	Upvotes                int       `json:"upvotes"`
+	OPReplied              bool      `json:"op_replied"`
+	OtherCommentEngagement bool      `json:"other_comment_engagement"`
+	LandedState            string    `json:"landed_state"` // landed|ignored|too_long|too_generic|too_operational|too_soft
+	KovaSignal             string    `json:"kova_signal"`  // helped|hurt|neutral
+	Note                   string    `json:"note,omitempty"`
+}

--- a/reply/session.go
+++ b/reply/session.go
@@ -188,6 +188,17 @@ func ResolveSession(root, idOrSubstring string) (*Session, error) {
 		return nil, errors.New("session id required")
 	}
 
+	// Reject path-traversal-y inputs before we touch the filesystem.
+	// Session ids are plain directory names (date-sub-postid, possibly
+	// with -2/-3 collision suffixes); anything containing a path
+	// separator or ".." is either a typo or an attempt to walk out of
+	// the sessions root. filepath.Join silently collapses ".." segments,
+	// so without this guard `tider reply post ../../foo` would resolve
+	// to a directory outside ~/.tider/sessions/replies/ on Stat.
+	if strings.ContainsAny(idOrSubstring, `/\`) || strings.Contains(idOrSubstring, "..") {
+		return nil, fmt.Errorf("invalid session id %q: must be a plain directory name", idOrSubstring)
+	}
+
 	// Exact match first.
 	exact := filepath.Join(root, idOrSubstring)
 	if fi, err := os.Stat(exact); err == nil && fi.IsDir() {

--- a/reply/session.go
+++ b/reply/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -143,4 +144,151 @@ func (s *Session) SaveDrafts(b *types.ReplyBundle) error {
 
 func (s *Session) SaveOutput(md string) error {
 	return s.WriteMarkdown("output.md", md)
+}
+
+func (s *Session) SavePost(p *types.ReplyPost) error {
+	return s.WriteJSON("post.json", p)
+}
+
+func (s *Session) SaveOutcome(o *types.ReplyOutcome) error {
+	return s.WriteJSON("outcome.json", o)
+}
+
+// HasFile reports whether <name> exists in the session directory.
+func (s *Session) HasFile(name string) bool {
+	_, err := os.Stat(filepath.Join(s.Dir, name))
+	return err == nil
+}
+
+// LoadJSON reads <name> from the session directory and unmarshals into v.
+func (s *Session) LoadJSON(name string, v any) error {
+	data, err := os.ReadFile(filepath.Join(s.Dir, name))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("unmarshal %s: %w", name, err)
+	}
+	return nil
+}
+
+// ResolveSession finds a session under root by an exact directory name
+// or unique substring match. Returns the matched session, or an error
+// listing the candidates if the substring matches more than one.
+//
+// Substring (rather than strict prefix) is the contract because the
+// canonical id format is date-sub-postid: users naturally remember the
+// postID, which sits at the *end* of the slug, so a strict prefix rule
+// would reject the most common shorthand. Exact match wins over
+// substring to avoid surprises when one id happens to be a substring
+// of another.
+func ResolveSession(root, idOrSubstring string) (*Session, error) {
+	idOrSubstring = strings.TrimSpace(idOrSubstring)
+	if idOrSubstring == "" {
+		return nil, errors.New("session id required")
+	}
+
+	// Exact match first.
+	exact := filepath.Join(root, idOrSubstring)
+	if fi, err := os.Stat(exact); err == nil && fi.IsDir() {
+		return &Session{Dir: exact}, nil
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no sessions found at %s (have you run `tider reply --url=...` yet?)", root)
+		}
+		return nil, fmt.Errorf("read sessions root: %w", err)
+	}
+
+	var matches []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if strings.Contains(e.Name(), idOrSubstring) {
+			matches = append(matches, e.Name())
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no session matching %q under %s", idOrSubstring, root)
+	case 1:
+		return &Session{Dir: filepath.Join(root, matches[0])}, nil
+	default:
+		return nil, fmt.Errorf("ambiguous session id %q matches %d candidates:\n  %s", idOrSubstring, len(matches), strings.Join(matches, "\n  "))
+	}
+}
+
+// SessionStatus reports the lifecycle stage of a session based on which
+// artifacts are on disk. The values map directly to what `reply recent`
+// displays.
+type SessionStatus string
+
+const (
+	SessionStatusFailed          SessionStatus = "failed"
+	SessionStatusDrafted         SessionStatus = "drafted"
+	SessionStatusPosted          SessionStatus = "posted"
+	SessionStatusOutcomeRecorded SessionStatus = "outcome-recorded"
+)
+
+// Status inspects the session directory and returns the current stage.
+// Order matters: outcome > post > drafts > failed.
+func (s *Session) Status() SessionStatus {
+	switch {
+	case s.HasFile("outcome.json"):
+		return SessionStatusOutcomeRecorded
+	case s.HasFile("post.json"):
+		return SessionStatusPosted
+	case s.HasFile("drafts.json"):
+		return SessionStatusDrafted
+	default:
+		return SessionStatusFailed
+	}
+}
+
+// ListSessions returns every session under root, newest first, capped at
+// limit (limit <= 0 means no cap). Newest is determined by the session
+// directory's mtime, which is set when the directory is created in
+// NewSession and stable across subsequent file writes inside it.
+func ListSessions(root string, limit int) ([]*Session, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read sessions root: %w", err)
+	}
+
+	type entryInfo struct {
+		name    string
+		modTime time.Time
+	}
+	infos := make([]entryInfo, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+		infos = append(infos, entryInfo{name: e.Name(), modTime: fi.ModTime()})
+	}
+
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].modTime.After(infos[j].modTime)
+	})
+
+	if limit > 0 && len(infos) > limit {
+		infos = infos[:limit]
+	}
+
+	sessions := make([]*Session, 0, len(infos))
+	for _, info := range infos {
+		sessions = append(sessions, &Session{Dir: filepath.Join(root, info.name)})
+	}
+	return sessions, nil
 }

--- a/reply/session_resolve_test.go
+++ b/reply/session_resolve_test.go
@@ -1,0 +1,258 @@
+package reply
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+func TestResolveSessionExactMatch(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	s, err := NewSession(root, "shopify", "abc123", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveSession(root, filepath.Base(s.Path()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path() != s.Path() {
+		t.Errorf("got %s, want %s", got.Path(), s.Path())
+	}
+}
+
+func TestResolveSessionSubstringMatch(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	s, err := NewSession(root, "shopify", "xyz789", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Substring match — user remembers just the postID, which lives at
+	// the end of the canonical slug (date-sub-postid), so a strict
+	// prefix rule would reject this common case.
+	got, err := ResolveSession(root, "xyz789")
+	if err != nil {
+		t.Fatalf("expected match, got %v", err)
+	}
+	if got.Path() != s.Path() {
+		t.Errorf("got %s, want %s", got.Path(), s.Path())
+	}
+}
+
+func TestResolveSessionAmbiguousErrors(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	if _, err := NewSession(root, "shopify", "abc123", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewSession(root, "shopify", "abc123", now); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two same-day collisions produce abc123 and abc123-2 — the
+	// substring "shopify" matches both.
+	_, err := ResolveSession(root, "shopify")
+	if err == nil {
+		t.Fatal("expected ambiguous-match error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should mention ambiguity, got: %v", err)
+	}
+}
+
+func TestResolveSessionNoMatch(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	if _, err := NewSession(root, "shopify", "abc123", now); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveSession(root, "definitely-not-here")
+	if err == nil {
+		t.Fatal("expected no-match error")
+	}
+}
+
+func TestResolveSessionEmptyID(t *testing.T) {
+	root := t.TempDir()
+	_, err := ResolveSession(root, "")
+	if err == nil {
+		t.Fatal("expected error for empty id")
+	}
+	_, err = ResolveSession(root, "   ")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only id")
+	}
+}
+
+func TestResolveSessionMissingRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := ResolveSession(missing, "anything")
+	if err == nil {
+		t.Fatal("expected error when root does not exist")
+	}
+}
+
+func TestSessionStatusProgression(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewSession(root, "shopify", "abc", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty session — no drafts.json yet — counts as failed.
+	if got := s.Status(); got != SessionStatusFailed {
+		t.Errorf("empty session status = %s, want %s", got, SessionStatusFailed)
+	}
+
+	// drafted: drafts.json present.
+	if err := s.SaveDrafts(&types.ReplyBundle{Mode: types.ReplyModeReply}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Status(); got != SessionStatusDrafted {
+		t.Errorf("after drafts.json, status = %s, want %s", got, SessionStatusDrafted)
+	}
+
+	// posted: post.json present.
+	if err := s.SavePost(&types.ReplyPost{SessionID: filepath.Base(s.Path()), FinalText: "hi", PostedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Status(); got != SessionStatusPosted {
+		t.Errorf("after post.json, status = %s, want %s", got, SessionStatusPosted)
+	}
+
+	// outcome-recorded: outcome.json present (highest priority).
+	if err := s.SaveOutcome(&types.ReplyOutcome{SessionID: filepath.Base(s.Path()), CheckedAt: time.Now(), LandedState: "landed", KovaSignal: "neutral"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Status(); got != SessionStatusOutcomeRecorded {
+		t.Errorf("after outcome.json, status = %s, want %s", got, SessionStatusOutcomeRecorded)
+	}
+}
+
+func TestListSessionsNewestFirstAndLimit(t *testing.T) {
+	root := t.TempDir()
+
+	// Create three sessions with separate mtimes so ordering is
+	// deterministic regardless of filesystem timestamp granularity.
+	mkSession := func(sub, postID string, mtime time.Time) string {
+		s, err := NewSession(root, sub, postID, mtime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Stamp the directory mtime explicitly — NewSession sets it to
+		// "now" implicitly, which collapses on fast machines.
+		if err := os.Chtimes(s.Path(), mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+		return filepath.Base(s.Path())
+	}
+
+	t1 := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	oldest := mkSession("a", "p1", t1)
+	mid := mkSession("b", "p2", t2)
+	newest := mkSession("c", "p3", t3)
+
+	got, err := ListSessions(root, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(got))
+	}
+	if filepath.Base(got[0].Path()) != newest {
+		t.Errorf("newest first: got[0] = %s, want %s", filepath.Base(got[0].Path()), newest)
+	}
+	if filepath.Base(got[2].Path()) != oldest {
+		t.Errorf("oldest last: got[2] = %s, want %s", filepath.Base(got[2].Path()), oldest)
+	}
+
+	// Limit=2 returns only the two newest, dropping the oldest.
+	got2, err := ListSessions(root, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) != 2 {
+		t.Fatalf("limit=2: got %d, want 2", len(got2))
+	}
+	if filepath.Base(got2[0].Path()) != newest || filepath.Base(got2[1].Path()) != mid {
+		t.Errorf("limit=2 ordering wrong: %s, %s", filepath.Base(got2[0].Path()), filepath.Base(got2[1].Path()))
+	}
+}
+
+func TestListSessionsEmptyRoot(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-sessions-yet")
+	got, err := ListSessions(missing, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("missing root should return nil, got %v", got)
+	}
+}
+
+func TestSavePostAndOutcomeRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	s, err := NewSession(root, "shopify", "abc", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	post := &types.ReplyPost{
+		SessionID: filepath.Base(s.Path()),
+		ThreadURL: "https://reddit.com/r/shopify/comments/abc/x",
+		FinalText: "the actual posted reply\n\nwith blank lines",
+		PostedAt:  time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC),
+		Feedback:  []string{"shorter", "added-personal-opener"},
+		Note:      "removed the checklist at the end",
+	}
+	if err := s.SavePost(post); err != nil {
+		t.Fatal(err)
+	}
+
+	var got types.ReplyPost
+	if err := s.LoadJSON("post.json", &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.FinalText != post.FinalText {
+		t.Errorf("final_text round-trip lost data: %q", got.FinalText)
+	}
+	if len(got.Feedback) != 2 || got.Feedback[0] != "shorter" {
+		t.Errorf("feedback round-trip wrong: %v", got.Feedback)
+	}
+
+	outcome := &types.ReplyOutcome{
+		SessionID:              filepath.Base(s.Path()),
+		ThreadURL:              post.ThreadURL,
+		PostedAt:               post.PostedAt,
+		CheckedAt:              time.Date(2026, 5, 4, 9, 0, 0, 0, time.UTC),
+		Upvotes:                12,
+		OPReplied:              true,
+		OtherCommentEngagement: false,
+		LandedState:            "landed",
+		KovaSignal:             "helped",
+		Note:                   "OP asked a follow-up about pricing",
+	}
+	if err := s.SaveOutcome(outcome); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotOutcome types.ReplyOutcome
+	if err := s.LoadJSON("outcome.json", &gotOutcome); err != nil {
+		t.Fatal(err)
+	}
+	if gotOutcome.Upvotes != 12 || gotOutcome.LandedState != "landed" || gotOutcome.KovaSignal != "helped" {
+		t.Errorf("outcome round-trip wrong: %+v", gotOutcome)
+	}
+}

--- a/reply/session_resolve_test.go
+++ b/reply/session_resolve_test.go
@@ -101,6 +101,39 @@ func TestResolveSessionMissingRoot(t *testing.T) {
 	}
 }
 
+func TestResolveSessionRejectsPathTraversal(t *testing.T) {
+	// Defense against the path-traversal class of inputs. Without the
+	// guard, filepath.Join collapses ".." segments and the exact-match
+	// branch would happily Stat outside the sessions root — letting
+	// `tider reply post ../../foo` operate on arbitrary directories.
+	root := t.TempDir()
+	if _, err := NewSession(root, "shopify", "abc123", time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []string{
+		"../foo",
+		"../../etc",
+		"foo/bar",
+		"foo\\bar",
+		"..",
+		"foo/../bar",
+		"/absolute/path",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := ResolveSession(root, in)
+			if err == nil {
+				t.Errorf("expected error for traversal-y input %q", in)
+				return
+			}
+			if !strings.Contains(err.Error(), "invalid session id") {
+				t.Errorf("expected invalid-session-id error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestSessionStatusProgression(t *testing.T) {
 	root := t.TempDir()
 	s, err := NewSession(root, "shopify", "abc", time.Now())


### PR DESCRIPTION
## Summary
- Adds `tider reply post`, `tider reply recent`, `tider reply outcome` subcommands under `reply`. Existing `tider reply --url=...` flow is unchanged.
- `post.json` captures final posted text + edit-delta tags + optional note. `source_draft_id` empty in v1 (final text is the truth, forcing draft selection is noise).
- `outcome.json` captures structured engagement signals (upvotes, op_replied, other_comment_engagement, landed_state, kova_signal, note). Rejects outcome-before-post.
- `reply recent` lists sessions newest-first with `drafted | posted | outcome-recorded | failed` status; annotates posted rows ≥48h old with `outcome-due`.
- Session resolver accepts full id or any unique substring (substring not strict prefix — postID lives at the *end* of the canonical `date-sub-postid` slug). Ambiguous matches error and list candidates.

Closes #36.

## Test plan
- [x] `go test ./...` — all green; new tests cover resolver (exact / substring / ambiguous / missing), status progression, listing + ordering + limit, recent-row builder including 48h annotation logic, age formatting, post-tag parsing (numbers, names, mixed, dedupe, unknowns), yes/no defaults, choice-prompt loops, blank-line preservation in pasted reply text.
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [ ] Manual: run `tider reply --url=...` against a thread, copy session id, exercise `tider reply post <id>`, paste a multi-paragraph reply, confirm `post.json` contents.
- [ ] Manual: re-run `tider reply post <id>` and confirm overwrite prompt fires.
- [ ] Manual: `tider reply outcome <id>` before `post.json` exists rejects cleanly.
- [ ] Manual: `tider reply recent` shows expected status transitions and 48h annotation.

## Notes
- Resolved-clarifications and substring-contract addendum live in #36 comments.
- No new external deps. No new prompts. No Reddit write surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)