### PR TITLE
reply: enforce three-variant contract on regen output

### DIFF
--- a/prompts/reply_regen.tmpl
+++ b/prompts/reply_regen.tmpl
@@ -74,7 +74,7 @@ Return a single JSON object with exactly these three drafts, in this order, with
 
 - **`best`** — your recommended reply, fully obeying the operator note. One sharp frame, peer voice, grounded in the thread. The first paragraph carries the thesis. No fabricated first-person experience.
 - **`shorter`** — tightest viable version of `best` that preserves the core advice. One paragraph. No setup, no throat-clearing.
-- **`question`** — leads with a single clarifying question that would unblock genuinely better advice. Short (30-80 words). Skip only if the operator note explicitly says no question variant; otherwise always emit it.
+- **`question`** — leads with a single clarifying question that would unblock genuinely better advice. Short (30-80 words). Always emit this variant; the three-variant contract is unconditional.
 
 Word counts are guidance, not hard limits.
 

--- a/reply/regen.go
+++ b/reply/regen.go
@@ -87,13 +87,13 @@ func GenerateReplyRegen(ctx context.Context, p llm.Provider, model string, input
 	if err := json.Unmarshal([]byte(resp.Content), &raw); err != nil {
 		return nil, fmt.Errorf("reply regen: parse json: %w (model returned: %q)", err, truncate(resp.Content, 200))
 	}
-	if len(raw.Drafts) == 0 {
-		return nil, fmt.Errorf("reply regen: no drafts returned (model output: %q)", truncate(resp.Content, 200))
+	if err := validateRegenDrafts(raw.Drafts); err != nil {
+		return nil, fmt.Errorf("reply regen: %w (model returned: %q)", err, truncate(resp.Content, 200))
 	}
 
 	pickID := raw.PickID
 	if pickID == "" {
-		pickID = raw.Drafts[0].ID
+		pickID = "best"
 	}
 
 	return &types.ReplyBundle{
@@ -104,6 +104,50 @@ func GenerateReplyRegen(ctx context.Context, p llm.Provider, model string, input
 		PickID:    pickID,
 		Generated: time.Now().UTC(),
 	}, nil
+}
+
+// regenRequiredIDs is the v1 stable variant set. Codified here so the
+// validator is the single source of truth — the prompt template, the
+// renderer, and downstream consumers all assume this exact set.
+var regenRequiredIDs = []string{"best", "shorter", "question"}
+
+// validateRegenDrafts enforces the three-variant contract on whatever
+// the model returned. Failing loud here matters because a malformed
+// bundle that slips through would still be written to
+// regens/<ts>.json and history.jsonl — leaving a broken artifact in
+// the audit log that downstream tooling can't reason about.
+//
+// Checks:
+//  1. Exactly three drafts (not 2, not 4 — the contract is fixed).
+//  2. The IDs are exactly {best, shorter, question}, deduplicated.
+//
+// Order is not enforced — the renderer doesn't depend on it, and the
+// model occasionally swaps positions even when the IDs are right.
+func validateRegenDrafts(drafts []types.ReplyDraft) error {
+	if len(drafts) != len(regenRequiredIDs) {
+		return fmt.Errorf("expected %d drafts (best, shorter, question); got %d", len(regenRequiredIDs), len(drafts))
+	}
+	seen := make(map[string]bool, len(drafts))
+	for _, d := range drafts {
+		if seen[d.ID] {
+			return fmt.Errorf("duplicate draft id %q", d.ID)
+		}
+		seen[d.ID] = true
+	}
+	for _, want := range regenRequiredIDs {
+		if !seen[want] {
+			return fmt.Errorf("missing required draft id %q (got %v)", want, draftIDs(drafts))
+		}
+	}
+	return nil
+}
+
+func draftIDs(drafts []types.ReplyDraft) []string {
+	ids := make([]string, 0, len(drafts))
+	for _, d := range drafts {
+		ids = append(ids, d.ID)
+	}
+	return ids
 }
 
 // RenderRegenPrompt exposes the rendered prompt for inspection/tests

--- a/reply/regen_test.go
+++ b/reply/regen_test.go
@@ -133,6 +133,14 @@ func TestRenderRegenPromptIncludesNoteAndPrecedence(t *testing.T) {
 			t.Errorf("rendered prompt missing variant id %q", id)
 		}
 	}
+
+	// Pin that the contract is unconditional — the prompt must NOT
+	// hedge with "skip only if" language for any variant. v1 fork B
+	// resolved this as "Generate 3 variants, not one" with no escape
+	// hatch; the validator backs this up at the code level.
+	if strings.Contains(strings.ToLower(got), "skip only if") {
+		t.Errorf("prompt contains hedging skip clause; the three-variant contract should be unconditional")
+	}
 }
 
 func TestRenderRegenPromptIncludesPreviousDrafts(t *testing.T) {
@@ -215,14 +223,111 @@ func TestGenerateReplyRegenJSONParseError(t *testing.T) {
 }
 
 func TestGenerateReplyRegenEmptyDrafts(t *testing.T) {
+	// Empty drafts now flows through the variant-set validator: we
+	// expect a "got 0, want 3" error rather than the old "no drafts
+	// returned" message. The validator is the single source of truth
+	// for the contract.
 	p := &fakeProvider{name: "fake", response: `{"drafts":[],"pick_id":""}`}
 
 	_, err := GenerateReplyRegen(context.Background(), p, "gpt-5", sampleRegenInput(), 0)
 	if err == nil {
 		t.Fatal("expected error for empty drafts")
 	}
-	if !strings.Contains(err.Error(), "no drafts returned") {
-		t.Errorf("expected no-drafts error, got %v", err)
+	if !strings.Contains(err.Error(), "got 0") {
+		t.Errorf("expected got-0 count error, got %v", err)
+	}
+}
+
+func TestGenerateReplyRegenRejectsWrongCount(t *testing.T) {
+	// Two drafts where three are required — the model dropped a
+	// variant. The bundle must not be saved; the user should see a
+	// clear error and rerun rather than silently get a malformed
+	// regen artifact in their session.
+	resp := `{
+	  "drafts": [
+	    {"id":"best","label":"best","text":"x","reasoning":"r"},
+	    {"id":"shorter","label":"shorter","text":"y","reasoning":"r"}
+	  ],
+	  "pick_id": "best"
+	}`
+	p := &fakeProvider{name: "fake", response: resp}
+
+	_, err := GenerateReplyRegen(context.Background(), p, "gpt-5", sampleRegenInput(), 0)
+	if err == nil {
+		t.Fatal("expected error for 2 drafts when 3 are required")
+	}
+	if !strings.Contains(err.Error(), "expected 3 drafts") || !strings.Contains(err.Error(), "got 2") {
+		t.Errorf("expected count-mismatch error, got %v", err)
+	}
+}
+
+func TestGenerateReplyRegenRejectsExtraDraft(t *testing.T) {
+	// Four drafts (model leaked a `counterpoint` from the original
+	// drafter's vocabulary). Same reject-and-fail-loud expectation.
+	resp := `{
+	  "drafts": [
+	    {"id":"best","label":"best","text":"x","reasoning":"r"},
+	    {"id":"shorter","label":"shorter","text":"y","reasoning":"r"},
+	    {"id":"question","label":"question","text":"z","reasoning":"r"},
+	    {"id":"counterpoint","label":"counterpoint","text":"w","reasoning":"r"}
+	  ],
+	  "pick_id": "best"
+	}`
+	p := &fakeProvider{name: "fake", response: resp}
+
+	_, err := GenerateReplyRegen(context.Background(), p, "gpt-5", sampleRegenInput(), 0)
+	if err == nil {
+		t.Fatal("expected error for 4 drafts")
+	}
+	if !strings.Contains(err.Error(), "got 4") {
+		t.Errorf("expected count-mismatch error, got %v", err)
+	}
+}
+
+func TestGenerateReplyRegenRejectsUnexpectedID(t *testing.T) {
+	// Right count, wrong ID — `warmer-personal` belongs to the
+	// initial drafter's vocabulary and isn't part of the v1 stable
+	// regen set. Validator must reject so downstream tooling that
+	// assumes {best, shorter, question} stays sound.
+	resp := `{
+	  "drafts": [
+	    {"id":"best","label":"best","text":"x","reasoning":"r"},
+	    {"id":"shorter","label":"shorter","text":"y","reasoning":"r"},
+	    {"id":"warmer-personal","label":"warmer-personal","text":"z","reasoning":"r"}
+	  ],
+	  "pick_id": "best"
+	}`
+	p := &fakeProvider{name: "fake", response: resp}
+
+	_, err := GenerateReplyRegen(context.Background(), p, "gpt-5", sampleRegenInput(), 0)
+	if err == nil {
+		t.Fatal("expected error for unexpected draft id")
+	}
+	if !strings.Contains(err.Error(), `missing required draft id "question"`) {
+		t.Errorf("expected missing-question error, got %v", err)
+	}
+}
+
+func TestGenerateReplyRegenRejectsDuplicateID(t *testing.T) {
+	// Three drafts but two share an id. Validator catches this so a
+	// regen artifact can't pretend to satisfy the contract while
+	// silently dropping a variant.
+	resp := `{
+	  "drafts": [
+	    {"id":"best","label":"best","text":"x","reasoning":"r"},
+	    {"id":"best","label":"best","text":"x2","reasoning":"r"},
+	    {"id":"question","label":"question","text":"z","reasoning":"r"}
+	  ],
+	  "pick_id": "best"
+	}`
+	p := &fakeProvider{name: "fake", response: resp}
+
+	_, err := GenerateReplyRegen(context.Background(), p, "gpt-5", sampleRegenInput(), 0)
+	if err == nil {
+		t.Fatal("expected error for duplicate draft id")
+	}
+	if !strings.Contains(err.Error(), `duplicate draft id "best"`) {
+		t.Errorf("expected duplicate-id error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related fixes for `tider reply regen` (#41 / #42 follow-up).

**Prompt contradiction.** `prompts/reply_regen.tmpl` said "Return a single JSON object with exactly these three drafts" and a few lines later hedged "Skip only if the operator note explicitly says no question variant" on the `question` variant. Those two sentences cannot both be true. Resolved fork B from the issue was unconditional ("Generate 3 variants, not one"); the skip clause was a hedge I added without checking. Removed.

**Contract not enforced in code.** `reply/regen.go` only checked `len(drafts) > 0`. A model that returned 2 drafts, 4 drafts, an unknown id like `warmer-personal` (from the original drafter's vocabulary), or a duplicate id would still be saved to `regens/<ts>.json` and get a `history.jsonl` event pointing at it — leaving a broken artifact in the audit log. Added `validateRegenDrafts`:

1. exactly 3 drafts (fixed count, not a minimum)
2. exactly the set `{best, shorter, question}`, deduplicated
3. order not enforced (renderer doesn't depend on it)

On any violation the bundle is not saved and the model's actual output is included in the error so the user can rerun. `pick_id` now defaults to `"best"` rather than `drafts[0].ID` since the validator guarantees `best` is present.

## Test plan
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] Wrong count (2 drafts) → error (`TestGenerateReplyRegenRejectsWrongCount`)
- [x] Wrong count (4 drafts) → error (`TestGenerateReplyRegenRejectsExtraDraft`)
- [x] Unexpected id `warmer-personal` → "missing required draft id" error (`TestGenerateReplyRegenRejectsUnexpectedID`)
- [x] Duplicate id → "duplicate draft id" error (`TestGenerateReplyRegenRejectsDuplicateID`)
- [x] Prompt no longer contains "skip only if" hedge (`TestRenderRegenPromptIncludesNoteAndPrecedence`)
- [x] Existing 3-variant happy path still passes
- [x] No regressions in initial drafter / post / outcome / recent / mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)