### PR TITLE
retry: bounce transient 5xx in llm provider + firecrawl (#38, #39)

### DIFF
--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	anthropicDefaultBaseURL = "https://api.anthropic.com"
-	anthropicAPIVersion     = "2023-06-01"
+	anthropicDefaultBaseURL  = "https://api.anthropic.com"
+	anthropicAPIVersion      = "2023-06-01"
 	anthropicJSONInstruction = "Respond with a single valid JSON value only. No prose, no markdown fences, no commentary."
 )
 
@@ -139,11 +139,13 @@ func (a *Anthropic) Complete(ctx context.Context, req Request) (*Response, error
 	respBody, _ := io.ReadAll(httpResp.Body)
 
 	if httpResp.StatusCode != http.StatusOK {
+		herr := &HTTPError{Provider: "anthropic", StatusCode: httpResp.StatusCode, Body: string(respBody)}
 		var ae anthropicErrorResponse
 		if err := json.Unmarshal(respBody, &ae); err == nil && ae.Error.Message != "" {
-			return nil, fmt.Errorf("anthropic %d %s: %s", httpResp.StatusCode, ae.Error.Type, ae.Error.Message)
+			herr.ErrType = ae.Error.Type
+			herr.Message = ae.Error.Message
 		}
-		return nil, fmt.Errorf("anthropic %d: %s", httpResp.StatusCode, string(respBody))
+		return nil, herr
 	}
 
 	var resp anthropicResponse

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -16,18 +16,29 @@ type TaskConfig struct {
 	Model    string
 }
 
-// New constructs the provider implied by cfg.
+// New constructs the provider implied by cfg, wrapped with retry on
+// transient 5xx + 429 responses so every call site (draft, regen,
+// classifier, intake, research) is resilient to upstream provider
+// hiccups without needing per-caller retry plumbing.
 func New(cfg Config) (Provider, error) {
+	var (
+		p   Provider
+		err error
+	)
 	switch cfg.Provider {
 	case "anthropic":
-		return NewAnthropic(cfg.Model)
+		p, err = NewAnthropic(cfg.Model)
 	case "openai":
-		return NewOpenAI(cfg.Model)
+		p, err = NewOpenAI(cfg.Model)
 	case "":
 		return nil, fmt.Errorf("llm: provider not configured")
 	default:
 		return nil, fmt.Errorf("llm: unknown provider %q", cfg.Provider)
 	}
+	if err != nil {
+		return nil, err
+	}
+	return WithRetry(p), nil
 }
 
 // ForTask returns the provider for a named task, falling back to the base

--- a/internal/llm/factory_test.go
+++ b/internal/llm/factory_test.go
@@ -66,8 +66,12 @@ func TestForTaskOverride(t *testing.T) {
 	if p.Name() != "openai" {
 		t.Errorf("override not applied: name = %q", p.Name())
 	}
-	if openai, ok := p.(*OpenAI); !ok || openai.Model != "gpt-5" {
-		t.Errorf("override model not applied: %+v", p)
+	inner := p
+	if rp, ok := p.(*retryProvider); ok {
+		inner = rp.Unwrap()
+	}
+	if openai, ok := inner.(*OpenAI); !ok || openai.Model != "gpt-5" {
+		t.Errorf("override model not applied: %+v", inner)
 	}
 }
 

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -184,11 +184,13 @@ func (o *OpenAI) Complete(ctx context.Context, req Request) (*Response, error) {
 	respBody, _ := io.ReadAll(httpResp.Body)
 
 	if httpResp.StatusCode != http.StatusOK {
+		herr := &HTTPError{Provider: "openai", StatusCode: httpResp.StatusCode, Body: string(respBody)}
 		var oe openaiErrorResponse
 		if err := json.Unmarshal(respBody, &oe); err == nil && oe.Error.Message != "" {
-			return nil, fmt.Errorf("openai %d %s: %s", httpResp.StatusCode, oe.Error.Type, oe.Error.Message)
+			herr.ErrType = oe.Error.Type
+			herr.Message = oe.Error.Message
 		}
-		return nil, fmt.Errorf("openai %d: %s", httpResp.StatusCode, string(respBody))
+		return nil, herr
 	}
 
 	var resp openaiResponse

--- a/internal/llm/retry.go
+++ b/internal/llm/retry.go
@@ -1,0 +1,96 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// HTTPError is returned by providers when the upstream API responds with
+// a non-2xx status. The retry wrapper inspects StatusCode to decide
+// whether to retry (5xx + 429) or surface the error immediately (4xx).
+type HTTPError struct {
+	Provider   string
+	StatusCode int
+	Body       string
+	ErrType    string
+	Message    string
+}
+
+func (e *HTTPError) Error() string {
+	switch {
+	case e.ErrType != "" && e.Message != "":
+		return fmt.Sprintf("%s %d %s: %s", e.Provider, e.StatusCode, e.ErrType, e.Message)
+	case e.Message != "":
+		return fmt.Sprintf("%s %d: %s", e.Provider, e.StatusCode, e.Message)
+	default:
+		return fmt.Sprintf("%s %d: %s", e.Provider, e.StatusCode, e.Body)
+	}
+}
+
+// RetryableStatus reports whether a status warrants a retry. Mirrors the
+// Reddit client policy: any 5xx or 429.
+func RetryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+const (
+	DefaultMaxRetry  = 3
+	DefaultBaseDelay = 500 * time.Millisecond
+)
+
+type retryProvider struct {
+	inner     Provider
+	MaxRetry  int
+	BaseDelay time.Duration
+}
+
+// WithRetry wraps p so transient 5xx + 429 responses retry with
+// exponential backoff. Wrapping is idempotent. Non-retryable errors
+// (4xx, request build failures, JSON parse failures) propagate
+// immediately. Context cancellation aborts the wait.
+func WithRetry(p Provider) Provider {
+	if p == nil {
+		return nil
+	}
+	if _, ok := p.(*retryProvider); ok {
+		return p
+	}
+	return &retryProvider{
+		inner:     p,
+		MaxRetry:  DefaultMaxRetry,
+		BaseDelay: DefaultBaseDelay,
+	}
+}
+
+func (r *retryProvider) Name() string { return r.inner.Name() }
+
+// Unwrap exposes the inner Provider so callers (and tests) can reach
+// concrete provider types when needed.
+func (r *retryProvider) Unwrap() Provider { return r.inner }
+
+func (r *retryProvider) Complete(ctx context.Context, req Request) (*Response, error) {
+	var lastErr error
+	for attempt := 0; attempt <= r.MaxRetry; attempt++ {
+		if attempt > 0 {
+			delay := r.BaseDelay << (attempt - 1)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		resp, err := r.inner.Complete(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		var herr *HTTPError
+		if !errors.As(err, &herr) || !RetryableStatus(herr.StatusCode) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", r.MaxRetry+1, lastErr)
+}

--- a/internal/llm/retry_test.go
+++ b/internal/llm/retry_test.go
@@ -1,0 +1,230 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeProvider is a Provider stub whose Complete returns a programmable
+// sequence of responses/errors. Each call advances the sequence.
+type fakeProvider struct {
+	name    string
+	results []fakeResult
+	calls   atomic.Int32
+}
+
+type fakeResult struct {
+	resp *Response
+	err  error
+}
+
+func (f *fakeProvider) Name() string { return f.name }
+
+func (f *fakeProvider) Complete(ctx context.Context, _ Request) (*Response, error) {
+	idx := int(f.calls.Add(1)) - 1
+	if idx >= len(f.results) {
+		return nil, fmt.Errorf("fake: ran out of results at call %d", idx)
+	}
+	r := f.results[idx]
+	return r.resp, r.err
+}
+
+func newRetryNoSleep(p Provider) *retryProvider {
+	return &retryProvider{inner: p, MaxRetry: DefaultMaxRetry, BaseDelay: 1 * time.Millisecond}
+}
+
+func TestRetryReturnsImmediatelyOnSuccess(t *testing.T) {
+	want := &Response{Content: "ok"}
+	f := &fakeProvider{name: "fake", results: []fakeResult{{resp: want}}}
+	r := newRetryNoSleep(f)
+	got, err := r.Complete(context.Background(), Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("response = %v", got)
+	}
+	if n := f.calls.Load(); n != 1 {
+		t.Errorf("calls = %d, want 1", n)
+	}
+}
+
+func TestRetryRetriesOn5xxThenSucceeds(t *testing.T) {
+	want := &Response{Content: "ok"}
+	f := &fakeProvider{
+		name: "fake",
+		results: []fakeResult{
+			{err: &HTTPError{Provider: "openai", StatusCode: 502, Message: "bad gateway"}},
+			{err: &HTTPError{Provider: "openai", StatusCode: 503}},
+			{resp: want},
+		},
+	}
+	r := newRetryNoSleep(f)
+	got, err := r.Complete(context.Background(), Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("response = %v", got)
+	}
+	if n := f.calls.Load(); n != 3 {
+		t.Errorf("calls = %d, want 3", n)
+	}
+}
+
+func TestRetryRetriesOn429(t *testing.T) {
+	want := &Response{Content: "ok"}
+	f := &fakeProvider{
+		name: "fake",
+		results: []fakeResult{
+			{err: &HTTPError{Provider: "openai", StatusCode: 429, Message: "rate limited"}},
+			{resp: want},
+		},
+	}
+	r := newRetryNoSleep(f)
+	if _, err := r.Complete(context.Background(), Request{}); err != nil {
+		t.Fatal(err)
+	}
+	if n := f.calls.Load(); n != 2 {
+		t.Errorf("calls = %d, want 2", n)
+	}
+}
+
+func TestRetryDoesNotRetry4xx(t *testing.T) {
+	wantErr := &HTTPError{Provider: "openai", StatusCode: 401, Message: "auth"}
+	f := &fakeProvider{name: "fake", results: []fakeResult{{err: wantErr}}}
+	r := newRetryNoSleep(f)
+	_, err := r.Complete(context.Background(), Request{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var herr *HTTPError
+	if !errors.As(err, &herr) || herr.StatusCode != 401 {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if n := f.calls.Load(); n != 1 {
+		t.Errorf("calls = %d, want 1 (no retry on 4xx)", n)
+	}
+}
+
+func TestRetryDoesNotRetryNonHTTPError(t *testing.T) {
+	wantErr := errors.New("marshal: bad request")
+	f := &fakeProvider{name: "fake", results: []fakeResult{{err: wantErr}}}
+	r := newRetryNoSleep(f)
+	_, err := r.Complete(context.Background(), Request{})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected %v, got %v", wantErr, err)
+	}
+	if n := f.calls.Load(); n != 1 {
+		t.Errorf("calls = %d, want 1", n)
+	}
+}
+
+func TestRetryGivesUpAfterMaxRetry(t *testing.T) {
+	final := &HTTPError{Provider: "openai", StatusCode: 500, Message: "boom"}
+	f := &fakeProvider{
+		name: "fake",
+		results: []fakeResult{
+			{err: &HTTPError{Provider: "openai", StatusCode: 500}},
+			{err: &HTTPError{Provider: "openai", StatusCode: 502}},
+			{err: &HTTPError{Provider: "openai", StatusCode: 503}},
+			{err: final},
+		},
+	}
+	r := newRetryNoSleep(f)
+	_, err := r.Complete(context.Background(), Request{})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	var herr *HTTPError
+	if !errors.As(err, &herr) || herr != final {
+		t.Errorf("expected wrapped final HTTPError, got %v", err)
+	}
+	// MaxRetry=3 → 1 initial + 3 retries = 4 calls total.
+	if n := f.calls.Load(); n != 4 {
+		t.Errorf("calls = %d, want 4", n)
+	}
+}
+
+func TestRetryRespectsContextCancellation(t *testing.T) {
+	f := &fakeProvider{
+		name: "fake",
+		results: []fakeResult{
+			{err: &HTTPError{Provider: "openai", StatusCode: 500}},
+			{err: &HTTPError{Provider: "openai", StatusCode: 500}},
+		},
+	}
+	// BaseDelay long enough that the wait actually blocks; we cancel
+	// before the first backoff completes.
+	r := &retryProvider{inner: f, MaxRetry: 3, BaseDelay: 200 * time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := r.Complete(ctx, Request{})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRetryWithNilReturnsNil(t *testing.T) {
+	if WithRetry(nil) != nil {
+		t.Error("WithRetry(nil) should return nil")
+	}
+}
+
+func TestRetryIsIdempotent(t *testing.T) {
+	f := &fakeProvider{name: "fake", results: []fakeResult{{resp: &Response{}}}}
+	once := WithRetry(f)
+	twice := WithRetry(once)
+	if once != twice {
+		t.Error("WithRetry should be idempotent (same pointer)")
+	}
+}
+
+func TestHTTPErrorMessageFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		e    *HTTPError
+		want string
+	}{
+		{"type+message", &HTTPError{Provider: "openai", StatusCode: 502, ErrType: "server_error", Message: "bad gateway"}, "openai 502 server_error: bad gateway"},
+		{"message only", &HTTPError{Provider: "anthropic", StatusCode: 500, Message: "boom"}, "anthropic 500: boom"},
+		{"body fallback", &HTTPError{Provider: "openai", StatusCode: 503, Body: "Service Unavailable"}, "openai 503: Service Unavailable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.e.Error(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryableStatus(t *testing.T) {
+	cases := []struct {
+		code int
+		want bool
+	}{
+		{200, false},
+		{401, false},
+		{404, false},
+		{http.StatusTooManyRequests, true},
+		{500, true},
+		{502, true},
+		{503, true},
+		{504, true},
+		{599, true},
+	}
+	for _, tc := range cases {
+		if got := RetryableStatus(tc.code); got != tc.want {
+			t.Errorf("RetryableStatus(%d) = %v, want %v", tc.code, got, tc.want)
+		}
+	}
+}

--- a/reply/firecrawl.go
+++ b/reply/firecrawl.go
@@ -25,6 +25,17 @@ var firecrawlAPIBase = "https://api.firecrawl.dev"
 // few seconds per page. 60s is conservative.
 const firecrawlScrapeTimeout = 60 * time.Second
 
+// Retry policy for transient Firecrawl failures (5xx + 429). Mirrors
+// internal/reddit/client.go: 3 retries, 500ms exponential base.
+// SCRAPE_SITE_ERROR / ERR_ABORTED comes back as a 500 — usually a
+// transient browser-load failure that succeeds on retry. Tunable as
+// vars so tests can shrink the delay; production defaults stay constant
+// for the lifetime of a binary.
+var (
+	firecrawlMaxRetry  = 3
+	firecrawlBaseDelay = 500 * time.Millisecond
+)
+
 // firecrawlScreenshotMaxBytes caps the screenshot download. Real
 // full-page screenshots from Firecrawl average 200KB-2MB depending on
 // page complexity; cap protects against pathological cases.
@@ -61,32 +72,10 @@ func InspectFirecrawl(ctx context.Context, client *http.Client, apiKey, target s
 	}
 
 	scrapeURL := firecrawlAPIBase + "/v1/scrape"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, scrapeURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("firecrawl: build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
-	httpReq.Header.Set("User-Agent", inspectUserAgent)
 
-	resp, err := client.Do(httpReq)
+	respBody, err := firecrawlScrapeWithRetry(ctx, client, scrapeURL, bodyBytes, apiKey)
 	if err != nil {
-		return nil, fmt.Errorf("firecrawl: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("firecrawl: read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		// Sanitize: include status + truncated body, never the auth header.
-		short := string(respBody)
-		if len(short) > 400 {
-			short = short[:400] + "..."
-		}
-		return nil, fmt.Errorf("firecrawl: status %d: %s", resp.StatusCode, strings.TrimSpace(short))
+		return nil, err
 	}
 
 	var parsed firecrawlScrapeResp
@@ -124,6 +113,56 @@ func InspectFirecrawl(ctx context.Context, client *http.Client, apiKey, target s
 	insp.ImageURLs = imageURLsFromMarkdown(parsed.Data.Markdown)
 
 	return insp, nil
+}
+
+// firecrawlScrapeWithRetry POSTs to /v1/scrape and retries on transient
+// upstream failures (5xx + 429). Same backoff shape as
+// internal/reddit/client.go. The auth key is set fresh each attempt and
+// never appears in returned error strings.
+func firecrawlScrapeWithRetry(ctx context.Context, client *http.Client, scrapeURL string, bodyBytes []byte, apiKey string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= firecrawlMaxRetry; attempt++ {
+		if attempt > 0 {
+			delay := firecrawlBaseDelay << (attempt - 1)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, scrapeURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("firecrawl: build request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+		httpReq.Header.Set("User-Agent", inspectUserAgent)
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			lastErr = fmt.Errorf("firecrawl: %w", err)
+			continue
+		}
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("firecrawl: read response: %w", readErr)
+		}
+		if resp.StatusCode == http.StatusOK {
+			return respBody, nil
+		}
+		short := strings.TrimSpace(string(respBody))
+		if len(short) > 400 {
+			short = short[:400] + "..."
+		}
+		statusErr := fmt.Errorf("firecrawl: status %d: %s", resp.StatusCode, short)
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = statusErr
+			continue
+		}
+		return nil, statusErr
+	}
+	return nil, fmt.Errorf("firecrawl: exhausted retries: %w", lastErr)
 }
 
 // DownloadScreenshot fetches the screenshot URL into destDir as a PNG
@@ -193,16 +232,16 @@ type firecrawlScrapeReq struct {
 }
 
 type firecrawlScrapeResp struct {
-	Success bool             `json:"success"`
-	Data    firecrawlData    `json:"data"`
-	Error   string           `json:"error,omitempty"`
+	Success bool          `json:"success"`
+	Data    firecrawlData `json:"data"`
+	Error   string        `json:"error,omitempty"`
 }
 
 type firecrawlData struct {
-	Markdown   string             `json:"markdown"`
-	Links      []string           `json:"links"`
-	Screenshot string             `json:"screenshot"`
-	Metadata   firecrawlMetadata  `json:"metadata"`
+	Markdown   string            `json:"markdown"`
+	Links      []string          `json:"links"`
+	Screenshot string            `json:"screenshot"`
+	Metadata   firecrawlMetadata `json:"metadata"`
 }
 
 type firecrawlMetadata struct {

--- a/reply/firecrawl.go
+++ b/reply/firecrawl.go
@@ -140,8 +140,11 @@ func firecrawlScrapeWithRetry(ctx context.Context, client *http.Client, scrapeUR
 
 		resp, err := client.Do(httpReq)
 		if err != nil {
-			lastErr = fmt.Errorf("firecrawl: %w", err)
-			continue
+			// Transport errors (connection reset, client timeout) are
+			// terminal: we can't tell if the server already accepted the
+			// request, and a retry could double-bill the scrape.
+			// Idempotent retry only kicks in on explicit 5xx + 429 below.
+			return nil, fmt.Errorf("firecrawl: %w", err)
 		}
 		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
 		resp.Body.Close()

--- a/reply/firecrawl_test.go
+++ b/reply/firecrawl_test.go
@@ -3,6 +3,7 @@ package reply
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -12,6 +13,19 @@ import (
 	"testing"
 	"time"
 )
+
+// countingErrorRT is an http.RoundTripper that always errors and counts
+// invocations. Used to assert retry policy without spinning up a real
+// network endpoint.
+type countingErrorRT struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (rt *countingErrorRT) RoundTrip(*http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	return nil, rt.err
+}
 
 // stubFirecrawl returns an httptest server that pretends to be the
 // Firecrawl /v1/scrape endpoint, plus a teardown that resets the
@@ -343,6 +357,28 @@ func TestInspectFirecrawlDoesNotRetryOn4xx(t *testing.T) {
 	}
 	if got := calls.Load(); got != 1 {
 		t.Errorf("4xx should not retry; calls = %d, want 1", got)
+	}
+}
+
+func TestInspectFirecrawlDoesNotRetryTransportErrors(t *testing.T) {
+	// Transport-level errors (connection reset, client timeout) must
+	// not retry: we can't tell whether the server already accepted the
+	// POST, and Firecrawl /v1/scrape is billed per request. Codex P1
+	// finding from PR #44 review.
+	withFastFirecrawlRetry(t)
+
+	rt := &countingErrorRT{err: errors.New("connection refused")}
+	client := &http.Client{Transport: rt}
+
+	_, err := InspectFirecrawl(context.Background(), client, "k", "https://x.example.com")
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("expected transport error surfaced, got %v", err)
+	}
+	if got := rt.calls.Load(); got != 1 {
+		t.Errorf("transport errors must not retry; calls = %d, want 1", got)
 	}
 }
 

--- a/reply/firecrawl_test.go
+++ b/reply/firecrawl_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // stubFirecrawl returns an httptest server that pretends to be the
@@ -253,6 +255,119 @@ func TestInspectFirecrawlNon200Errors(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "Bearer") || strings.Contains(err.Error(), "test-key") {
 		t.Errorf("error should not leak auth header: %v", err)
+	}
+}
+
+// withFastFirecrawlRetry shrinks the retry delay so retry tests don't
+// sleep the production 500ms+ between attempts.
+func withFastFirecrawlRetry(t *testing.T) {
+	t.Helper()
+	prev := firecrawlBaseDelay
+	firecrawlBaseDelay = 1 * time.Millisecond
+	t.Cleanup(func() { firecrawlBaseDelay = prev })
+}
+
+func TestInspectFirecrawlRetriesOn5xxThenSucceeds(t *testing.T) {
+	withFastFirecrawlRetry(t)
+	resp := firecrawlScrapeResp{
+		Success: true,
+		Data: firecrawlData{
+			Markdown: "# ok",
+			Metadata: firecrawlMetadata{Title: "T", StatusCode: 200},
+		},
+	}
+	var calls atomic.Int32
+	srv := stubFirecrawl(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		switch n {
+		case 1:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"success":false,"code":"SCRAPE_SITE_ERROR","error":"ERR_ABORTED"}`))
+		case 2:
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("Bad Gateway"))
+		default:
+			_ = json.NewEncoder(w).Encode(resp)
+		}
+	}))
+
+	insp, err := InspectFirecrawl(context.Background(), srv.Client(), "k", "https://x.example.com")
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if insp.Title != "T" {
+		t.Errorf("title = %q", insp.Title)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("calls = %d, want 3", got)
+	}
+}
+
+func TestInspectFirecrawlRetriesExhaustedOn5xx(t *testing.T) {
+	withFastFirecrawlRetry(t)
+	var calls atomic.Int32
+	srv := stubFirecrawl(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"code":"SCRAPE_SITE_ERROR","error":"ERR_ABORTED"}`))
+	}))
+
+	_, err := InspectFirecrawl(context.Background(), srv.Client(), "k", "https://x.example.com")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "exhausted retries") {
+		t.Errorf("expected 'exhausted retries' in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected status 500 surfaced, got %v", err)
+	}
+	// MaxRetry=3 → 1 initial + 3 retries = 4 calls.
+	if got := calls.Load(); got != int32(firecrawlMaxRetry+1) {
+		t.Errorf("calls = %d, want %d", got, firecrawlMaxRetry+1)
+	}
+}
+
+func TestInspectFirecrawlDoesNotRetryOn4xx(t *testing.T) {
+	withFastFirecrawlRetry(t)
+	var calls atomic.Int32
+	srv := stubFirecrawl(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid api key"}`))
+	}))
+
+	_, err := InspectFirecrawl(context.Background(), srv.Client(), "k", "https://x.example.com")
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 error, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("4xx should not retry; calls = %d, want 1", got)
+	}
+}
+
+func TestInspectFirecrawlRetriesOn429(t *testing.T) {
+	withFastFirecrawlRetry(t)
+	resp := firecrawlScrapeResp{
+		Success: true,
+		Data:    firecrawlData{Markdown: "# ok", Metadata: firecrawlMetadata{StatusCode: 200}},
+	}
+	var calls atomic.Int32
+	srv := stubFirecrawl(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+
+	if _, err := InspectFirecrawl(context.Background(), srv.Client(), "k", "https://x.example.com"); err != nil {
+		t.Fatalf("expected success after 429 retry, got %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("calls = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Closes #38 — Firecrawl 5xx during review-mode inspection now retried with backoff (3 attempts, 500ms exponential, mirrors `internal/reddit/client.go`).
- Closes #39 — OpenAI/Anthropic provider 5xx + 429 now retried at the `internal/llm` boundary, so all 11 `Provider.Complete` call sites (draft, regen, intake, research, reply) get the same resilience without per-caller plumbing.
- Providers now return a typed `*llm.HTTPError` carrying status code so the wrapper can decide retry vs. propagate. 4xx still fails fast.

## Test plan
- [ ] `go test ./...` (already green locally)
- [ ] New table tests in `internal/llm/retry_test.go` cover: success-on-first, retry-then-succeed, 429 retried, 4xx not retried, exhausted retries, context cancellation mid-backoff, idempotent wrap, nil safety.
- [ ] New tests in `reply/firecrawl_test.go` cover: 5xx then success, 5xx exhausted, 429 retried, 4xx not retried.
- [ ] Manually rerun a failing review-mode session against an Etsy shop URL; transient `SCRAPE_SITE_ERROR` / `ERR_ABORTED` responses should now recover instead of aborting.