### PR TITLE
post: one-step UX from --note / stdin / --file / --url (#45)

### DIFF
--- a/cmd/tider/post.go
+++ b/cmd/tider/post.go
@@ -12,16 +12,23 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/viggy28/tider/config"
+	"github.com/viggy28/tider/contextbank"
 	"github.com/viggy28/tider/draft"
+	"github.com/viggy28/tider/intake"
 	"github.com/viggy28/tider/internal/llm"
 	"github.com/viggy28/tider/internal/reddit"
 	"github.com/viggy28/tider/internal/types"
 	"github.com/viggy28/tider/lastdraft"
+	"github.com/viggy28/tider/reply"
 	"github.com/viggy28/tider/research"
 )
 
 var (
 	postBriefPath  string
+	postNote       string
+	postFile       string
+	postURL        string
+	postContexts   []string
 	postSub        string
 	postProviders  string
 	postAnthropic  string
@@ -37,132 +44,278 @@ var (
 
 var postCmd = &cobra.Command{
 	Use:   "post",
-	Short: "Draft a Reddit submission (fan-out across providers) for a Brief on one subreddit",
-	Long: `post turns a Brief + per-sub research into structured post drafts. By
-default it fans out across both Anthropic and OpenAI concurrently so you
-can compare framings side-by-side.
+	Short: "Draft a Reddit submission for a subreddit (one-step from --note, stdin, --file, or --url)",
+	Long: `post turns operator intent or source material plus per-sub research into
+structured post drafts, fanning out across providers so framings are
+side-by-side comparable.
 
-  tider post --brief=brief.json --sub=golang
-  tider post --brief=brief.json --sub=PostgreSQL --providers=anthropic
-  tider post --brief=brief.json --sub=golang --render=markdown
-  tider post --brief=brief.json --sub=golang --dry-run    # show prompt only
+Source input — exactly one is required:
+
+  --note "..."      operator intent (raw, no extraction)
+  stdin             piped content (raw, no extraction); e.g. pbpaste | tider post --sub=…
+  --file=path       local file (extracted via LLM)
+  --url=https://…   remote URL (extracted via LLM)
+  --brief=path      pre-built Brief JSON (advanced — output of ` + "`tider intake`" + `)
+
+Reusable background context (repeatable):
+
+  --context=<id>    name in the context bank (~/.tider/contexts/<id>.md)
+  --context=path/to/file.md
+
+  tider post --sub=EtsySellers --note="Ask sellers whether AI listing images hurt buyer trust. Don't pitch Kova." --context=kova
+  pbpaste | tider post --sub=EtsySellers --context=kova
+  tider post --sub=EtsySellers --file=./notes.md
+  tider post --sub=EtsySellers --url=https://example.com/source
 
 API keys come from env vars: ANTHROPIC_API_KEY, OPENAI_API_KEY. Providers
 without a key are skipped with a warning rather than failing the run.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if postBriefPath == "" || postSub == "" {
-			return errors.New("--brief and --sub are required")
-		}
-		brief, err := loadBrief(postBriefPath)
-		if err != nil {
-			return err
-		}
-
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("home dir: %w", err)
-		}
-		cacheRoot := postCacheRoot
-		if cacheRoot == "" {
-			cacheRoot = filepath.Join(home, ".tider", "cache")
-		}
-		notesPath := postNotesPath
-		if notesPath == "" {
-			notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
-		}
-
-		notes, err := research.LoadNotes(notesPath)
-		if err != nil {
-			return err
-		}
-		client := reddit.NewClient(reddit.NewCache(cacheRoot))
-		ctx := context.Background()
-		researchBundle, err := research.For(ctx, client, notes, postSub, postRefresh)
-		if err != nil {
-			return fmt.Errorf("research %s: %w", postSub, err)
-		}
-
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		_, _, cfgMaxTokens := cfg.FanOutModels("post")
-
-		opts := draft.Default()
-		if postVariantSet == "full" {
-			opts = draft.Full()
-		}
-		// Resolve max_tokens: explicit flag wins, then config, then opts default.
-		if postMaxTokens > 0 {
-			opts.MaxTokens = postMaxTokens
-		} else if cfgMaxTokens > 0 {
-			opts.MaxTokens = cfgMaxTokens
-		}
-		opts.AuthorContext = cfg.AuthorContext
-
-		if postDryRun {
-			prompt, err := draft.RenderPrompt(*brief, *researchBundle, opts)
-			if err != nil {
-				return err
-			}
-			fmt.Println(prompt)
-			return nil
-		}
-
-		// Resolve fan-out provider list and per-provider models with config fallback.
-		providers := postProviders
-		if providers == "" {
-			providers = cfg.Defaults.Providers
-		}
-		anthropicModel := postAnthropic
-		openaiModel := postOpenAI
-		if anthropicModel == "" {
-			anthropicModel = cfg.LLM.AnthropicModel
-		}
-		if openaiModel == "" {
-			openaiModel = cfg.LLM.OpenAIModel
-		}
-		refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
-		if err != nil {
-			return err
-		}
-		if len(refs) == 0 {
-			return errors.New("no usable providers — set ANTHROPIC_API_KEY and/or OPENAI_API_KEY")
-		}
-
-		bundle, err := draft.Generate(ctx, refs, *brief, *researchBundle, opts)
-		if err != nil {
-			return err
-		}
-
-		// Persist snapshot so `tider regen` can pick up where we left off.
-		// A failure here shouldn't block the user from seeing the bundle —
-		// log to stderr and proceed.
-		if root, derr := lastdraft.Default(); derr == nil {
-			snap := &types.Snapshot{Brief: *brief, Research: *researchBundle, Bundle: *bundle}
-			if serr := lastdraft.Save(root, postSub, snap); serr != nil {
-				fmt.Fprintf(os.Stderr, "warning: failed to save last-draft snapshot: %v\n", serr)
-			}
-		}
-
-		switch resolveRender(postRender) {
-		case "markdown":
-			md := draft.RenderMarkdown(bundle)
-			if isTerminal(os.Stdout) {
-				md = renderTerminal(md)
-			}
-			fmt.Print(md)
-		case "json":
-			out, err := json.MarshalIndent(bundle, "", "  ")
-			if err != nil {
-				return err
-			}
-			fmt.Println(string(out))
-		default:
-			return fmt.Errorf("unknown --render value: %s (use json or markdown)", postRender)
-		}
-		return nil
+		return runPost(cmd.Context(), os.Stdin)
 	},
+}
+
+func runPost(ctx context.Context, stdin *os.File) error {
+	if postSub == "" {
+		return errors.New("--sub is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	brief, operatorNote, err := resolvePostSource(ctx, cfg, stdin)
+	if err != nil {
+		return err
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home dir: %w", err)
+	}
+	cacheRoot := postCacheRoot
+	if cacheRoot == "" {
+		cacheRoot = filepath.Join(home, ".tider", "cache")
+	}
+	notesPath := postNotesPath
+	if notesPath == "" {
+		notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
+	}
+
+	notes, err := research.LoadNotes(notesPath)
+	if err != nil {
+		return err
+	}
+	client := reddit.NewClient(reddit.NewCache(cacheRoot))
+	researchBundle, err := research.For(ctx, client, notes, postSub, postRefresh)
+	if err != nil {
+		return fmt.Errorf("research %s: %w", postSub, err)
+	}
+
+	bankDir, err := contextbank.DefaultDir()
+	if err != nil {
+		return err
+	}
+	contexts, err := reply.LoadContexts(bankDir, postContexts)
+	if err != nil {
+		return err
+	}
+
+	_, _, cfgMaxTokens := cfg.FanOutModels("post")
+
+	opts := draft.Default()
+	if postVariantSet == "full" {
+		opts = draft.Full()
+	}
+	if postMaxTokens > 0 {
+		opts.MaxTokens = postMaxTokens
+	} else if cfgMaxTokens > 0 {
+		opts.MaxTokens = cfgMaxTokens
+	}
+	opts.AuthorContext = cfg.AuthorContext
+
+	in := draft.Input{
+		Brief:        *brief,
+		Research:     *researchBundle,
+		Contexts:     contexts,
+		OperatorNote: operatorNote,
+		Opts:         opts,
+	}
+
+	if postDryRun {
+		prompt, err := draft.RenderPrompt(in)
+		if err != nil {
+			return err
+		}
+		fmt.Println(prompt)
+		return nil
+	}
+
+	providers := postProviders
+	if providers == "" {
+		providers = cfg.Defaults.Providers
+	}
+	anthropicModel := postAnthropic
+	openaiModel := postOpenAI
+	if anthropicModel == "" {
+		anthropicModel = cfg.LLM.AnthropicModel
+	}
+	if openaiModel == "" {
+		openaiModel = cfg.LLM.OpenAIModel
+	}
+	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
+	if err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		return errors.New("no usable providers — set ANTHROPIC_API_KEY and/or OPENAI_API_KEY")
+	}
+
+	bundle, err := draft.Generate(ctx, refs, in)
+	if err != nil {
+		return err
+	}
+
+	if root, derr := lastdraft.Default(); derr == nil {
+		snap := &types.Snapshot{Brief: *brief, Research: *researchBundle, Bundle: *bundle}
+		if serr := lastdraft.Save(root, postSub, snap); serr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to save last-draft snapshot: %v\n", serr)
+		}
+	}
+
+	switch resolveRender(postRender) {
+	case "markdown":
+		md := draft.RenderMarkdown(bundle)
+		if isTerminal(os.Stdout) {
+			md = renderTerminal(md)
+		}
+		fmt.Print(md)
+	case "json":
+		out, err := json.MarshalIndent(bundle, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(out))
+	default:
+		return fmt.Errorf("unknown --render value: %s (use json or markdown)", postRender)
+	}
+	return nil
+}
+
+// resolvePostSource picks the single allowed source input and returns
+// the resulting Brief plus the operator-note string (empty for
+// --file/--url/--brief because those go through extraction). Stdin is
+// used only when no source flag is set and stdin is piped — an
+// interactive shell is treated as "no source" so we can fail with a
+// usage message instead of blocking on a tty.
+func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) (*types.Brief, string, error) {
+	sources := []string{}
+	if postNote != "" {
+		sources = append(sources, "--note")
+	}
+	if postFile != "" {
+		sources = append(sources, "--file")
+	}
+	if postURL != "" {
+		sources = append(sources, "--url")
+	}
+	if postBriefPath != "" {
+		sources = append(sources, "--brief")
+	}
+	stdinPiped := isStdinPiped(stdin)
+	if len(sources) == 0 && stdinPiped {
+		sources = append(sources, "stdin")
+	}
+
+	switch len(sources) {
+	case 0:
+		return nil, "", errors.New("provide a source: --note, stdin (piped), --file, --url, or --brief")
+	case 1:
+		// proceed
+	default:
+		return nil, "", fmt.Errorf("only one source may be set; got %s", strings.Join(sources, ", "))
+	}
+
+	switch sources[0] {
+	case "--note":
+		b, err := intake.FromNote(postNote)
+		if err != nil {
+			return nil, "", err
+		}
+		return b, b.Summary, nil
+	case "stdin":
+		b, err := intake.FromStdin(stdin, 256*1024)
+		if err != nil {
+			return nil, "", err
+		}
+		return b, b.Summary, nil
+	case "--file":
+		ip, err := newIntakeProvider(cfg)
+		if err != nil {
+			return nil, "", err
+		}
+		b, err := ip.build().FromFile(ctx, postFile)
+		if err != nil {
+			return nil, "", err
+		}
+		return b, "", nil
+	case "--url":
+		ip, err := newIntakeProvider(cfg)
+		if err != nil {
+			return nil, "", err
+		}
+		b, err := ip.build().FromURL(ctx, postURL)
+		if err != nil {
+			return nil, "", err
+		}
+		return b, "", nil
+	case "--brief":
+		b, err := loadBrief(postBriefPath)
+		if err != nil {
+			return nil, "", err
+		}
+		return b, "", nil
+	}
+	return nil, "", fmt.Errorf("internal: unhandled source %s", sources[0])
+}
+
+func newIntakeProvider(cfg *config.Config) (postIntake, error) {
+	provider, model, maxTokens := cfg.ForTask("intake")
+	p, err := llm.New(llm.Config{Provider: provider, Model: model})
+	if err != nil {
+		return postIntake{}, err
+	}
+	return postIntake{p: p, maxTokens: maxTokens}, nil
+}
+
+type postIntake struct {
+	p         llm.Provider
+	maxTokens int
+}
+
+func (ip postIntake) build() *intake.Intake {
+	i := intake.New(ip.p)
+	if ip.maxTokens > 0 {
+		i.MaxTokens = ip.maxTokens
+	}
+	return i
+}
+
+// isStdinPiped reports whether stdin is connected to a pipe or
+// redirected file rather than an interactive terminal. Mirrors the
+// idiom in term.go's isTerminal but for stdin.
+func isStdinPiped(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice == 0
 }
 
 func loadBrief(path string) (*types.Brief, error) {
@@ -216,7 +369,11 @@ func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]dra
 }
 
 func init() {
-	postCmd.Flags().StringVar(&postBriefPath, "brief", "", "path to a brief.json (output of `tider intake`)")
+	postCmd.Flags().StringVar(&postBriefPath, "brief", "", "path to a brief.json (advanced — output of `tider intake`)")
+	postCmd.Flags().StringVar(&postNote, "note", "", "inline operator intent; rendered raw without LLM extraction")
+	postCmd.Flags().StringVar(&postFile, "file", "", "local file with source material; LLM-extracted into a Brief")
+	postCmd.Flags().StringVar(&postURL, "url", "", "URL with source material; LLM-extracted into a Brief")
+	postCmd.Flags().StringSliceVar(&postContexts, "context", nil, "context bank id or path; repeatable")
 	postCmd.Flags().StringVar(&postSub, "sub", "", "subreddit name to draft for (e.g., golang)")
 	postCmd.Flags().StringVar(&postProviders, "providers", "", "comma-separated providers to fan out across (default from config)")
 	postCmd.Flags().StringVar(&postAnthropic, "anthropic-model", "", "Anthropic model to use (default from config)")

--- a/cmd/tider/post.go
+++ b/cmd/tider/post.go
@@ -285,10 +285,39 @@ func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) 
 func newIntakeProvider(cfg *config.Config) (postIntake, error) {
 	provider, model, maxTokens := cfg.ForTask("intake")
 	p, err := llm.New(llm.Config{Provider: provider, Model: model})
-	if err != nil {
-		return postIntake{}, err
+	if err == nil {
+		return postIntake{p: p, maxTokens: maxTokens}, nil
 	}
+	// Fall back to the other provider when the configured intake
+	// provider's key isn't set. Without this a single-provider user
+	// (only ANTHROPIC_API_KEY, default intake → openai) hits a hard
+	// fail at --file/--url before drafting even runs, which
+	// contradicts the rest of post's "missing key → skip with warning"
+	// behavior. Codex P1 finding from PR #48 review.
+	altProvider, altModel := otherIntakeProvider(provider, cfg)
+	if altProvider == "" {
+		return postIntake{}, fmt.Errorf("intake: %w", err)
+	}
+	p, altErr := llm.New(llm.Config{Provider: altProvider, Model: altModel})
+	if altErr != nil {
+		return postIntake{}, fmt.Errorf("intake: no usable provider — set ANTHROPIC_API_KEY or OPENAI_API_KEY")
+	}
+	fmt.Fprintf(os.Stderr, "intake: %s key missing, falling back to %s\n", provider, altProvider)
 	return postIntake{p: p, maxTokens: maxTokens}, nil
+}
+
+// otherIntakeProvider returns the cross-provider name + its configured
+// model for use when the primary intake provider's key is missing.
+// Returns ("", "") for unknown primaries (no fallback attempted).
+func otherIntakeProvider(current string, cfg *config.Config) (string, string) {
+	switch current {
+	case "openai":
+		return "anthropic", cfg.LLM.AnthropicModel
+	case "anthropic":
+		return "openai", cfg.LLM.OpenAIModel
+	default:
+		return "", ""
+	}
 }
 
 type postIntake struct {

--- a/cmd/tider/post_test.go
+++ b/cmd/tider/post_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/viggy28/tider/config"
+	"github.com/viggy28/tider/internal/types"
+)
+
+// resetPostFlags zeros every package-level post flag and restores the
+// previous values when the test ends. Without this, table tests share
+// state and bleed into each other (the cobra flag parser sets these
+// once at command-line parse time; tests don't go through cobra).
+func resetPostFlags(t *testing.T) {
+	t.Helper()
+	prevNote, prevFile, prevURL, prevBrief := postNote, postFile, postURL, postBriefPath
+	postNote, postFile, postURL, postBriefPath = "", "", "", ""
+	t.Cleanup(func() {
+		postNote, postFile, postURL, postBriefPath = prevNote, prevFile, prevURL, prevBrief
+	})
+}
+
+// stdinPipe returns an *os.File that reads from contents and looks
+// "piped" to isStdinPiped (i.e. not a tty). Cleanup closes both ends.
+func stdinPipe(t *testing.T, contents string) *os.File {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+
+// stdinTTY returns an *os.File that looks like an interactive terminal
+// to isStdinPiped. We open /dev/tty when available (CI may not have
+// one); on systems without a tty we synthesize the same condition by
+// returning os.Stdout, which has ModeCharDevice when tests run under a
+// terminal. The function skips the test when neither path works so we
+// don't get false failures in headless CI.
+func stdinTTY(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.Open("/dev/tty")
+	if err == nil {
+		t.Cleanup(func() { f.Close() })
+		fi, statErr := f.Stat()
+		if statErr == nil && fi.Mode()&os.ModeCharDevice != 0 {
+			return f
+		}
+	}
+	t.Skip("no tty available for interactive-stdin simulation")
+	return nil
+}
+
+func TestResolvePostSourceFromNote(t *testing.T) {
+	resetPostFlags(t)
+	postNote = "Ask sellers about AI listing images. Don't pitch Kova."
+
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Source.Mode != "note" {
+		t.Errorf("Source.Mode = %q", brief.Source.Mode)
+	}
+	if brief.Title != "Operator note" {
+		t.Errorf("Title = %q", brief.Title)
+	}
+	if opNote != postNote {
+		t.Errorf("operator note = %q, want %q", opNote, postNote)
+	}
+	if !strings.Contains(brief.Summary, "Don't pitch Kova") {
+		t.Errorf("Summary = %q", brief.Summary)
+	}
+}
+
+func TestResolvePostSourceFromStdin(t *testing.T) {
+	resetPostFlags(t)
+	const body = "Long pasted material with multiple paragraphs.\n\nFrom pbpaste."
+	stdin := stdinPipe(t, body)
+
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Source.Mode != "stdin" {
+		t.Errorf("Source.Mode = %q", brief.Source.Mode)
+	}
+	if brief.Source.Value != "-" {
+		t.Errorf("Source.Value = %q", brief.Source.Value)
+	}
+	if opNote != body {
+		t.Errorf("operator note mismatch")
+	}
+}
+
+func TestResolvePostSourceConflictingFlags(t *testing.T) {
+	resetPostFlags(t)
+	postNote = "x"
+	postFile = "y.md"
+
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "only one source") {
+		t.Errorf("error = %v, want 'only one source'", err)
+	}
+	if !strings.Contains(err.Error(), "--note") || !strings.Contains(err.Error(), "--file") {
+		t.Errorf("conflict error should name both flags; got %v", err)
+	}
+}
+
+func TestResolvePostSourceConflictWithStdin(t *testing.T) {
+	resetPostFlags(t)
+	postNote = "operator intent"
+	stdin := stdinPipe(t, "piped content")
+
+	// --note set AND stdin piped → should pick --note (explicit flag),
+	// not error. Stdin only counts as a source when no flag is set.
+	brief, _, err := resolvePostSource(context.Background(), &config.Config{}, stdin)
+	if err != nil {
+		t.Fatalf("explicit flag should win over piped stdin: %v", err)
+	}
+	if brief.Source.Mode != "note" {
+		t.Errorf("Source.Mode = %q, want note (explicit flag should win)", brief.Source.Mode)
+	}
+}
+
+func TestResolvePostSourceNoSource(t *testing.T) {
+	resetPostFlags(t)
+	tty := stdinTTY(t)
+
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, tty)
+	if err == nil {
+		t.Fatal("expected usage error when no source set and stdin is interactive")
+	}
+	if !strings.Contains(err.Error(), "provide a source") {
+		t.Errorf("error = %v, want 'provide a source'", err)
+	}
+}
+
+func TestResolvePostSourceFromBriefJSON(t *testing.T) {
+	resetPostFlags(t)
+	dir := t.TempDir()
+	briefPath := filepath.Join(dir, "brief.json")
+	b := types.Brief{
+		Source: types.BriefSource{Mode: "file", Value: "notes.md"},
+		Title:  "Streambed launch",
+	}
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(briefPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	postBriefPath = briefPath
+
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brief.Title != "Streambed launch" {
+		t.Errorf("Title = %q", brief.Title)
+	}
+	// --brief is the structured-source path, NOT operator-note semantics.
+	if opNote != "" {
+		t.Errorf("operator note should be empty for --brief; got %q", opNote)
+	}
+}
+
+func TestIsStdinPipedDetectsPipe(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	if !isStdinPiped(r) {
+		t.Error("pipe should report as piped")
+	}
+}
+
+func TestIsStdinPipedHandlesNil(t *testing.T) {
+	if isStdinPiped(nil) {
+		t.Error("nil should not be piped")
+	}
+}
+
+// TestResolvePostSourceEmptyNote verifies we surface a clean error
+// rather than producing an empty Brief when --note is set to an
+// all-whitespace string. intake.FromNote enforces this; this test
+// covers the integration.
+func TestResolvePostSourceEmptyNote(t *testing.T) {
+	resetPostFlags(t)
+	postNote = "   \n\t  "
+
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	if err == nil {
+		t.Fatal("expected error for whitespace-only note")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty; got %v", err)
+	}
+}

--- a/cmd/tider/post_test.go
+++ b/cmd/tider/post_test.go
@@ -179,6 +179,57 @@ func TestResolvePostSourceFromBriefJSON(t *testing.T) {
 	}
 }
 
+func TestNewIntakeProviderFallsBackWhenPrimaryKeyMissing(t *testing.T) {
+	// Default intake task points to openai (gpt-4o-mini). With only
+	// ANTHROPIC_API_KEY set, the fallback should kick in instead of
+	// hard-failing — that's the Codex P1 fix on PR #48.
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic")
+
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			Provider:       "openai",
+			Model:          "gpt-5",
+			AnthropicModel: "claude-sonnet-4-7",
+			OpenAIModel:    "gpt-5",
+			Tasks: map[string]config.TaskConfig{
+				"intake": {Model: "gpt-4o-mini", MaxTokens: 8192},
+			},
+		},
+	}
+	ip, err := newIntakeProvider(cfg)
+	if err != nil {
+		t.Fatalf("expected fallback to anthropic, got error: %v", err)
+	}
+	if ip.p == nil || ip.p.Name() != "anthropic" {
+		t.Errorf("expected anthropic provider; got %v", ip.p)
+	}
+}
+
+func TestNewIntakeProviderErrorsWhenAllKeysMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg := &config.Config{
+		LLM: config.LLMConfig{
+			Provider:       "openai",
+			Model:          "gpt-5",
+			AnthropicModel: "claude-sonnet-4-7",
+			OpenAIModel:    "gpt-5",
+			Tasks: map[string]config.TaskConfig{
+				"intake": {Model: "gpt-4o-mini"},
+			},
+		},
+	}
+	_, err := newIntakeProvider(cfg)
+	if err == nil {
+		t.Fatal("expected error when no provider keys are set")
+	}
+	if !strings.Contains(err.Error(), "no usable provider") {
+		t.Errorf("error should explain no usable provider; got %v", err)
+	}
+}
+
 func TestIsStdinPipedDetectsPipe(t *testing.T) {
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/draft/draft.go
+++ b/draft/draft.go
@@ -33,6 +33,21 @@ type Options struct {
 	AuthorContext string
 }
 
+// Input bundles everything one Generate call needs. Contexts and
+// OperatorNote are new in the post one-step UX: contexts carry
+// background project material loaded via --context, OperatorNote carries
+// the operator's intent passed via --note or stdin (treated as
+// instruction, not source material). Both are optional — a brief
+// extracted from --file or --url with no contexts and no note still
+// renders cleanly.
+type Input struct {
+	Brief        types.Brief
+	Research     types.Research
+	Contexts     []types.LoadedReplyContext
+	OperatorNote string
+	Opts         Options
+}
+
 // Default is the spec's "2 angles × 3 titles × 2 bodies" — ~12 artifacts.
 // MaxTokens sized for reasoning models (gpt-5, o-series): real-run usage
 // has been ~5K output tokens, so 10K leaves headroom for reasoning.
@@ -63,8 +78,8 @@ type ProviderRef = llm.ProviderRef
 
 // RenderPrompt produces the user-facing prompt the LLM will see. Exposed
 // so `--dry-run` can print it without burning a real API call.
-func RenderPrompt(brief types.Brief, research types.Research, opts Options) (string, error) {
-	if opts.AngleCount <= 0 || opts.TitlesPerAngle <= 0 || opts.BodiesPerAngle <= 0 {
+func RenderPrompt(in Input) (string, error) {
+	if in.Opts.AngleCount <= 0 || in.Opts.TitlesPerAngle <= 0 || in.Opts.BodiesPerAngle <= 0 {
 		return "", fmt.Errorf("draft: variant counts must be > 0")
 	}
 	var buf bytes.Buffer
@@ -79,25 +94,29 @@ func RenderPrompt(brief types.Brief, research types.Research, opts Options) (str
 		Stickies       []types.Post
 		Flairs         []types.Flair
 		Brief          types.Brief
+		Contexts       []types.LoadedReplyContext
+		OperatorNote   string
 		AngleCount     int
 		TitlesPerAngle int
 		BodiesPerAngle int
 		AuthorContext  string
 	}{
-		SubName:        research.Sub.Name,
-		Subscribers:    research.Sub.Subscribers,
-		CuratedNotes:   research.Notes,
-		Rules:          research.Rules,
-		TopWeek:        research.TopWeek,
-		TopMonth:       research.TopMonth,
-		Hot:            research.Hot,
-		Stickies:       research.Stickies,
-		Flairs:         research.Flairs,
-		Brief:          brief,
-		AngleCount:     opts.AngleCount,
-		TitlesPerAngle: opts.TitlesPerAngle,
-		BodiesPerAngle: opts.BodiesPerAngle,
-		AuthorContext:  opts.AuthorContext,
+		SubName:        in.Research.Sub.Name,
+		Subscribers:    in.Research.Sub.Subscribers,
+		CuratedNotes:   in.Research.Notes,
+		Rules:          in.Research.Rules,
+		TopWeek:        in.Research.TopWeek,
+		TopMonth:       in.Research.TopMonth,
+		Hot:            in.Research.Hot,
+		Stickies:       in.Research.Stickies,
+		Flairs:         in.Research.Flairs,
+		Brief:          in.Brief,
+		Contexts:       in.Contexts,
+		OperatorNote:   in.OperatorNote,
+		AngleCount:     in.Opts.AngleCount,
+		TitlesPerAngle: in.Opts.TitlesPerAngle,
+		BodiesPerAngle: in.Opts.BodiesPerAngle,
+		AuthorContext:  in.Opts.AuthorContext,
 	})
 	if err != nil {
 		return "", fmt.Errorf("render draft prompt: %w", err)
@@ -108,11 +127,11 @@ func RenderPrompt(brief types.Brief, research types.Research, opts Options) (str
 // Generate fans out across providers concurrently and returns the bundle.
 // Per-provider errors are recorded on the Draft (not propagated) so a
 // transient failure in one provider doesn't kill the whole comparison.
-func Generate(ctx context.Context, refs []ProviderRef, brief types.Brief, research types.Research, opts Options) (*types.DraftBundle, error) {
+func Generate(ctx context.Context, refs []ProviderRef, in Input) (*types.DraftBundle, error) {
 	if len(refs) == 0 {
 		return nil, errors.New("draft: at least one provider required")
 	}
-	prompt, err := RenderPrompt(brief, research, opts)
+	prompt, err := RenderPrompt(in)
 	if err != nil {
 		return nil, err
 	}
@@ -123,14 +142,14 @@ func Generate(ctx context.Context, refs []ProviderRef, brief types.Brief, resear
 		wg.Add(1)
 		go func(i int, ref ProviderRef) {
 			defer wg.Done()
-			drafts[i] = generateOne(ctx, ref, research.Sub.Name, prompt, opts.MaxTokens)
+			drafts[i] = generateOne(ctx, ref, in.Research.Sub.Name, prompt, in.Opts.MaxTokens)
 		}(i, ref)
 	}
 	wg.Wait()
 
 	return &types.DraftBundle{
-		Sub:       research.Sub.Name,
-		Brief:     brief,
+		Sub:       in.Research.Sub.Name,
+		Brief:     in.Brief,
 		Drafts:    drafts,
 		Generated: time.Now().UTC(),
 	}, nil
@@ -168,13 +187,13 @@ func parseInto(d *types.Draft, raw string) error {
 		return errors.New("empty response")
 	}
 	var payload struct {
-		Risk                string                `json:"risk"`
-		RiskReason          string                `json:"risk_reason"`
-		Angles              []types.Angle         `json:"angles"`
-		Recommendation      types.Recommendation  `json:"recommendation"`
-		Flair               types.FlairRec        `json:"flair"`
-		SuggestedWindow     string                `json:"suggested_window"`
-		MediaRecommendation string                `json:"media_recommendation"`
+		Risk                string               `json:"risk"`
+		RiskReason          string               `json:"risk_reason"`
+		Angles              []types.Angle        `json:"angles"`
+		Recommendation      types.Recommendation `json:"recommendation"`
+		Flair               types.FlairRec       `json:"flair"`
+		SuggestedWindow     string               `json:"suggested_window"`
+		MediaRecommendation string               `json:"media_recommendation"`
 	}
 	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
 		return fmt.Errorf("parse draft json: %w (model returned: %q)", err, truncate(raw, 200))

--- a/draft/draft_test.go
+++ b/draft/draft_test.go
@@ -109,22 +109,33 @@ func sampleResearch() types.Research {
 	}
 }
 
+// sampleInput wraps the sample Brief/Research with default opts. Tests
+// override fields (Opts.AuthorContext, OperatorNote, Contexts, etc.)
+// after constructing.
+func sampleInput() Input {
+	return Input{
+		Brief:    sampleBrief(),
+		Research: sampleResearch(),
+		Opts:     Default(),
+	}
+}
+
 func TestRenderPromptIncludesContextAndCounts(t *testing.T) {
-	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), Default())
+	prompt, err := RenderPrompt(sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
 	wantSubstrings := []string{
-		"r/golang",                  // sub header
-		"Some discussion post",      // top post leaked in
-		"terse, hype-allergic",      // curated notes leaked in
-		"Streambed",                 // brief title
-		"Postgres wire protocol",    // highlight
-		"2 *distinct* angles",       // variant count
-		"3 candidate titles",        // titles per angle
-		"2 candidate bodies",        // bodies per angle
-		"Anti-tells",                // anti-tells section present
-		"\"risk\":",                 // output schema present
+		"r/golang",               // sub header
+		"Some discussion post",   // top post leaked in
+		"terse, hype-allergic",   // curated notes leaked in
+		"Streambed",              // brief title
+		"Postgres wire protocol", // highlight
+		"2 *distinct* angles",    // variant count
+		"3 candidate titles",     // titles per angle
+		"2 candidate bodies",     // bodies per angle
+		"Anti-tells",             // anti-tells section present
+		"\"risk\":",              // output schema present
 	}
 	for _, s := range wantSubstrings {
 		if !strings.Contains(prompt, s) {
@@ -134,9 +145,9 @@ func TestRenderPromptIncludesContextAndCounts(t *testing.T) {
 }
 
 func TestRenderPromptIncludesAuthorContextWhenSet(t *testing.T) {
-	opts := Default()
-	opts.AuthorContext = "Five years at Cloudflare leading the Postgres team. Currently building Streambed."
-	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), opts)
+	in := sampleInput()
+	in.Opts.AuthorContext = "Five years at Cloudflare leading the Postgres team. Currently building Streambed."
+	prompt, err := RenderPrompt(in)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +163,7 @@ func TestRenderPromptIncludesAuthorContextWhenSet(t *testing.T) {
 }
 
 func TestRenderPromptOmitsAuthorContextWhenEmpty(t *testing.T) {
-	prompt, err := RenderPrompt(sampleBrief(), sampleResearch(), Default())
+	prompt, err := RenderPrompt(sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,8 +172,60 @@ func TestRenderPromptOmitsAuthorContextWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderPromptIncludesOperatorNoteAndContexts(t *testing.T) {
+	in := sampleInput()
+	in.OperatorNote = "Ask sellers about AI listing images. Don't pitch Kova."
+	in.Contexts = []types.LoadedReplyContext{
+		{ID: "kova", Source: "bank", Body: "Kova is a CDC tool for Postgres."},
+		{ID: "personal", Source: "path", Path: "/home/user/.tider/personal.md", Body: "Five years building infra at Cloudflare."},
+	}
+
+	prompt, err := RenderPrompt(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSubstrings := []string{
+		"Operator intent",
+		"Ask sellers about AI listing images",
+		"Background context",
+		"context: kova",
+		"Kova is a CDC tool",
+		"context: personal",
+		"/home/user/.tider/personal.md",
+		"Five years building infra",
+		"Precedence",
+		"Operator intent",
+		"Background context",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing %q", s)
+		}
+	}
+}
+
+func TestRenderPromptOmitsOperatorAndContextSectionsWhenAbsent(t *testing.T) {
+	prompt, err := RenderPrompt(sampleInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The H1 section headers should not render when the inputs are
+	// empty. (The precedence list still mentions them inline by name —
+	// that's intentional, it's the rule.)
+	for _, header := range []string{"# Operator intent", "# Background context"} {
+		if strings.Contains(prompt, header) {
+			t.Errorf("prompt should not contain section header %q when input absent", header)
+		}
+	}
+	if !strings.Contains(prompt, "# Precedence") {
+		t.Error("Precedence section should always render")
+	}
+}
+
 func TestRenderPromptRejectsZeroCounts(t *testing.T) {
-	_, err := RenderPrompt(sampleBrief(), sampleResearch(), Options{AngleCount: 0, TitlesPerAngle: 3, BodiesPerAngle: 2})
+	in := sampleInput()
+	in.Opts = Options{AngleCount: 0, TitlesPerAngle: 3, BodiesPerAngle: 2}
+	_, err := RenderPrompt(in)
 	if err == nil {
 		t.Fatal("expected error for zero AngleCount")
 	}
@@ -176,7 +239,7 @@ func TestGenerateFanOutAcrossProviders(t *testing.T) {
 	bundle, err := Generate(context.Background(), []ProviderRef{
 		{Provider: a, Model: "claude-sonnet-4-7"},
 		{Provider: b, Model: "gpt-5"},
-	}, sampleBrief(), sampleResearch(), Default())
+	}, sampleInput())
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatal(err)
@@ -215,7 +278,7 @@ func TestGenerateFanOutAcrossProviders(t *testing.T) {
 }
 
 func TestGenerateRequiresAtLeastOneProvider(t *testing.T) {
-	_, err := Generate(context.Background(), nil, sampleBrief(), sampleResearch(), Default())
+	_, err := Generate(context.Background(), nil, sampleInput())
 	if err == nil {
 		t.Fatal("expected error for empty providers")
 	}
@@ -228,7 +291,7 @@ func TestGenerateRecordsPerProviderError(t *testing.T) {
 	bundle, err := Generate(context.Background(), []ProviderRef{
 		{Provider: good, Model: "claude-sonnet-4-7"},
 		{Provider: bad, Model: "gpt-5"},
-	}, sampleBrief(), sampleResearch(), Default())
+	}, sampleInput())
 	if err != nil {
 		t.Fatalf("bundle should succeed even when one provider fails: %v", err)
 	}
@@ -257,7 +320,7 @@ func TestGenerateRecordsPerProviderError(t *testing.T) {
 
 func TestGenerateBadJSONRecordedAsError(t *testing.T) {
 	p := &fakeProvider{name: "anthropic", response: "not json at all"}
-	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +333,7 @@ func TestGenerateBadJSONRecordedAsError(t *testing.T) {
 func TestGenerateRefusePath(t *testing.T) {
 	const refuseJSON = `{"risk":"refuse","risk_reason":"this sub rejects launch posts","angles":[]}`
 	p := &fakeProvider{name: "anthropic", response: refuseJSON}
-	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +351,7 @@ func TestGenerateRefusePath(t *testing.T) {
 
 func TestGenerateMissingRiskFieldErrors(t *testing.T) {
 	p := &fakeProvider{name: "anthropic", response: `{"angles":[]}`}
-	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +363,7 @@ func TestGenerateMissingRiskFieldErrors(t *testing.T) {
 
 func TestGenerateSendsJSONModeRequest(t *testing.T) {
 	p := &fakeProvider{name: "anthropic", response: cannedDraftJSON}
-	_, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "claude-sonnet-4-7"}}, sampleBrief(), sampleResearch(), Default())
+	_, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "claude-sonnet-4-7"}}, sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +383,7 @@ func TestGenerateSendsJSONModeRequest(t *testing.T) {
 
 func TestTokenUsageRecorded(t *testing.T) {
 	p := &fakeProvider{name: "anthropic", response: cannedDraftJSON}
-	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleBrief(), sampleResearch(), Default())
+	bundle, err := Generate(context.Background(), []ProviderRef{{Provider: p, Model: "x"}}, sampleInput())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/intake/note.go
+++ b/intake/note.go
@@ -1,0 +1,62 @@
+package intake
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/viggy28/tider/internal/types"
+)
+
+// FromNote builds a Brief directly from operator-supplied text without
+// running the LLM extractor. A note is the operator's *intent* ("ask
+// sellers whether AI listing images hurt buyer trust, don't pitch
+// Kova"), not source material to polish — running extraction over it
+// would invent structure and bias the drafter.
+//
+// Title is a deterministic placeholder ("Operator note") so downstream
+// code that requires a non-empty title (lastdraft, snapshot validation)
+// keeps working.
+func FromNote(note string) (*types.Brief, error) {
+	note = strings.TrimSpace(note)
+	if note == "" {
+		return nil, fmt.Errorf("note is empty")
+	}
+	return &types.Brief{
+		Source:     types.BriefSource{Mode: "note"},
+		Title:      "Operator note",
+		Summary:    note,
+		RawContent: note,
+		CreatedAt:  time.Now().UTC(),
+	}, nil
+}
+
+// FromStdin reads up to maxBytes from r and builds a Brief without
+// extraction — same operator-intent semantics as FromNote. Stdin is
+// almost always either a one-liner from `echo … | tider post` or a
+// larger blob from `pbpaste | tider post`; in either case the operator
+// wrote it, so it should land in the prompt as-is, not be re-summarized.
+func FromStdin(r io.Reader, maxBytes int64) (*types.Brief, error) {
+	if r == nil {
+		return nil, fmt.Errorf("stdin reader is nil")
+	}
+	if maxBytes <= 0 {
+		maxBytes = 256 * 1024
+	}
+	raw, err := io.ReadAll(io.LimitReader(r, maxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read stdin: %w", err)
+	}
+	body := strings.TrimSpace(string(raw))
+	if body == "" {
+		return nil, fmt.Errorf("stdin is empty")
+	}
+	return &types.Brief{
+		Source:     types.BriefSource{Mode: "stdin", Value: "-"},
+		Title:      "Operator note",
+		Summary:    body,
+		RawContent: body,
+		CreatedAt:  time.Now().UTC(),
+	}, nil
+}

--- a/intake/note_test.go
+++ b/intake/note_test.go
@@ -1,0 +1,97 @@
+package intake
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFromNoteBuildsBriefWithoutExtraction(t *testing.T) {
+	const note = "Ask sellers whether AI listing images hurt buyer trust. Don't pitch Kova."
+	b, err := FromNote(note)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Source.Mode != "note" {
+		t.Errorf("Source.Mode = %q, want note", b.Source.Mode)
+	}
+	if b.Source.Value != "" {
+		t.Errorf("Source.Value = %q, want empty for note", b.Source.Value)
+	}
+	if b.Title != "Operator note" {
+		t.Errorf("Title = %q, want 'Operator note'", b.Title)
+	}
+	if b.Summary != note {
+		t.Errorf("Summary = %q, want verbatim note", b.Summary)
+	}
+	if b.RawContent != note {
+		t.Errorf("RawContent = %q, want verbatim note", b.RawContent)
+	}
+	if len(b.Highlights) != 0 {
+		t.Errorf("Highlights = %v, want empty (no extraction)", b.Highlights)
+	}
+	if b.CreatedAt.IsZero() {
+		t.Error("CreatedAt unset")
+	}
+}
+
+func TestFromNoteTrimsWhitespace(t *testing.T) {
+	b, err := FromNote("   hello   \n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Summary != "hello" {
+		t.Errorf("Summary = %q, want trimmed", b.Summary)
+	}
+}
+
+func TestFromNoteRejectsEmpty(t *testing.T) {
+	cases := []string{"", "   ", "\n\t"}
+	for _, in := range cases {
+		if _, err := FromNote(in); err == nil {
+			t.Errorf("FromNote(%q) should error", in)
+		}
+	}
+}
+
+func TestFromStdinBuildsBriefWithoutExtraction(t *testing.T) {
+	const body = "Long pasted material from pbpaste\n\nWith multiple paragraphs."
+	b, err := FromStdin(strings.NewReader(body), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Source.Mode != "stdin" {
+		t.Errorf("Source.Mode = %q, want stdin", b.Source.Mode)
+	}
+	if b.Source.Value != "-" {
+		t.Errorf("Source.Value = %q, want '-'", b.Source.Value)
+	}
+	if b.Title != "Operator note" {
+		t.Errorf("Title = %q", b.Title)
+	}
+	if b.Summary != body {
+		t.Errorf("Summary mismatch")
+	}
+	if b.RawContent != body {
+		t.Errorf("RawContent mismatch")
+	}
+}
+
+func TestFromStdinHonorsMaxBytes(t *testing.T) {
+	big := strings.Repeat("a", 1000)
+	b, err := FromStdin(strings.NewReader(big), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b.Summary) != 100 {
+		t.Errorf("Summary len = %d, want 100", len(b.Summary))
+	}
+}
+
+func TestFromStdinRejectsEmpty(t *testing.T) {
+	if _, err := FromStdin(strings.NewReader(""), 0); err == nil {
+		t.Error("empty stdin should error")
+	}
+	if _, err := FromStdin(strings.NewReader("   \n"), 0); err == nil {
+		t.Error("whitespace-only stdin should error")
+	}
+}

--- a/prompts/draft.tmpl
+++ b/prompts/draft.tmpl
@@ -74,7 +74,31 @@ Notes: {{.CuratedNotes.Notes}}
 {{- end }}
 {{- end }}
 
+{{- if .OperatorNote }}
+
+# Operator intent (highest signal — this is what the user wants posted)
+
+{{.OperatorNote}}
+
+Treat the operator intent as the *brief itself*: it tells you what to draft and any constraints to honor (audience, things to avoid, what to lead with). Do not paraphrase or rewrite it as the post body — produce native r/{{.SubName}} drafts that act on the intent.
+{{- end }}
+{{- if .Contexts }}
+
+# Background context (reference material — lower priority than operator intent)
+
+These are the operator's own background notes (project context, prior work, voice/voiceless guardrails). Use them to ground voice and avoid contradicting known facts; do not promote or pitch them unless the operator intent explicitly says to.
+{{- range .Contexts }}
+
+## context: {{.ID}}{{if eq .Source "path"}} ({{.Path}}){{end}}
+{{.Body}}
+{{- end }}
+{{- end }}
+
 # What you're posting about
+{{- if .OperatorNote }}
+
+(See "Operator intent" above. The Brief below is the recorded source descriptor — favor the operator intent when they conflict.)
+{{- end }}
 
 Title: {{.Brief.Title}}
 Summary: {{.Brief.Summary}}
@@ -93,6 +117,14 @@ Reference links:
 - {{.}}
 {{- end }}
 {{- end }}
+
+# Precedence (apply when sources conflict)
+
+1. Subreddit rules and safety constraints
+2. Operator intent (the `--note` / piped input above, if any)
+3. Background context (the `--context` material above, if any)
+4. Subreddit research — recent top posts, hot, curated notes
+5. Default tone and style
 
 # Task
 


### PR DESCRIPTION
Closes #45.

## Summary

- `tider post` no longer requires `tider intake` first or a `brief.json` artifact for normal use.
- New source flags: `--note`, stdin, `--file`, `--url` (exactly one). `--brief` stays for the advanced JSON path.
- New `--context` flag (repeatable) loads context-bank entries / file paths the same way `tider reply` does.
- `--note` and stdin **skip LLM extraction** — they're operator *intent*, not source material to polish. The Brief is synthesized directly with `Source.Mode = "note"` / `"stdin"` and `Title = "Operator note"`.
- `--file` / `--url` keep LLM extraction (they're real source material).
- `draft.Generate` / `RenderPrompt` now take a single `Input{ Brief, Research, Contexts, OperatorNote, Opts }`. The draft prompt template adds explicit `# Operator intent` and `# Background context` sections plus a `# Precedence` list (rules > note > contexts > research > style).

## Acceptance criteria

- [x] `tider post --sub=<sub> --note="..."` drafts with no `brief.json`
- [x] `tider post --sub=<sub>` reads stdin when piped and no source flag is set
- [x] `tider post --sub=<sub> --file=./notes.md` drafts from a local file
- [x] `tider post --sub=<sub> --url=...` drafts from a URL
- [x] `--context` works on `post`, loads from bank or path
- [x] Conflicting source flags fail clearly
- [x] No source + interactive stdin fails with usage message
- [x] `tider regen ... --sub=<sub>` snapshot path unchanged

## Test plan

- [x] `go test ./...` (all green locally)
- [x] New tests: `intake.FromNote` / `FromStdin` (no extraction); `cmd/tider/resolvePostSource` (note, stdin, conflict, brief JSON, empty note); `draft.RenderPrompt` (operator-note + contexts sections + precedence list).
- [x] CLI smoke: `tider post --sub=golang` → "provide a source"; `tider post --sub=golang --note=hi --file=x.md` → "only one source may be set; got --note, --file".
- [ ] Manual end-to-end run with a real subreddit + API keys to verify the new prompt produces native drafts (not paraphrased note copy).

@codex review