### PR TITLE
progress: stage-based stderr feedback for long-running commands

### DIFF
--- a/cmd/tider/intake.go
+++ b/cmd/tider/intake.go
@@ -38,6 +38,12 @@ API key for the chosen provider must be set in the environment
 			return fmt.Errorf("exactly one of --url or --file is required")
 		}
 
+		// 2 stages: cheap setup (config + provider) then the LLM
+		// extraction call, which is the only step worth waiting on.
+		rep := newReporter()
+		rep.Start(2)
+		rep.Step("validating source...")
+
 		cfg, err := config.Load()
 		if err != nil {
 			return err
@@ -63,15 +69,21 @@ API key for the chosen provider must be set in the environment
 
 		ctx := context.Background()
 		var brief *types.Brief
+		var sourceLabel string
 		switch {
 		case intakeURL != "":
+			sourceLabel = intakeURL
+			rep.Step(fmt.Sprintf("extracting brief from %s with %s/%s...", sourceLabel, provider, model))
 			brief, err = i.FromURL(ctx, intakeURL)
 		case intakeFile != "":
+			sourceLabel = intakeFile
+			rep.Step(fmt.Sprintf("extracting brief from %s with %s/%s...", sourceLabel, provider, model))
 			brief, err = i.FromFile(ctx, intakeFile)
 		}
 		if err != nil {
 			return err
 		}
+		rep.Done()
 
 		switch resolveRender(intakeRender) {
 		case "markdown":

--- a/cmd/tider/main.go
+++ b/cmd/tider/main.go
@@ -5,6 +5,13 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/viggy28/tider/internal/progress"
+)
+
+var (
+	flagQuiet      bool
+	flagNoProgress bool
 )
 
 var rootCmd = &cobra.Command{
@@ -15,11 +22,24 @@ subreddit's rules and what's worked there. The bot reads Reddit; you
 post manually. No auth, no posting, no commenting — by design.`,
 }
 
+// newReporter constructs a stage-progress reporter for the current
+// command, honoring the persistent --quiet / --no-progress flags.
+// Always writes to stderr so stdout stays clean for piping.
+func newReporter() *progress.Reporter {
+	return progress.New(os.Stderr, progress.Options{
+		Quiet:      flagQuiet,
+		NoProgress: flagNoProgress,
+	})
+}
+
 func main() {
 	// Auto-load .env from cwd and ~/.tider/.env so users don't have to
 	// `source .env` (and don't have to remember `export` or `set -a`).
 	// Real env always wins.
 	autoloadEnv()
+
+	rootCmd.PersistentFlags().BoolVar(&flagQuiet, "quiet", false, "suppress progress and warnings; only final output and errors")
+	rootCmd.PersistentFlags().BoolVar(&flagNoProgress, "no-progress", false, "suppress stage progress lines; warnings and errors still print")
 
 	rootCmd.AddCommand(researchCmd)
 	rootCmd.AddCommand(intakeCmd)

--- a/cmd/tider/post.go
+++ b/cmd/tider/post.go
@@ -16,6 +16,7 @@ import (
 	"github.com/viggy28/tider/draft"
 	"github.com/viggy28/tider/intake"
 	"github.com/viggy28/tider/internal/llm"
+	"github.com/viggy28/tider/internal/progress"
 	"github.com/viggy28/tider/internal/reddit"
 	"github.com/viggy28/tider/internal/types"
 	"github.com/viggy28/tider/lastdraft"
@@ -82,12 +83,23 @@ func runPost(ctx context.Context, stdin *os.File) error {
 		ctx = context.Background()
 	}
 
+	// --dry-run skips provider selection, drafting, and snapshot save:
+	// 4 stages (resolve / research / contexts / render prompt) versus 6
+	// for a normal run.
+	rep := newReporter()
+	if postDryRun {
+		rep.Start(4)
+	} else {
+		rep.Start(6)
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
 
-	brief, operatorNote, err := resolvePostSource(ctx, cfg, stdin)
+	rep.Step("resolving source...")
+	brief, operatorNote, err := resolvePostSource(ctx, cfg, stdin, rep)
 	if err != nil {
 		return err
 	}
@@ -105,6 +117,7 @@ func runPost(ctx context.Context, stdin *os.File) error {
 		notesPath = filepath.Join(home, ".tider", "subreddits.yaml")
 	}
 
+	rep.Step(fmt.Sprintf("loading Reddit research for r/%s...", postSub))
 	notes, err := research.LoadNotes(notesPath)
 	if err != nil {
 		return err
@@ -115,6 +128,7 @@ func runPost(ctx context.Context, stdin *os.File) error {
 		return fmt.Errorf("research %s: %w", postSub, err)
 	}
 
+	rep.Step("loading contexts: " + formatContextLabel(postContexts))
 	bankDir, err := contextbank.DefaultDir()
 	if err != nil {
 		return err
@@ -146,14 +160,17 @@ func runPost(ctx context.Context, stdin *os.File) error {
 	}
 
 	if postDryRun {
+		rep.Step("rendering prompt (dry-run)...")
 		prompt, err := draft.RenderPrompt(in)
 		if err != nil {
 			return err
 		}
+		rep.Done()
 		fmt.Println(prompt)
 		return nil
 	}
 
+	rep.Step("selecting providers...")
 	providers := postProviders
 	if providers == "" {
 		providers = cfg.Defaults.Providers
@@ -166,7 +183,7 @@ func runPost(ctx context.Context, stdin *os.File) error {
 	if openaiModel == "" {
 		openaiModel = cfg.LLM.OpenAIModel
 	}
-	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
+	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel, rep)
 	if err != nil {
 		return err
 	}
@@ -174,6 +191,7 @@ func runPost(ctx context.Context, stdin *os.File) error {
 		return errors.New("no usable providers — set ANTHROPIC_API_KEY and/or OPENAI_API_KEY")
 	}
 
+	rep.Step(fmt.Sprintf("drafting with %s...", providerSummary(refs)))
 	bundle, err := draft.Generate(ctx, refs, in)
 	if err != nil {
 		return err
@@ -182,9 +200,11 @@ func runPost(ctx context.Context, stdin *os.File) error {
 	if root, derr := lastdraft.Default(); derr == nil {
 		snap := &types.Snapshot{Brief: *brief, Research: *researchBundle, Bundle: *bundle}
 		if serr := lastdraft.Save(root, postSub, snap); serr != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to save last-draft snapshot: %v\n", serr)
+			rep.Warn("failed to save last-draft snapshot: %v", serr)
 		}
 	}
+	rep.Step("saved snapshot")
+	rep.Done()
 
 	switch resolveRender(postRender) {
 	case "markdown":
@@ -211,7 +231,10 @@ func runPost(ctx context.Context, stdin *os.File) error {
 // used only when no source flag is set and stdin is piped — an
 // interactive shell is treated as "no source" so we can fail with a
 // usage message instead of blocking on a tty.
-func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) (*types.Brief, string, error) {
+//
+// rep is threaded so the intake LLM-fallback warning honors --quiet /
+// --no-progress instead of bypassing them via a raw stderr write.
+func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File, rep *progress.Reporter) (*types.Brief, string, error) {
 	sources := []string{}
 	if postNote != "" {
 		sources = append(sources, "--note")
@@ -253,7 +276,7 @@ func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) 
 		}
 		return b, b.Summary, nil
 	case "--file":
-		ip, err := newIntakeProvider(cfg)
+		ip, err := newIntakeProvider(cfg, rep)
 		if err != nil {
 			return nil, "", err
 		}
@@ -263,7 +286,7 @@ func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) 
 		}
 		return b, "", nil
 	case "--url":
-		ip, err := newIntakeProvider(cfg)
+		ip, err := newIntakeProvider(cfg, rep)
 		if err != nil {
 			return nil, "", err
 		}
@@ -282,7 +305,7 @@ func resolvePostSource(ctx context.Context, cfg *config.Config, stdin *os.File) 
 	return nil, "", fmt.Errorf("internal: unhandled source %s", sources[0])
 }
 
-func newIntakeProvider(cfg *config.Config) (postIntake, error) {
+func newIntakeProvider(cfg *config.Config, rep *progress.Reporter) (postIntake, error) {
 	provider, model, maxTokens := cfg.ForTask("intake")
 	p, err := llm.New(llm.Config{Provider: provider, Model: model})
 	if err == nil {
@@ -302,7 +325,7 @@ func newIntakeProvider(cfg *config.Config) (postIntake, error) {
 	if altErr != nil {
 		return postIntake{}, fmt.Errorf("intake: no usable provider — set ANTHROPIC_API_KEY or OPENAI_API_KEY")
 	}
-	fmt.Fprintf(os.Stderr, "intake: %s key missing, falling back to %s\n", provider, altProvider)
+	rep.Warn("intake: %s key missing, falling back to %s", provider, altProvider)
 	return postIntake{p: p, maxTokens: maxTokens}, nil
 }
 
@@ -365,10 +388,10 @@ func loadBrief(path string) (*types.Brief, error) {
 // buildProviderRefs constructs the list of providers to fan out across.
 // providersFlag is comma-separated ("anthropic,openai"). Each requested
 // provider needs its API key in the environment; missing keys cause that
-// provider to be silently skipped (with a stderr warning) rather than
-// failing the whole run, so a working provider isn't blocked by a missing
-// key for the other.
-func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]draft.ProviderRef, error) {
+// provider to be silently skipped (with a warning) rather than failing
+// the whole run, so a working provider isn't blocked by a missing key
+// for the other.
+func buildProviderRefs(providersFlag, anthropicModel, openaiModel string, rep *progress.Reporter) ([]draft.ProviderRef, error) {
 	want := strings.Split(providersFlag, ",")
 	var refs []draft.ProviderRef
 	for _, name := range want {
@@ -377,14 +400,14 @@ func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]dra
 		case "anthropic":
 			p, err := llm.NewAnthropic(anthropicModel)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "skipping anthropic: %v\n", err)
+				rep.Warn("skipping anthropic: %v", err)
 				continue
 			}
 			refs = append(refs, draft.ProviderRef{Provider: p, Model: anthropicModel})
 		case "openai":
 			p, err := llm.NewOpenAI(openaiModel)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "skipping openai: %v\n", err)
+				rep.Warn("skipping openai: %v", err)
 				continue
 			}
 			refs = append(refs, draft.ProviderRef{Provider: p, Model: openaiModel})
@@ -395,6 +418,16 @@ func buildProviderRefs(providersFlag, anthropicModel, openaiModel string) ([]dra
 		}
 	}
 	return refs, nil
+}
+
+// providerSummary renders a fan-out provider list as a stage-progress
+// suffix, e.g. "anthropic/claude-3-5-sonnet, openai/gpt-5".
+func providerSummary(refs []draft.ProviderRef) string {
+	parts := make([]string, 0, len(refs))
+	for _, r := range refs {
+		parts = append(parts, fmt.Sprintf("%s/%s", r.Provider.Name(), r.Model))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func init() {

--- a/cmd/tider/post_test.go
+++ b/cmd/tider/post_test.go
@@ -65,7 +65,7 @@ func TestResolvePostSourceFromNote(t *testing.T) {
 	resetPostFlags(t)
 	postNote = "Ask sellers about AI listing images. Don't pitch Kova."
 
-	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestResolvePostSourceFromStdin(t *testing.T) {
 	const body = "Long pasted material with multiple paragraphs.\n\nFrom pbpaste."
 	stdin := stdinPipe(t, body)
 
-	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, stdin)
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, stdin, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestResolvePostSourceConflictingFlags(t *testing.T) {
 	postNote = "x"
 	postFile = "y.md"
 
-	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil, nil)
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}
@@ -127,7 +127,7 @@ func TestResolvePostSourceConflictWithStdin(t *testing.T) {
 
 	// --note set AND stdin piped → should pick --note (explicit flag),
 	// not error. Stdin only counts as a source when no flag is set.
-	brief, _, err := resolvePostSource(context.Background(), &config.Config{}, stdin)
+	brief, _, err := resolvePostSource(context.Background(), &config.Config{}, stdin, nil)
 	if err != nil {
 		t.Fatalf("explicit flag should win over piped stdin: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestResolvePostSourceNoSource(t *testing.T) {
 	resetPostFlags(t)
 	tty := stdinTTY(t)
 
-	_, _, err := resolvePostSource(context.Background(), &config.Config{}, tty)
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, tty, nil)
 	if err == nil {
 		t.Fatal("expected usage error when no source set and stdin is interactive")
 	}
@@ -166,7 +166,7 @@ func TestResolvePostSourceFromBriefJSON(t *testing.T) {
 	}
 	postBriefPath = briefPath
 
-	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	brief, opNote, err := resolvePostSource(context.Background(), &config.Config{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestNewIntakeProviderFallsBackWhenPrimaryKeyMissing(t *testing.T) {
 			},
 		},
 	}
-	ip, err := newIntakeProvider(cfg)
+	ip, err := newIntakeProvider(cfg, nil)
 	if err != nil {
 		t.Fatalf("expected fallback to anthropic, got error: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestNewIntakeProviderErrorsWhenAllKeysMissing(t *testing.T) {
 			},
 		},
 	}
-	_, err := newIntakeProvider(cfg)
+	_, err := newIntakeProvider(cfg, nil)
 	if err == nil {
 		t.Fatal("expected error when no provider keys are set")
 	}
@@ -256,7 +256,7 @@ func TestResolvePostSourceEmptyNote(t *testing.T) {
 	resetPostFlags(t)
 	postNote = "   \n\t  "
 
-	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil)
+	_, _, err := resolvePostSource(context.Background(), &config.Config{}, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for whitespace-only note")
 	}

--- a/cmd/tider/regen.go
+++ b/cmd/tider/regen.go
@@ -114,7 +114,11 @@ func setupRegen() (*types.Snapshot, []llm.ProviderRef, error) {
 	if openaiModel == "" {
 		openaiModel = cfg.LLM.OpenAIModel
 	}
-	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel, nil)
+	// Use a real reporter so provider-skip warnings (e.g. one of
+	// --providers=anthropic,openai with a missing key) still reach the
+	// user. regen has no stage output of its own, so this reporter is
+	// only used for Warn.
+	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel, newReporter())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/tider/regen.go
+++ b/cmd/tider/regen.go
@@ -114,7 +114,7 @@ func setupRegen() (*types.Snapshot, []llm.ProviderRef, error) {
 	if openaiModel == "" {
 		openaiModel = cfg.LLM.OpenAIModel
 	}
-	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel)
+	refs, err := buildProviderRefs(providers, anthropicModel, openaiModel, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/tider/reply.go
+++ b/cmd/tider/reply.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -52,6 +53,11 @@ API key for the chosen provider must be set in the environment
 			return errors.New("--url is required")
 		}
 
+		// Reporter is sized for the reply path (5 stages); review mode
+		// bumps the total to 8 once the classifier returns.
+		rep := newReporter()
+		rep.Start(5)
+
 		// 1. Parse URL. Canonicalize first so Reddit mobile share links
 		//    (https://www.reddit.com/s/<token>, common when pasting from
 		//    the Reddit app's Share menu) get resolved to a canonical
@@ -73,6 +79,7 @@ API key for the chosen provider must be set in the environment
 		}
 		cacheRoot := filepath.Join(home, ".tider", "cache")
 		client := reddit.NewClient(reddit.NewCache(cacheRoot))
+		rep.Step("fetching Reddit thread...")
 		thread, err := client.FetchThread(ctx, sub, postID)
 		if err != nil {
 			return err
@@ -88,7 +95,7 @@ API key for the chosen provider must be set in the environment
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(os.Stderr, "session: %s\n", sess.Path())
+		rep.SessionPath(sess.Path())
 
 		// 4. Save thread immediately. Subsequent steps may fail; this
 		//    artifact is preserved regardless.
@@ -102,6 +109,7 @@ API key for the chosen provider must be set in the environment
 		if err != nil {
 			return err
 		}
+		rep.Step("loading contexts: " + formatContextLabel(replyContexts))
 		contexts, err := reply.LoadContexts(bankDir, replyContexts)
 		if err != nil {
 			return err
@@ -123,6 +131,7 @@ API key for the chosen provider must be set in the environment
 		//    b) run the cheaper classifier from tasks.reply_mode.
 		//    --provider propagates so `--provider=anthropic` doesn't
 		//    silently still require OPENAI_API_KEY for the classifier.
+		rep.Step("classifying thread...")
 		var modeResult *types.ReplyModeResult
 		if replyModeOverride != "" {
 			switch replyModeOverride {
@@ -145,6 +154,7 @@ API key for the chosen provider must be set in the environment
 				return err
 			}
 		}
+		rep.Update(string(modeResult.Mode))
 		if err := sess.SaveMode(modeResult); err != nil {
 			return err
 		}
@@ -171,12 +181,17 @@ API key for the chosen provider must be set in the environment
 			if err := sess.WriteJSON("draft-input.json", input); err != nil {
 				return err
 			}
+			rep.Step(fmt.Sprintf("drafting replies with %s/%s...", draftProvider, draftModel))
 			bundle, err = reply.GenerateReply(ctx, draftP, draftModel, input, draftMaxTokens)
 			if err != nil {
 				return err
 			}
 
 		case types.ReplyModeReview:
+			// Review pipeline runs three additional stages on top of the
+			// shared 1–3 (fetch / contexts / classify). Bump total so the
+			// remaining lines render as [N/8] instead of [N/5].
+			rep.SetTotal(8)
 			if len(modeResult.TargetURLs) == 0 {
 				return errors.New("review request detected, but no shop/site URL was found in the original post — rerun with --mode=reply for an ordinary reply, or use a thread that includes a target link")
 			}
@@ -200,11 +215,13 @@ API key for the chosen provider must be set in the environment
 			//   4. Text-only review notes still run alongside; both flow
 			//      into the drafter.
 			httpClient := &http.Client{Timeout: 60 * time.Second}
+			rep.Step("inspecting target with Firecrawl...")
 			inspection, err := reply.InspectReviewTarget(ctx, httpClient, modeResult.TargetURLs[0])
 			if err != nil {
 				return fmt.Errorf("inspection: %w (session preserved at %s; rerun with --mode=reply to draft an ordinary reply)", err, sess.Path())
 			}
 
+			rep.Step("saving screenshot and images...")
 			screenshotDir := filepath.Join(sess.Path(), "screenshots")
 			localPath, err := reply.DownloadScreenshot(ctx, httpClient, inspection.ScreenshotURL, screenshotDir)
 			if err != nil {
@@ -258,6 +275,7 @@ API key for the chosen provider must be set in the environment
 				return err
 			}
 
+			rep.Step("analyzing screenshot and product images...")
 			visualNotes, err := reply.AnalyzeVisual(ctx, visualP, visualModel, visualInput, visualMaxTokens)
 			if err != nil {
 				return fmt.Errorf("visual analysis: %w (session preserved at %s)", err, sess.Path())
@@ -266,6 +284,7 @@ API key for the chosen provider must be set in the environment
 				return err
 			}
 
+			rep.Step("drafting review reply...")
 			// Text-only review notes — still useful alongside visual
 			// because they cover headings/copy/meta which aren't really
 			// "visual" anyway. Uses the cheap classifier model.
@@ -320,6 +339,8 @@ API key for the chosen provider must be set in the environment
 		if err := sess.SaveOutput(md); err != nil {
 			return err
 		}
+		rep.Step("saved session artifacts")
+		rep.Done()
 
 		switch resolveRender(replyRender) {
 		case "markdown":
@@ -379,6 +400,24 @@ func resolveProviderModel(cfg *config.Config, task, providerOverride, modelOverr
 		maxTokens = maxTokensOverride
 	}
 	return
+}
+
+// formatContextLabel renders the user's --context refs as a comma-joined
+// stage-progress suffix, e.g. "loading contexts: kova, ./profile.md".
+// Returns "(none)" when no contexts were requested so the line still
+// reads naturally instead of trailing into a colon.
+func formatContextLabel(refs []string) string {
+	cleaned := make([]string, 0, len(refs))
+	for _, r := range refs {
+		r = strings.TrimSpace(r)
+		if r != "" {
+			cleaned = append(cleaned, r)
+		}
+	}
+	if len(cleaned) == 0 {
+		return "(none)"
+	}
+	return strings.Join(cleaned, ", ")
 }
 
 func init() {

--- a/cmd/tider/research.go
+++ b/cmd/tider/research.go
@@ -51,26 +51,18 @@ var researchCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		// --raw skips the LLM step, so the total drops from 4 to 3.
+		// --raw skips the LLM step, so the total drops from 3 to 2.
+		// One stage covers cache lookup + (notes parse + Reddit fetch)
+		// because subreddits.yaml is read lazily — a cache hit must not
+		// fail just because notes are missing or malformed.
 		rep := newReporter()
 		if researchRaw {
-			rep.Start(3)
+			rep.Start(2)
 		} else {
-			rep.Start(4)
+			rep.Start(3)
 		}
 
-		// Stage 1: load curated metadata (subreddits.yaml). Always read
-		// fresh; stage runs even on cache hit so progress is consistent.
-		rep.Step("loading subreddit metadata...")
-		notes, err := research.LoadNotes(notesPath)
-		if err != nil {
-			return err
-		}
-
-		// Stage 2: fetch recent posts. Cache hit short-circuits the
-		// network call; the stage line still prints so the user sees the
-		// canonical [2/N] and the next [3/N] follows in order.
-		rep.Step("fetching recent posts...")
+		rep.Step("loading subreddit data...")
 		var bundle *types.Research
 		if !researchRefresh {
 			cached, err := research.LoadRaw(cacheRoot, sub, research.RawBundleTTL)
@@ -80,6 +72,10 @@ var researchCmd = &cobra.Command{
 			bundle = cached
 		}
 		if bundle == nil {
+			notes, err := research.LoadNotes(notesPath)
+			if err != nil {
+				return err
+			}
 			client := reddit.NewClient(reddit.NewCache(cacheRoot))
 			bundle, err = research.For(ctx, client, notes, sub, researchRefresh)
 			if err != nil {

--- a/cmd/tider/research.go
+++ b/cmd/tider/research.go
@@ -50,12 +50,49 @@ var researchCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		bundle, err := loadOrFetchResearch(ctx, cacheRoot, notesPath, sub, researchRefresh)
+
+		// --raw skips the LLM step, so the total drops from 4 to 3.
+		rep := newReporter()
+		if researchRaw {
+			rep.Start(3)
+		} else {
+			rep.Start(4)
+		}
+
+		// Stage 1: load curated metadata (subreddits.yaml). Always read
+		// fresh; stage runs even on cache hit so progress is consistent.
+		rep.Step("loading subreddit metadata...")
+		notes, err := research.LoadNotes(notesPath)
 		if err != nil {
 			return err
 		}
 
+		// Stage 2: fetch recent posts. Cache hit short-circuits the
+		// network call; the stage line still prints so the user sees the
+		// canonical [2/N] and the next [3/N] follows in order.
+		rep.Step("fetching recent posts...")
+		var bundle *types.Research
+		if !researchRefresh {
+			cached, err := research.LoadRaw(cacheRoot, sub, research.RawBundleTTL)
+			if err != nil {
+				return err
+			}
+			bundle = cached
+		}
+		if bundle == nil {
+			client := reddit.NewClient(reddit.NewCache(cacheRoot))
+			bundle, err = research.For(ctx, client, notes, sub, researchRefresh)
+			if err != nil {
+				return err
+			}
+		}
+
 		if researchRaw {
+			if err := research.SaveRaw(cacheRoot, sub, bundle); err != nil {
+				rep.Warn("failed to save raw research cache: %v", err)
+			}
+			rep.Step("saved raw bundle to cache")
+			rep.Done()
 			return printJSON(bundle)
 		}
 
@@ -80,11 +117,23 @@ var researchCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("%w (use --raw to print cached/fetched Reddit data without LLM insights)", err)
 		}
-		fmt.Fprintf(os.Stderr, "generating pain-point insights with %s/%s...\n", provider, model)
+
+		// Stage 3: insights LLM call (the slow one — typically 30-60s).
+		rep.Step(fmt.Sprintf("generating pain-point insights with %s/%s...", provider, model))
 		insights, err := research.GenerateInsights(ctx, p, model, *bundle, maxTokens)
 		if err != nil {
 			return err
 		}
+
+		// Stage 4: persist the raw Reddit bundle. Done after insights so
+		// a failed LLM run doesn't bury the cache write side-effect under
+		// an in-flight stage line.
+		if err := research.SaveRaw(cacheRoot, sub, bundle); err != nil {
+			rep.Warn("failed to save raw research cache: %v", err)
+		}
+		rep.Step("saved raw bundle to cache")
+		rep.Done()
+
 		report := &types.ResearchReport{
 			Raw:       *bundle,
 			Insights:  *insights,
@@ -107,29 +156,6 @@ var researchCmd = &cobra.Command{
 		}
 		return nil
 	},
-}
-
-func loadOrFetchResearch(ctx context.Context, cacheRoot, notesPath, sub string, refresh bool) (*types.Research, error) {
-	if !refresh {
-		if cached, err := research.LoadRaw(cacheRoot, sub, research.RawBundleTTL); err != nil {
-			return nil, err
-		} else if cached != nil {
-			return cached, nil
-		}
-	}
-	notes, err := research.LoadNotes(notesPath)
-	if err != nil {
-		return nil, err
-	}
-	client := reddit.NewClient(reddit.NewCache(cacheRoot))
-	bundle, err := research.For(ctx, client, notes, sub, refresh)
-	if err != nil {
-		return nil, err
-	}
-	if err := research.SaveRaw(cacheRoot, sub, bundle); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to save raw research cache: %v\n", err)
-	}
-	return bundle, nil
 }
 
 func printJSON(v any) error {

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,129 @@
+// Package progress prints compact, stage-based status to stderr so users
+// can tell what a long-running command is doing without overwhelming the
+// terminal. One line per stage, plus a final "done in Xs" summary.
+//
+// Output is line-buffered and append-only — no spinners, no \r rewrites,
+// no goroutines. All writes go to the configured writer (os.Stderr in
+// production); stdout is reserved for final command output so piping
+// stays clean.
+package progress
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// Options configures a Reporter at construction time.
+//
+// The two flags are independent so callers can wire CLI flags directly:
+//   --quiet       → Quiet=true       (suppress everything)
+//   --no-progress → NoProgress=true  (suppress stages, keep warnings)
+type Options struct {
+	Quiet      bool
+	NoProgress bool
+}
+
+// Reporter prints stage-based progress to its writer.
+type Reporter struct {
+	w            io.Writer
+	showProgress bool
+	showWarn     bool
+	total        int
+	cur          int
+	cmdStart     time.Time
+}
+
+// New returns a Reporter that writes to w.
+func New(w io.Writer, opts Options) *Reporter {
+	return &Reporter{
+		w:            w,
+		showProgress: !opts.Quiet && !opts.NoProgress,
+		showWarn:     !opts.Quiet,
+	}
+}
+
+// All methods are nil-safe so callers and tests can pass a nil
+// *Reporter without conditional guards; nil acts like a fully-disabled
+// reporter that drops every call.
+
+// Start records the total stage count and the command's start time.
+// Must be called before Step/Done; safe to call on a disabled reporter.
+func (r *Reporter) Start(total int) {
+	if r == nil {
+		return
+	}
+	r.total = total
+	r.cur = 0
+	r.cmdStart = time.Now()
+}
+
+// SetTotal updates the total stage count mid-run. Used when the total
+// depends on a runtime decision (e.g. tider reply switches from 5 stages
+// to 8 once the classifier detects review mode). Lines already printed
+// keep their original total; subsequent Step calls use the new value.
+func (r *Reporter) SetTotal(total int) {
+	if r == nil {
+		return
+	}
+	r.total = total
+}
+
+// Step advances the stage counter and prints "[N/M] label".
+func (r *Reporter) Step(label string) {
+	if r == nil || !r.showProgress {
+		return
+	}
+	r.cur++
+	fmt.Fprintf(r.w, "[%d/%d] %s\n", r.cur, r.total, label)
+}
+
+// Update prints an indented annotation line under the current step,
+// e.g. classifier results: "  → reply".
+func (r *Reporter) Update(label string) {
+	if r == nil || !r.showProgress {
+		return
+	}
+	fmt.Fprintf(r.w, "  → %s\n", label)
+}
+
+// Done prints the final "done in Xs" summary using the elapsed command time.
+func (r *Reporter) Done() {
+	if r == nil || !r.showProgress {
+		return
+	}
+	if r.cmdStart.IsZero() {
+		return
+	}
+	fmt.Fprintf(r.w, "done in %s\n", FormatDuration(time.Since(r.cmdStart)))
+}
+
+// Warn prints a warning regardless of --no-progress; suppressed by --quiet.
+func (r *Reporter) Warn(format string, args ...any) {
+	if r == nil || !r.showWarn {
+		return
+	}
+	fmt.Fprintf(r.w, "warning: "+format+"\n", args...)
+}
+
+// SessionPath prints the session directory once, before any long-running
+// work, so users can find the artifacts even if the run aborts later.
+func (r *Reporter) SessionPath(path string) {
+	if r == nil || !r.showProgress {
+		return
+	}
+	fmt.Fprintf(r.w, "session: %s\n", path)
+}
+
+// FormatDuration renders a duration as "Ns" or "NmSSs" (always
+// two-digit seconds when minutes are present), matching the style used
+// in issue #20: 38s, 1m12s, 1m03s.
+func FormatDuration(d time.Duration) string {
+	sec := int(d.Round(time.Second).Seconds())
+	if sec < 60 {
+		return fmt.Sprintf("%ds", sec)
+	}
+	m := sec / 60
+	s := sec % 60
+	return fmt.Sprintf("%dm%02ds", m, s)
+}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,150 @@
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0s"},
+		{500 * time.Millisecond, "1s"}, // rounds to 1s
+		{499 * time.Millisecond, "0s"}, // rounds to 0s
+		{5 * time.Second, "5s"},
+		{38 * time.Second, "38s"},
+		{59 * time.Second, "59s"},
+		{60 * time.Second, "1m00s"},
+		{63 * time.Second, "1m03s"},
+		{72 * time.Second, "1m12s"},
+		{102 * time.Second, "1m42s"},
+		{3601 * time.Second, "60m01s"},
+	}
+	for _, c := range cases {
+		if got := FormatDuration(c.in); got != c.want {
+			t.Errorf("FormatDuration(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStepFormat(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.Start(3)
+	r.Step("fetching Reddit thread...")
+	r.Step("loading contexts: kova")
+	r.Step("classifying thread...")
+
+	got := buf.String()
+	want := "[1/3] fetching Reddit thread...\n[2/3] loading contexts: kova\n[3/3] classifying thread...\n"
+	if got != want {
+		t.Errorf("step output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestUpdateFormat(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.Start(1)
+	r.Step("classifying thread...")
+	r.Update("reply")
+
+	got := buf.String()
+	want := "[1/1] classifying thread...\n  → reply\n"
+	if got != want {
+		t.Errorf("update output mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestSessionPath(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.SessionPath("/tmp/sessions/abc")
+
+	if got := buf.String(); got != "session: /tmp/sessions/abc\n" {
+		t.Errorf("session path output: %q", got)
+	}
+}
+
+func TestDonePrintsElapsed(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.Start(1)
+	r.Step("only step")
+	// Backdate the start so Done sees a non-zero elapsed.
+	r.cmdStart = time.Now().Add(-65 * time.Second)
+	r.Done()
+
+	out := buf.String()
+	if !strings.Contains(out, "done in 1m05s\n") {
+		t.Errorf("expected 'done in 1m05s' in output, got: %q", out)
+	}
+}
+
+func TestDoneWithoutStartIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.Done()
+	if got := buf.String(); got != "" {
+		t.Errorf("expected no output, got %q", got)
+	}
+}
+
+func TestWarnFormat(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{})
+	r.Warn("could not save %s: %v", "foo.json", "disk full")
+
+	if got := buf.String(); got != "warning: could not save foo.json: disk full\n" {
+		t.Errorf("warn output: %q", got)
+	}
+}
+
+func TestQuietSuppressesEverything(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{Quiet: true})
+	r.Start(2)
+	r.SessionPath("/tmp/x")
+	r.Step("one")
+	r.Update("annotation")
+	r.Step("two")
+	r.Warn("warn me")
+	r.Done()
+
+	if got := buf.String(); got != "" {
+		t.Errorf("quiet mode should produce no output, got: %q", got)
+	}
+}
+
+func TestNilReporterIsSafe(t *testing.T) {
+	// Tests and helpers commonly pass nil when they don't need progress.
+	// Every method must short-circuit instead of panicking.
+	var r *Reporter
+	r.Start(3)
+	r.SetTotal(5)
+	r.Step("one")
+	r.Update("annotated")
+	r.SessionPath("/tmp/x")
+	r.Warn("careful")
+	r.Done()
+}
+
+func TestNoProgressKeepsWarnings(t *testing.T) {
+	var buf bytes.Buffer
+	r := New(&buf, Options{NoProgress: true})
+	r.Start(2)
+	r.SessionPath("/tmp/x")
+	r.Step("one")
+	r.Update("annotation")
+	r.Warn("still here")
+	r.Done()
+
+	got := buf.String()
+	if got != "warning: still here\n" {
+		t.Errorf("no-progress should print only warnings, got: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #20.

## Summary

- New `internal/progress` package with a tiny `Reporter` (`Start` / `Step` / `Update` / `SetTotal` / `Done` / `Warn` / `SessionPath`). One line per stage to stderr, plus a final `done in Xs`.
- Two persistent root flags: `--quiet` (suppress all) and `--no-progress` (keep warnings, drop stages).
- Wired through `reply` (5 stages reply / 8 stages review), `research` (4 stages, 3 with `--raw`), `post` (6 stages, 4 with `--dry-run`), and `intake` (2 stages).
- Stdout stays clean — `--render=json | jq` works unchanged.

## What's deliberately *not* here

- No live elapsed ticker on long stages (no `\r` rewrites, no goroutines). The user wanted "high-level what's happening," not a per-step stopwatch — total elapsed comes through `done in Xs`.
- No `--verbose` flag yet. The acceptance criteria don't require it, and adding per-step timings touches every call site; better as a follow-up.

## Sample output

`tider intake --file=/no/such/file`:

```
[1/2] validating source...
[2/2] extracting brief from /no/such/file with openai/gpt-4o-mini...
Error: open /no/such/file: ...
```

`tider post --sub=test --note=hello --providers=anthropic` (no API key set):

```
[1/6] resolving source...
[2/6] loading Reddit research for r/test...
[3/6] loading contexts: (none)
[4/6] selecting providers...
warning: skipping anthropic: ANTHROPIC_API_KEY not set
Error: no usable providers — set ANTHROPIC_API_KEY and/or OPENAI_API_KEY
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (including new `internal/progress` tests)
- [x] Stage output goes to stderr only — confirmed by piping (`1>/dev/null` shows stages, `2>/dev/null` silences them)
- [x] `--quiet` suppresses both stages and warnings
- [x] `--no-progress` suppresses stages, keeps warnings
- [ ] End-to-end smoke against real Reddit/Firecrawl/LLM (requires API keys; left for the reviewer / next manual run)

@codex please review.